### PR TITLE
docs(readme): remove token from CircleCI status badge after open source

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![tests](https://github.com/slackapi/slack-cli/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/slackapi/slack-cli/actions/workflows/tests.yml)
 [![codecov](https://codecov.io/gh/slackapi/slack-cli/branch/main/graph/badge.svg?token=G5TU59IV9I)](https://codecov.io/gh/slackapi/slack-cli)
-[![circleci](https://dl.circleci.com/status-badge/img/gh/slackapi/slack-cli/tree/main.svg?style=svg&circle-token=CCIPRJ_TfxL4UXvmnaoZ6np7aRRsT_df235908b5a56f4206787b59c6fbee59490ac35d)](https://dl.circleci.com/status-badge/redirect/gh/slackapi/slack-cli/tree/main)
+[![circleci](https://dl.circleci.com/status-badge/img/gh/slackapi/slack-cli/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/slackapi/slack-cli/tree/main)
 
 > Command-line interface for building apps on the Slack Platform.
 


### PR DESCRIPTION
### Summary

This pull request updates the `README.md` by removing the token from the CircleCI status badge. The token was required for private repos, but no longer required because we've now a public, open sourced project 🎉 🥳 

_The token is only used for the status badge, so there's no security concern that it's part of our commit history._

### Reviewers

* [Preview README.md](https://github.com/slackapi/slack-cli/blob/9644370ed9904eff7c5a29ce384155b50d003882/README.md)
  * If you're logged into CircleCI, you can open this link in an Incognito browser window

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).