### PR TITLE
ci: include compiled archives in snapshot build releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,7 +151,7 @@ jobs:
       - run:
           name: Run GoReleaser. Without actually publishing.
           command: |
-            export LDFLAGS="-s -w -X 'github.com/slackapi/slack-cli/internal/pkg/version.Version=$BUILD_VERSION'"
+            LDFLAGS="-s -w -X 'github.com/slackapi/slack-cli/internal/pkg/version.Version=$BUILD_VERSION'"
             make LDFLAGS="$LDFLAGS" build-snapshot
       - run:
           name: Show binaries are generated correctly


### PR DESCRIPTION
### Summary

This PR uses a packaged CLI build in CI runs to match releases, using the `-s` and `-W` [flags](https://pkg.go.dev/cmd/link) to omit debug info 🤖

### Preview

The updated build is shown in the download size!

Before changes:

```
$ du dist/*
25276   dist/slack-macos_darwin_amd64_v1/bin
25248   dist/slack_linux_amd64_v1/bin
25592   dist/slack_windows_amd64_v1/bin
```

After changes:

```
$ du dist/*
17768   dist/slack-macos_darwin_amd64_v1/bin
17352   dist/slack_linux_amd64_v1/bin
17712   dist/slack_windows_amd64_v1/bin
```

### Notes

A few comments were exploring other CI happenings that other PRs hope to address 🙏 

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).