### PR TITLE
build: include build tags in the autogenerated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -7,6 +7,9 @@ changelog:
     - title: 🐛 Bug Fixes
       labels:
         - bug
+    - title: 🤖 Build
+      labels:
+        - build
     - title: 🧪 Testing/Code Health
       labels:
         - code health


### PR DESCRIPTION
### Summary

This PR updates the autogenerated release notes to include a section for the new [`build`](https://github.com/slackapi/slack-cli/pull/11#issuecomment-2779581137) tag as mentioned in #12!

### Preview

Before changes the `dev-build` groups "build" as other:

<img width="480" alt="preview" src="https://github.com/user-attachments/assets/4bca0f5e-2f54-4d54-9c67-bacc1b7c1480" />

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).