### PR TITLE
docs(readme): Update CodeCov badge on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Slack CLI
 
-[![CodeCov](https://codecov.io/gh/slackapi/slack-cli/branch/main/graph/badge.svg?token=5QO6RECHOF)](https://codecov.io/gh/slackapi/slack-cli)
-[![Tests](https://github.com/slackapi/slack-cli/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/slackapi/slack-cli/actions/workflows/tests.yml)
-[![CircleCI](https://dl.circleci.com/status-badge/img/gh/slackapi/slack-cli/tree/main.svg?style=svg&circle-token=CCIPRJ_TfxL4UXvmnaoZ6np7aRRsT_df235908b5a56f4206787b59c6fbee59490ac35d)](https://dl.circleci.com/status-badge/redirect/gh/slackapi/slack-cli/tree/main)
+[![tests](https://github.com/slackapi/slack-cli/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/slackapi/slack-cli/actions/workflows/tests.yml)
+[![codecov](https://codecov.io/gh/slackapi/slack-cli/branch/main/graph/badge.svg?token=G5TU59IV9I)](https://codecov.io/gh/slackapi/slack-cli)
+[![circleci](https://dl.circleci.com/status-badge/img/gh/slackapi/slack-cli/tree/main.svg?style=svg&circle-token=CCIPRJ_TfxL4UXvmnaoZ6np7aRRsT_df235908b5a56f4206787b59c6fbee59490ac35d)](https://dl.circleci.com/status-badge/redirect/gh/slackapi/slack-cli/tree/main)
 
 > Command-line interface for building apps on the Slack Platform.
 


### PR DESCRIPTION
### Summary

This pull request updates the token used by the codecov badge, so that it displays the correct code coverage report. It also reorders the badges to be: Tests, CodeCov, and then CircleCI

### Reviewers

* [Preview of README.md](https://github.com/slackapi/slack-cli/blob/1fd524340077e187e8b997ce743974b280296b0b/README.md)

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).