### PR TITLE
docs: fix sync issue by updating README.md logo to use GitHub URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Slack CLI <img src="docs/static/img/slack-cli-logo.svg" alt="Slack CLI logo" style="height: 1em; max-width: 100%" />
+# Slack CLI <img src="https://avatars.githubusercontent.com/t/6592032" alt="Slack CLI logo" style="height: 1em; max-width: 100%" /> 
 
 [![tests](https://github.com/slackapi/slack-cli/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/slackapi/slack-cli/actions/workflows/tests.yml)
 [![codecov](https://codecov.io/gh/slackapi/slack-cli/branch/main/graph/badge.svg?token=G5TU59IV9I)](https://codecov.io/gh/slackapi/slack-cli)


### PR DESCRIPTION
### Summary

This makes it an external link so we no longer need to host the image, which is creating an issue with the docs syncing. 

### Requirements

* [X] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).