### PR TITLE
ci: label dependabot changes as 'build' patch changes in pull requests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,11 @@ updates:
       interval: "daily"
     labels:
       - "build"
+      - "semver:patch"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
     labels:
       - "build"
+      - "semver:patch"


### PR DESCRIPTION
### Summary

This PR changes the label `@dependabot` uses from `code health` to `build` as part of this new label 🏷️ ✨ 

### Notes

This is a follow up from the following: 📚 

https://github.com/slackapi/slack-cli/blob/main/.github/MAINTAINERS_GUIDE.md#issue-management

> `build`: A change to the build, compile, or CI/CD pipeline.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).