### PR TITLE
ci(fix): delete branch prereleases started in prior versions on merge to main

### DIFF
--- a/.github/workflows/delete-pr-build-on-close.yml
+++ b/.github/workflows/delete-pr-build-on-close.yml
@@ -18,7 +18,7 @@ jobs:
         shell: bash
         run: |
           # Figure out tag name from branch name. This is coupled to the tag name generation that exists in .circleci/config.yml's `create-github-release` job.
-          RELEASES=$(gh release list --repo="slackapi/slack-cli" --order="desc" --json="tagName" --exclude-drafts --exclude-pre-releases --limit=6 --jq ".[] | .tagName")
+          RELEASES=$(gh release list --repo="slackapi/slack-cli" --order="desc" --json="tagName" --exclude-drafts --exclude-pre-releases --limit=24 --jq ".[] | .tagName")
           for TAGS in $RELEASES; do
             TAG_NAME="${TAGS}-${{ github.event.ref }}"
             echo "Identified pre-release tagname to 🔪: $TAG_NAME"


### PR DESCRIPTION
### Summary

This PR fixes an issue where branch prereleases aren't deleted after a merge to `main` **if** the prerelease tag starts with a version from **before** the latest release.

### Preview

In this example, we have multiple releases, a few stable tags, and some lingering releases. From most recent to least:

- [v3.0.4](https://github.com/slackapi/slack-cli/releases/tag/v3.0.4)
- [v3.0.2-zimeg-build-dev](https://github.com/slackapi/slack-cli/releases/tag/v3.0.2-zimeg-build-dev)
- [v3.0.2-zimeg-build-goreleaser-2.8.2](https://github.com/slackapi/slack-cli/releases/tag/v3.0.2-zimeg-build-goreleaser-2.8.2)
- [v3.0.3](https://github.com/slackapi/slack-cli/releases/tag/v3.0.3)
- [v3.0.2](https://github.com/slackapi/slack-cli/releases/tag/v3.0.2)

Which lines up with when the "build" branches were started - before `v3.0.3` - and when these merged after `v3.0.3`.

The changes within check the last `6` stable releases for a matching branch name to decide which release to delete. This is bound to PRs that haven't gone "stale" while also avoiding perhaps unexpected deletes of long past releases. TBH that should never happen.

### Notes

- I'm now wondering if tests and similar uploaded artifacts encounter stranegness when the branch is worked on across versions, but I haven't seen anything so strange here 🔍 

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).