### PR TITLE
docs(readme): Update README.me URLs to slack.dev and fix CircleCI badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Slack CLI
 
-[![codecov](https://codecov.io/gh/slackapi/slack-cli/branch/main/graph/badge.svg?token=5QO6RECHOF)](https://codecov.io/gh/slackapi/slack-cli)
-[![tests](https://github.com/slackapi/slack-cli/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/slackapi/slack-cli/actions/workflows/tests.yml)
+[![CodeCov](https://codecov.io/gh/slackapi/slack-cli/branch/main/graph/badge.svg?token=5QO6RECHOF)](https://codecov.io/gh/slackapi/slack-cli)
+[![Tests](https://github.com/slackapi/slack-cli/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/slackapi/slack-cli/actions/workflows/tests.yml)
 [![CircleCI](https://dl.circleci.com/status-badge/img/gh/slackapi/slack-cli/tree/main.svg?style=svg&circle-token=CCIPRJ_TfxL4UXvmnaoZ6np7aRRsT_df235908b5a56f4206787b59c6fbee59490ac35d)](https://dl.circleci.com/status-badge/redirect/gh/slackapi/slack-cli/tree/main)
 
 > Command-line interface for building apps on the Slack Platform.


### PR DESCRIPTION
### Summary

This pull request updates the `README.md` to update the docs page URLs to slack.dev and updates the CircleCI badge.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).