### PR TITLE
test: use slackcontext.MockContext(...) instead of context.Background()

### DIFF
--- a/cmd/app/link_test.go
+++ b/cmd/app/link_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/slackapi/slack-cli/internal/iostreams"
 	"github.com/slackapi/slack-cli/internal/shared"
 	"github.com/slackapi/slack-cli/internal/shared/types"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/internal/slackdeps"
 	"github.com/slackapi/slack-cli/internal/slackerror"
 	"github.com/slackapi/slack-cli/test/testutil"
@@ -569,10 +570,8 @@ func Test_Apps_LinkAppHeaderSection(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			// Setup parameters for test
-			ctx := context.Background()
-
 			// Create mocks
+			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := shared.NewClientsMock()
 			clientsMock.AddDefaultMocks()
 

--- a/cmd/app/uninstall_test.go
+++ b/cmd/app/uninstall_test.go
@@ -48,7 +48,7 @@ func TestAppsUninstall(t *testing.T) {
 	testutil.TableTestCommand(t, testutil.CommandTests{
 		"Successfully uninstall": {
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				prepareCommonUninstallMocks(clients, clientsMock)
+				prepareCommonUninstallMocks(ctx, clients, clientsMock)
 				clientsMock.ApiInterface.On("UninstallApp", mock.Anything, mock.Anything, fakeAppID, fakeAppTeamID).
 					Return(nil).Once()
 			},
@@ -58,7 +58,7 @@ func TestAppsUninstall(t *testing.T) {
 		},
 		"Successfully uninstall with a get-manifest hook error": {
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				prepareCommonUninstallMocks(clients, clientsMock)
+				prepareCommonUninstallMocks(ctx, clients, clientsMock)
 				clientsMock.ApiInterface.On("UninstallApp", mock.Anything, mock.Anything, fakeAppID, fakeAppTeamID).
 					Return(nil).Once()
 				manifestMock := &app.ManifestMockObject{}
@@ -73,7 +73,7 @@ func TestAppsUninstall(t *testing.T) {
 		"Fail to uninstall due to API error": {
 			ExpectedError: slackerror.New("something went wrong"),
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				prepareCommonUninstallMocks(clients, clientsMock)
+				prepareCommonUninstallMocks(ctx, clients, clientsMock)
 				clientsMock.ApiInterface.On("UninstallApp", mock.Anything, mock.Anything, fakeAppID, fakeAppTeamID).
 					Return(slackerror.New("something went wrong")).Once()
 			},
@@ -82,7 +82,7 @@ func TestAppsUninstall(t *testing.T) {
 			CmdArgs:       []string{},
 			ExpectedError: slackerror.New(slackerror.ErrCredentialsNotFound),
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
-				prepareCommonUninstallMocks(cf, cm)
+				prepareCommonUninstallMocks(ctx, cf, cm)
 				appSelectMock := prompts.NewAppSelectMock()
 				uninstallAppSelectPromptFunc = appSelectMock.AppSelectPrompt
 				appSelectMock.On("AppSelectPrompt").Return(prompts.SelectedApp{App: fakeApp}, nil)
@@ -95,7 +95,7 @@ func TestAppsUninstall(t *testing.T) {
 	})
 }
 
-func prepareCommonUninstallMocks(clients *shared.ClientFactory, clientsMock *shared.ClientsMock) *shared.ClientFactory {
+func prepareCommonUninstallMocks(ctx context.Context, clients *shared.ClientFactory, clientsMock *shared.ClientsMock) *shared.ClientFactory {
 
 	// Mock App Selection
 	appSelectMock := prompts.NewAppSelectMock()
@@ -124,7 +124,7 @@ func prepareCommonUninstallMocks(clients *shared.ClientFactory, clientsMock *sha
 
 	clients.AppClient().AppClientInterface = appClientMock
 
-	err := clients.AppClient().SaveDeployed(context.Background(), fakeApp)
+	err := clients.AppClient().SaveDeployed(ctx, fakeApp)
 	if err != nil {
 		panic("error setting up test; cant write apps.json")
 	}

--- a/cmd/auth/token_test.go
+++ b/cmd/auth/token_test.go
@@ -15,18 +15,20 @@
 package auth
 
 import (
-	"context"
 	"testing"
 
 	"github.com/slackapi/slack-cli/internal/api"
 	"github.com/slackapi/slack-cli/internal/shared"
 	"github.com/slackapi/slack-cli/internal/shared/types"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/test/testutil"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
 func TestTokenCommand(t *testing.T) {
+	ctx := slackcontext.MockContext(t.Context())
+
 	clientsMock := shared.NewClientsMock()
 	clientsMock.ApiInterface.On("ValidateSession", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.AuthSession{UserID: &mockOrgAuth.UserID,
 		TeamID:   &mockOrgAuth.TeamID,
@@ -42,7 +44,7 @@ func TestTokenCommand(t *testing.T) {
 	tokenFlag = "xoxp-example-1234"
 
 	cmd := NewTokenCommand(clients)
-	cmd.SetContext(context.Background())
+	cmd.SetContext(ctx)
 	testutil.MockCmdIO(clients.IO, cmd)
 
 	serviceTokenFlag = true

--- a/cmd/collaborators/collaborators_test.go
+++ b/cmd/collaborators/collaborators_test.go
@@ -22,9 +22,7 @@ import (
 	"github.com/slackapi/slack-cli/internal/prompts"
 	"github.com/slackapi/slack-cli/internal/shared"
 	"github.com/slackapi/slack-cli/internal/shared/types"
-	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/internal/slacktrace"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -133,31 +131,4 @@ func TestCollaboratorsCommand(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestCollaboratorsCommand_PrintSuccess(t *testing.T) {
-	// Setup
-	ctx := slackcontext.MockContext(t.Context())
-	clientsMock := shared.NewClientsMock()
-	clients := shared.NewClientFactory(clientsMock.MockClientFactory())
-
-	// Execute tests
-	t.Run("Username will be used if present", func(t *testing.T) {
-		user := types.SlackUser{Email: "joe.smith@company.com", ID: "U1234", PermissionType: types.OWNER}
-		printSuccess(ctx, clients.IO, user, "added")
-		assert.Contains(t, clientsMock.GetStdoutOutput(), "joe.smith@company.com successfully added as an owner collaborator on this app")
-	})
-
-	t.Run("User has no email set; fall back on user ID", func(t *testing.T) {
-		user := types.SlackUser{ID: "U1234", PermissionType: types.OWNER}
-		printSuccess(ctx, clients.IO, user, "removed")
-		assert.Contains(t, clientsMock.GetStdoutOutput(), "\nU1234 successfully removed as an owner collaborator on this app\n\n")
-	})
-
-	t.Run("Reader-type collaborator", func(t *testing.T) {
-		user := types.SlackUser{Email: "joe.smith@company.com", ID: "U1234", PermissionType: types.READER}
-		printSuccess(ctx, clients.IO, user, "updated")
-		assert.Contains(t, clientsMock.GetStdoutOutput(), "\njoe.smith@company.com successfully updated as a reader collaborator on this app\n\n")
-	})
-
 }

--- a/cmd/collaborators/collaborators_test.go
+++ b/cmd/collaborators/collaborators_test.go
@@ -22,7 +22,9 @@ import (
 	"github.com/slackapi/slack-cli/internal/prompts"
 	"github.com/slackapi/slack-cli/internal/shared"
 	"github.com/slackapi/slack-cli/internal/shared/types"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/internal/slacktrace"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -131,4 +133,31 @@ func TestCollaboratorsCommand(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCollaboratorsCommand_PrintSuccess(t *testing.T) {
+	// Setup
+	ctx := slackcontext.MockContext(t.Context())
+	clientsMock := shared.NewClientsMock()
+	clients := shared.NewClientFactory(clientsMock.MockClientFactory())
+
+	// Execute tests
+	t.Run("Username will be used if present", func(t *testing.T) {
+		user := types.SlackUser{Email: "joe.smith@company.com", ID: "U1234", PermissionType: types.OWNER}
+		printSuccess(ctx, clients.IO, user, "added")
+		assert.Contains(t, clientsMock.GetStdoutOutput(), "joe.smith@company.com successfully added as an owner collaborator on this app")
+	})
+
+	t.Run("User has no email set; fall back on user ID", func(t *testing.T) {
+		user := types.SlackUser{ID: "U1234", PermissionType: types.OWNER}
+		printSuccess(ctx, clients.IO, user, "removed")
+		assert.Contains(t, clientsMock.GetStdoutOutput(), "\nU1234 successfully removed as an owner collaborator on this app\n\n")
+	})
+
+	t.Run("Reader-type collaborator", func(t *testing.T) {
+		user := types.SlackUser{Email: "joe.smith@company.com", ID: "U1234", PermissionType: types.READER}
+		printSuccess(ctx, clients.IO, user, "updated")
+		assert.Contains(t, clientsMock.GetStdoutOutput(), "\njoe.smith@company.com successfully updated as a reader collaborator on this app\n\n")
+	})
+
 }

--- a/cmd/doctor/check_test.go
+++ b/cmd/doctor/check_test.go
@@ -15,7 +15,6 @@
 package doctor
 
 import (
-	"context"
 	"fmt"
 	"runtime"
 	"testing"
@@ -26,6 +25,7 @@ import (
 	"github.com/slackapi/slack-cli/internal/pkg/version"
 	"github.com/slackapi/slack-cli/internal/shared"
 	"github.com/slackapi/slack-cli/internal/shared/types"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/internal/slackerror"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -34,10 +34,10 @@ import (
 
 func TestDoctorCheckOS(t *testing.T) {
 	t.Run("returns the operating system version", func(t *testing.T) {
+		ctx := slackcontext.MockContext(t.Context())
 		clientsMock := shared.NewClientsMock()
 		clientsMock.AddDefaultMocks()
 		clients := shared.NewClientFactory(clientsMock.MockClientFactory())
-		ctx := context.Background()
 		expected := Section{
 			Label: "Operating System",
 			Value: "the computer conductor",
@@ -56,10 +56,10 @@ func TestDoctorCheckOS(t *testing.T) {
 
 func TestDoctorCheckCLIVersion(t *testing.T) {
 	t.Run("returns the current version of this tool", func(t *testing.T) {
+		ctx := slackcontext.MockContext(t.Context())
 		clientsMock := shared.NewClientsMock()
 		clientsMock.AddDefaultMocks()
 		clients := shared.NewClientFactory(clientsMock.MockClientFactory())
-		ctx := context.Background()
 		expected := Section{
 			Label: "CLI",
 			Value: "this tool for building Slack apps",
@@ -141,13 +141,13 @@ func TestDoctorCheckProjectConfig(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
+			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := shared.NewClientsMock()
 			clientsMock.AddDefaultMocks()
 			pcm := &config.ProjectConfigMock{}
 			pcm.On("ReadProjectConfigFile", mock.Anything).Return(tt.projectConfig, nil)
 			clientsMock.Config.ProjectConfig = pcm
 			clients := shared.NewClientFactory(clientsMock.MockClientFactory())
-			ctx := context.Background()
 			expected := Section{
 				Label:       "Configurations",
 				Value:       "your project's CLI settings",
@@ -218,10 +218,10 @@ func TestDoctorCheckProjectDeps(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
+			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := shared.NewClientsMock()
 			clientsMock.AddDefaultMocks()
 			clients := tt.mockHookSetup(clientsMock)
-			ctx := context.Background()
 			expected := Section{
 				Label:       "Dependencies",
 				Value:       "requisites for development",
@@ -246,6 +246,7 @@ func TestDoctorCheckCLIConfig(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
+			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := shared.NewClientsMock()
 			clientsMock.AddDefaultMocks()
 			scm := &config.SystemConfigMock{}
@@ -254,7 +255,6 @@ func TestDoctorCheckCLIConfig(t *testing.T) {
 			}, nil)
 			clientsMock.Config.SystemConfig = scm
 			clients := shared.NewClientFactory(clientsMock.MockClientFactory())
-			ctx := context.Background()
 			expected := Section{
 				Label: "Configurations",
 				Value: "any adjustments to settings",
@@ -297,10 +297,10 @@ func TestDoctorCheckCLICreds(t *testing.T) {
 
 	for name := range tests {
 		t.Run(name, func(t *testing.T) {
+			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := shared.NewClientsMock()
 			clientsMock.AddDefaultMocks()
 			clients := shared.NewClientFactory(clientsMock.MockClientFactory())
-			ctx := context.Background()
 			expected := Section{
 				Label:       "Credentials",
 				Value:       "your Slack authentication",
@@ -391,10 +391,10 @@ func TestDoctorCheckProjectTooling(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
+			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := shared.NewClientsMock()
 			clientsMock.AddDefaultMocks()
 			clients := tt.mockHookSetup(clientsMock)
-			ctx := context.Background()
 			expected := Section{
 				Label:       "Runtime",
 				Value:       "foundations for the application",
@@ -410,7 +410,7 @@ func TestDoctorCheckProjectTooling(t *testing.T) {
 
 func TestDoctorCheckGit(t *testing.T) {
 	t.Run("returns the version of git", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := slackcontext.MockContext(t.Context())
 		gitVersion, err := deputil.GetGitVersion()
 		require.NoError(t, err)
 		expected := Section{

--- a/cmd/doctor/doctor_test.go
+++ b/cmd/doctor/doctor_test.go
@@ -16,7 +16,6 @@ package doctor
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"runtime"
 	"testing"
@@ -28,6 +27,7 @@ import (
 	"github.com/slackapi/slack-cli/internal/pkg/version"
 	"github.com/slackapi/slack-cli/internal/shared"
 	"github.com/slackapi/slack-cli/internal/shared/types"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/internal/slackerror"
 	"github.com/slackapi/slack-cli/test/testutil"
 	"github.com/stretchr/testify/assert"
@@ -401,7 +401,7 @@ func TestDoctorHook(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := shared.NewClientsMock()
 			clientsMock.AddDefaultMocks()
 			clients := tt.mockHookSetup(clientsMock)

--- a/cmd/env/add_test.go
+++ b/cmd/env/add_test.go
@@ -145,7 +145,7 @@ func Test_Env_AddCommand(t *testing.T) {
 		"add a variable using arguments": {
 			CmdArgs: []string{"ENV_NAME", "ENV_VALUE"},
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
-				setupEnvAddCommandMocks(cm, cf)
+				setupEnvAddCommandMocks(ctx, cm, cf)
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
 				cm.ApiInterface.AssertCalled(
@@ -169,7 +169,7 @@ func Test_Env_AddCommand(t *testing.T) {
 		"provide a variable name by argument and value by prompt": {
 			CmdArgs: []string{"ENV_NAME"},
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
-				setupEnvAddCommandMocks(cm, cf)
+				setupEnvAddCommandMocks(ctx, cm, cf)
 				cm.IO.On(
 					"PasswordPrompt",
 					mock.Anything,
@@ -200,7 +200,7 @@ func Test_Env_AddCommand(t *testing.T) {
 		"provide a variable name by argument and value by flag": {
 			CmdArgs: []string{"ENV_NAME", "--value", "example_value"},
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
-				setupEnvAddCommandMocks(cm, cf)
+				setupEnvAddCommandMocks(ctx, cm, cf)
 				cm.IO.On(
 					"PasswordPrompt",
 					mock.Anything,
@@ -231,7 +231,7 @@ func Test_Env_AddCommand(t *testing.T) {
 		"provide both variable name and value by prompt": {
 			CmdArgs: []string{},
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
-				setupEnvAddCommandMocks(cm, cf)
+				setupEnvAddCommandMocks(ctx, cm, cf)
 				cm.IO.On(
 					"InputPrompt",
 					mock.Anything,
@@ -276,10 +276,10 @@ func Test_Env_AddCommand(t *testing.T) {
 }
 
 // setupEnvAddCommandMocks prepares common mocks for these tests
-func setupEnvAddCommandMocks(cm *shared.ClientsMock, cf *shared.ClientFactory) {
+func setupEnvAddCommandMocks(ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
 	cf.SDKConfig = hooks.NewSDKConfigMock()
 	cm.AddDefaultMocks()
-	_ = cf.AppClient().SaveDeployed(context.Background(), mockApp)
+	_ = cf.AppClient().SaveDeployed(ctx, mockApp)
 
 	appSelectMock := prompts.NewAppSelectMock()
 	teamAppSelectPromptFunc = appSelectMock.TeamAppSelectPrompt

--- a/cmd/feedback/feedback_test.go
+++ b/cmd/feedback/feedback_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/slackapi/slack-cli/internal/config"
 	"github.com/slackapi/slack-cli/internal/iostreams"
 	"github.com/slackapi/slack-cli/internal/shared"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/internal/slackerror"
 	"github.com/slackapi/slack-cli/internal/style"
 	"github.com/stretchr/testify/assert"
@@ -46,6 +47,7 @@ func TestFeedbackCommand(t *testing.T) {
 		}
 
 		// Prepare mocks
+		ctx := slackcontext.MockContext(t.Context())
 		clientsMock := shared.NewClientsMock()
 		clientsMock.AddDefaultMocks()
 
@@ -69,7 +71,7 @@ func TestFeedbackCommand(t *testing.T) {
 
 		// Execute test
 		cmd := NewFeedbackCommand(clients)
-		err := runFeedbackCommand(context.Background(), clients, cmd)
+		err := runFeedbackCommand(ctx, clients, cmd)
 		assert.NoError(t, err)
 		clientsMock.Browser.AssertCalled(t, "OpenURL", "https://survey.com?project_id=projectID&system_id=systemID&utm_medium=cli&utm_source=cli")
 	})
@@ -104,6 +106,7 @@ func TestFeedbackCommand(t *testing.T) {
 		}
 
 		// Prepare mocks
+		ctx := slackcontext.MockContext(t.Context())
 		clientsMock := shared.NewClientsMock()
 		clientsMock.AddDefaultMocks()
 
@@ -134,7 +137,7 @@ func TestFeedbackCommand(t *testing.T) {
 
 		// Execute test
 		cmd := NewFeedbackCommand(clients)
-		err := runFeedbackCommand(context.Background(), clients, cmd)
+		err := runFeedbackCommand(ctx, clients, cmd)
 		assert.NoError(t, err)
 		clientsMock.Browser.AssertCalled(t, "OpenURL", "https://survey.com?project_id=projectID&system_id=systemID&utm_medium=cli&utm_source=cli")
 	})
@@ -196,6 +199,7 @@ func TestShowSurveyMessages(t *testing.T) {
 		}
 
 		// Prepare mocks
+		ctx := slackcontext.MockContext(t.Context())
 		clientsMock := shared.NewClientsMock()
 		clientsMock.AddDefaultMocks()
 
@@ -239,7 +243,7 @@ func TestShowSurveyMessages(t *testing.T) {
 		SurveyStore = surveys
 
 		// Execute test
-		err := ShowSurveyMessages(context.Background(), clients)
+		err := ShowSurveyMessages(ctx, clients)
 		assert.NoError(t, err)
 		clientsMock.Browser.AssertCalled(t, "OpenURL", "https://B.com?project_id=projectID&system_id=systemID&utm_medium=cli&utm_source=cli")
 		clientsMock.Browser.AssertCalled(t, "OpenURL", "https://C.com?project_id=projectID&system_id=systemID&utm_medium=cli&utm_source=cli")

--- a/cmd/function/access_test.go
+++ b/cmd/function/access_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/slackapi/slack-cli/internal/shared"
 	"github.com/slackapi/slack-cli/internal/shared/types"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/internal/slackerror"
 	"github.com/slackapi/slack-cli/test/testutil"
 	"github.com/spf13/afero"
@@ -326,6 +327,7 @@ func TestFunctionDistributionCommand_PermissionsFile(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
+			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := shared.NewClientsMock()
 			clientsMock.IO.AddDefaultMocks()
 			err := afero.WriteFile(clientsMock.Fs, tt.filename, []byte(tt.data), 0644)
@@ -339,7 +341,6 @@ func TestFunctionDistributionCommand_PermissionsFile(t *testing.T) {
 			clientsMock.ApiInterface.On("FunctionDistributionSet", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 				Return([]types.FunctionDistributionUser{}, nil)
 
-			ctx := context.Background()
 			clients := shared.NewClientFactory(clientsMock.MockClientFactory())
 			app := types.App{AppID: "A123"}
 
@@ -400,6 +401,7 @@ func TestFunctionDistributeCommand_UpdateNamedEntitiesDistribution(t *testing.T)
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
+			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := shared.NewClientsMock()
 			clientsMock.ApiInterface.On("FunctionDistributionSet", mock.Anything, mock.Anything, mock.Anything, types.NAMED_ENTITIES, mock.Anything).
 				Return([]types.FunctionDistributionUser{}, nil).
@@ -414,7 +416,6 @@ func TestFunctionDistributeCommand_UpdateNamedEntitiesDistribution(t *testing.T)
 
 			app := types.App{AppID: "A123"}
 			function := "Ft123"
-			ctx := context.Background()
 			clients := shared.NewClientFactory(clientsMock.MockClientFactory())
 
 			err := updateNamedEntitiesDistribution(ctx, clients, app, function, tt.updatedEntities)

--- a/cmd/function/prompt_test.go
+++ b/cmd/function/prompt_test.go
@@ -15,13 +15,13 @@
 package function
 
 import (
-	"context"
 	"testing"
 
 	"github.com/slackapi/slack-cli/internal/hooks"
 	"github.com/slackapi/slack-cli/internal/iostreams"
 	"github.com/slackapi/slack-cli/internal/shared"
 	"github.com/slackapi/slack-cli/internal/shared/types"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/internal/slackerror"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -61,6 +61,7 @@ func TestFunction_ChooseFunctionPrompt(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
+			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := shared.NewClientsMock()
 			clientsMock.IO.On("SelectPrompt", mock.Anything, "Choose a function", mock.Anything, iostreams.MatchPromptConfig(iostreams.SelectPromptConfig{
 				Flag: clientsMock.Config.Flags.Lookup("name"),
@@ -77,7 +78,6 @@ func TestFunction_ChooseFunctionPrompt(t *testing.T) {
 			clients := shared.NewClientFactory(clientsMock.MockClientFactory(), func(clients *shared.ClientFactory) {
 				clients.SDKConfig = sdkConfigMock
 			})
-			ctx := context.Background()
 			functions := []types.Function{
 				{CallbackID: "alphabet_function"},
 				{CallbackID: "hello_function"},

--- a/cmd/help/help_test.go
+++ b/cmd/help/help_test.go
@@ -15,11 +15,11 @@
 package help
 
 import (
-	"context"
 	"testing"
 
 	"github.com/slackapi/slack-cli/internal/experiment"
 	"github.com/slackapi/slack-cli/internal/shared"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/internal/style"
 	"github.com/slackapi/slack-cli/test/testutil"
 	"github.com/spf13/cobra"
@@ -75,6 +75,7 @@ func TestHelpFunc(t *testing.T) {
 				experiment.EnabledExperiments = _EnabledExperiments
 			}()
 
+			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := shared.NewClientsMock()
 			clientsMock.AddDefaultMocks()
 			clientsMock.Config.ExperimentsFlag = tt.experiments
@@ -90,7 +91,7 @@ func TestHelpFunc(t *testing.T) {
 				Run:   func(cmd *cobra.Command, args []string) {},
 			}
 			rootCmd.AddCommand(subCommand)
-			rootCmd.SetContext(context.Background())
+			rootCmd.SetContext(ctx)
 			rootCmd.Flags().Bool("help", true, "mock help flag")
 			clientsMock.Config.SetFlags(rootCmd)
 			testutil.MockCmdIO(clientsMock.IO, rootCmd)

--- a/cmd/platform/deploy_test.go
+++ b/cmd/platform/deploy_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/slackapi/slack-cli/internal/prompts"
 	"github.com/slackapi/slack-cli/internal/shared"
 	"github.com/slackapi/slack-cli/internal/shared/types"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/internal/slackerror"
 	"github.com/slackapi/slack-cli/internal/slacktrace"
 	"github.com/slackapi/slack-cli/test/testutil"
@@ -145,6 +146,7 @@ func TestDeployCommand_HasValidDeploymentMethod(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
+			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := shared.NewClientsMock()
 			clients := shared.NewClientFactory(clientsMock.MockClientFactory(), func(clients *shared.ClientFactory) {
 				manifestMock := &app.ManifestMockObject{}
@@ -157,7 +159,6 @@ func TestDeployCommand_HasValidDeploymentMethod(t *testing.T) {
 				clients.SDKConfig = hooks.NewSDKConfigMock()
 				clients.SDKConfig.Hooks.Deploy.Command = tt.deployScript
 			})
-			ctx := context.Background()
 			err := hasValidDeploymentMethod(ctx, clients, types.App{}, types.SlackAuth{})
 			if tt.expectedError != nil {
 				require.Error(t, err)

--- a/cmd/project/create_samples_test.go
+++ b/cmd/project/create_samples_test.go
@@ -15,7 +15,6 @@
 package project
 
 import (
-	"context"
 	"io"
 	"net/http/httptest"
 	"testing"
@@ -23,6 +22,7 @@ import (
 	"github.com/slackapi/slack-cli/internal/iostreams"
 	"github.com/slackapi/slack-cli/internal/pkg/create"
 	"github.com/slackapi/slack-cli/internal/shared"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -102,6 +102,7 @@ func TestSamples_PromptSampleSelection(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
+			ctx := slackcontext.MockContext(t.Context())
 			sampler := create.NewMockSampler()
 			w := httptest.NewRecorder()
 			_, _ = io.WriteString(w, tt.mockSlackHTTPResponse)
@@ -118,7 +119,6 @@ func TestSamples_PromptSampleSelection(t *testing.T) {
 				}),
 			).Return(tt.mockSelection, nil)
 			clients := shared.NewClientFactory(clientsMock.MockClientFactory())
-			ctx := context.Background()
 
 			// Execute test
 			repoName, err := PromptSampleSelection(ctx, clients, sampler)

--- a/cmd/project/create_test.go
+++ b/cmd/project/create_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/slackapi/slack-cli/internal/logger"
 	"github.com/slackapi/slack-cli/internal/pkg/create"
 	"github.com/slackapi/slack-cli/internal/shared"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/internal/slackerror"
 	"github.com/slackapi/slack-cli/test/testutil"
 	"github.com/stretchr/testify/assert"
@@ -235,6 +236,7 @@ func TestCreateCommand_confirmExternalTemplateSelection(t *testing.T) {
 
 func Test_CreateCommand_BoltExperiment(t *testing.T) {
 	// Create mocks
+	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
 	clientsMock.AddDefaultMocks()
 
@@ -243,7 +245,7 @@ func Test_CreateCommand_BoltExperiment(t *testing.T) {
 
 	// Set experiment flag
 	clientsMock.Config.ExperimentsFlag = append(clientsMock.Config.ExperimentsFlag, "bolt")
-	clientsMock.Config.LoadExperiments(context.Background(), clientsMock.IO.PrintDebug)
+	clientsMock.Config.LoadExperiments(ctx, clientsMock.IO.PrintDebug)
 
 	// Create the command
 	cmd := NewCreateCommand(clients)

--- a/cmd/project/init_test.go
+++ b/cmd/project/init_test.go
@@ -56,14 +56,14 @@ func Test_Project_InitCommand(t *testing.T) {
 			CmdArgs: []string{},
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
 				// Do not set experiment flag
-				setupProjectInitCommandMocks(t, cm, cf, false)
+				setupProjectInitCommandMocks(t, ctx, cm, cf, false)
 			},
 			ExpectedErrorStrings: []string{"Command requires the Bolt Framework experiment"},
 		},
 		"init a project and do not link an existing app": {
 			CmdArgs: []string{},
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
-				setupProjectInitCommandMocks(t, cm, cf, true)
+				setupProjectInitCommandMocks(t, ctx, cm, cf, true)
 				// Do not link an existing app
 				cm.IO.On("ConfirmPrompt", mock.Anything, app.LinkAppConfirmPromptText, mock.Anything).Return(false, nil)
 			},
@@ -114,7 +114,7 @@ func Test_Project_InitCommand(t *testing.T) {
 					mockLinkSlackAuth1,
 				}, nil)
 				// Default setup
-				setupProjectInitCommandMocks(t, cm, cf, true)
+				setupProjectInitCommandMocks(t, ctx, cm, cf, true)
 				// Do not link an existing app
 				cm.IO.On("ConfirmPrompt", mock.Anything, app.LinkAppConfirmPromptText, mock.Anything).Return(true, nil)
 				// Mock prompt to link an existing app
@@ -221,7 +221,7 @@ func Test_Project_InitCommand(t *testing.T) {
 }
 
 // setupProjectInitCommandMocks prepares common mocks for these tests
-func setupProjectInitCommandMocks(t *testing.T, cm *shared.ClientsMock, cf *shared.ClientFactory, boltExperimentEnabled bool) {
+func setupProjectInitCommandMocks(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory, boltExperimentEnabled bool) {
 	// Mocks
 	projectDirPath := "/path/to/project-name"
 	cm.Os.On("Getwd").Return(projectDirPath, nil)
@@ -230,7 +230,7 @@ func setupProjectInitCommandMocks(t *testing.T, cm *shared.ClientsMock, cf *shar
 	// Set experiment flag
 	if boltExperimentEnabled {
 		cm.Config.ExperimentsFlag = append(cm.Config.ExperimentsFlag, "bolt")
-		cm.Config.LoadExperiments(context.Background(), cm.IO.PrintDebug)
+		cm.Config.LoadExperiments(ctx, cm.IO.PrintDebug)
 	}
 
 	// Create project directory

--- a/cmd/triggers/generate_test.go
+++ b/cmd/triggers/generate_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/slackapi/slack-cli/internal/iostreams"
 	"github.com/slackapi/slack-cli/internal/shared"
 	"github.com/slackapi/slack-cli/internal/shared/types"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/internal/slackerror"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
@@ -54,7 +55,7 @@ func Test_TriggerGenerate_accept_prompt(t *testing.T) {
 	}
 
 	t.Run(tt.name, func(t *testing.T) {
-		ctx, clientsMock := prepareMocks(tt.triggersListResponse, tt.globResponse, tt.triggersCreateResponse, nil /*trigger create error*/)
+		ctx, clientsMock := prepareMocks(t, tt.triggersListResponse, tt.globResponse, tt.triggersCreateResponse, nil /*trigger create error*/)
 
 		clientsMock.IO.On("SelectPrompt", mock.Anything, "Choose a trigger definition file:", mock.Anything, iostreams.MatchPromptConfig(iostreams.SelectPromptConfig{
 			Flag: clientsMock.Config.Flags.Lookup("trigger-def"),
@@ -94,7 +95,7 @@ func Test_TriggerGenerate_decline_prompt(t *testing.T) {
 	}
 
 	t.Run(tt.name, func(t *testing.T) {
-		ctx, clientsMock := prepareMocks(tt.triggersListResponse, tt.globResponse, tt.triggersCreateResponse, nil /*trigger create error*/)
+		ctx, clientsMock := prepareMocks(t, tt.triggersListResponse, tt.globResponse, tt.triggersCreateResponse, nil /*trigger create error*/)
 		clientsMock.IO.On("SelectPrompt", mock.Anything, "Choose a trigger definition file:", mock.Anything, iostreams.MatchPromptConfig(iostreams.SelectPromptConfig{
 			Flag: clientsMock.Config.Flags.Lookup("trigger-def"),
 		})).Return(iostreams.SelectPromptResponse{
@@ -127,7 +128,7 @@ func Test_TriggerGenerate_skip_prompt(t *testing.T) {
 	}
 
 	t.Run(tt.name, func(t *testing.T) {
-		ctx, clientsMock := prepareMocks(tt.triggersListResponse, tt.globResponse, tt.triggersCreateResponse, nil /*trigger create error*/)
+		ctx, clientsMock := prepareMocks(t, tt.triggersListResponse, tt.globResponse, tt.triggersCreateResponse, nil /*trigger create error*/)
 		clientsMock.ApiInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
 		clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 			Return(types.EVERYONE, []string{}, nil).Once()
@@ -158,7 +159,7 @@ func Test_TriggerGenerate_handle_error(t *testing.T) {
 	}
 
 	t.Run(tt.name, func(t *testing.T) {
-		ctx, clientsMock := prepareMocks(tt.triggersListResponse, tt.globResponse, tt.triggersCreateResponse, fmt.Errorf("something went wrong") /*trigger create error*/)
+		ctx, clientsMock := prepareMocks(t, tt.triggersListResponse, tt.globResponse, tt.triggersCreateResponse, fmt.Errorf("something went wrong") /*trigger create error*/)
 		clientsMock.IO.On("SelectPrompt", mock.Anything, "Choose a trigger definition file:", mock.Anything, iostreams.MatchPromptConfig(iostreams.SelectPromptConfig{
 			Flag: clientsMock.Config.Flags.Lookup("trigger-def"),
 		})).Return(iostreams.SelectPromptResponse{
@@ -197,7 +198,7 @@ func Test_TriggerGenerate_handle_invalid_paths(t *testing.T) {
 	}
 
 	t.Run(tt.name, func(t *testing.T) {
-		ctx, clientsMock := prepareMocks(tt.triggersListResponse, tt.globResponse, tt.triggersCreateResponse, nil)
+		ctx, clientsMock := prepareMocks(t, tt.triggersListResponse, tt.globResponse, tt.triggersCreateResponse, nil)
 
 		clients := shared.NewClientFactory(clientsMock.MockClientFactory(), func(clients *shared.ClientFactory) {
 			clients.SDKConfig = hooks.NewSDKConfigMock()
@@ -226,7 +227,7 @@ func Test_TriggerGenerate_Config_TriggerPaths_Default(t *testing.T) {
 	}
 
 	t.Run(tt.name, func(t *testing.T) {
-		ctx, clientsMock := prepareMocks(tt.triggersListResponse, tt.globResponse, tt.triggersCreateResponse, nil /*trigger create error*/)
+		ctx, clientsMock := prepareMocks(t, tt.triggersListResponse, tt.globResponse, tt.triggersCreateResponse, nil /*trigger create error*/)
 		clientsMock.IO.On("SelectPrompt", mock.Anything, "Choose a trigger definition file:", mock.Anything, iostreams.MatchPromptConfig(iostreams.SelectPromptConfig{
 			Flag: clientsMock.Config.Flags.Lookup("trigger-def"),
 		})).Return(iostreams.SelectPromptResponse{
@@ -266,7 +267,7 @@ func Test_TriggerGenerate_Config_TriggerPaths_Custom(t *testing.T) {
 	}
 
 	t.Run(tt.name, func(t *testing.T) {
-		ctx, clientsMock := prepareMocks(tt.triggersListResponse, tt.globResponse, tt.triggersCreateResponse, nil /*trigger create error*/)
+		ctx, clientsMock := prepareMocks(t, tt.triggersListResponse, tt.globResponse, tt.triggersCreateResponse, nil /*trigger create error*/)
 		clientsMock.IO.On("SelectPrompt", mock.Anything, "Choose a trigger definition file:", mock.Anything, iostreams.MatchPromptConfig(iostreams.SelectPromptConfig{
 			Flag: clientsMock.Config.Flags.Lookup("trigger-def"),
 		})).Return(iostreams.SelectPromptResponse{
@@ -451,8 +452,8 @@ func Test_ShowTriggers(t *testing.T) {
 	}
 }
 
-func prepareMocks(triggersListResponse []types.DeployedTrigger, globResponse []string, triggersCreateResponse types.DeployedTrigger, triggersCreateResponseError error) (context.Context, *shared.ClientsMock) {
-	ctx := context.Background()
+func prepareMocks(t *testing.T, triggersListResponse []types.DeployedTrigger, globResponse []string, triggersCreateResponse types.DeployedTrigger, triggersCreateResponseError error) (context.Context, *shared.ClientsMock) {
+	ctx := slackcontext.MockContext(t.Context())
 	ctx = config.SetContextToken(ctx, "token")
 
 	clientsMock := shared.NewClientsMock()

--- a/internal/app/app_client_test.go
+++ b/internal/app/app_client_test.go
@@ -15,7 +15,6 @@
 package app
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"os"
@@ -24,6 +23,7 @@ import (
 
 	"github.com/slackapi/slack-cli/internal/config"
 	"github.com/slackapi/slack-cli/internal/shared/types"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/internal/slackdeps"
 	"github.com/slackapi/slack-cli/internal/slackerror"
 	"github.com/spf13/afero"
@@ -211,8 +211,9 @@ func Test_AppClient_ReadDevApps_BrokenAppsJSON(t *testing.T) {
 func Test_AppClient_getDeployedAppTeamDomain_ViaCLIFlag(t *testing.T) {
 	ac, _, _, _, _, teardown := setup(t)
 	defer teardown(t)
+	ctx := slackcontext.MockContext(t.Context())
 	ac.config.TeamFlag = "flagname"
-	name := ac.getDeployedAppTeamDomain(context.Background())
+	name := ac.getDeployedAppTeamDomain(ctx)
 	assert.Equal(t, "flagname", name)
 }
 
@@ -220,7 +221,7 @@ func Test_AppClient_getDeployedAppTeamDomain_ViaCLIFlag(t *testing.T) {
 func Test_AppClient_getDeployedAppTeamDomain_ViaDefaultDef(t *testing.T) {
 	ac, _, _, _, _, teardown := setup(t)
 	defer teardown(t)
-	ctx := context.Background()
+	ctx := slackcontext.MockContext(t.Context())
 	err := ac.apps.Set(types.App{
 		TeamID:     "T123",
 		TeamDomain: "shouty-rooster",
@@ -235,7 +236,7 @@ func Test_AppClient_getDeployedAppTeamDomain_ViaDefaultDef(t *testing.T) {
 func Test_AppClient_getDeployedAppTeamDomain_ViaDefaultAppName(t *testing.T) {
 	ac, _, _, _, _, teardown := setup(t)
 	defer teardown(t)
-	ctx := context.Background()
+	ctx := slackcontext.MockContext(t.Context())
 	name := ac.getDeployedAppTeamDomain(ctx)
 	assert.Equal(t, "prod", name)
 }
@@ -244,7 +245,7 @@ func Test_AppClient_getDeployedAppTeamDomain_ViaDefaultAppName(t *testing.T) {
 func Test_AppClient_GetDeployed_Empty(t *testing.T) {
 	ac, _, _, _, _, teardown := setup(t)
 	defer teardown(t)
-	ctx := context.Background()
+	ctx := slackcontext.MockContext(t.Context())
 
 	// FIXME: This action is unsafely fetching an app. Please explicitly supply a TeamID
 	// This test case is specifically trying to test existing behavior when "" supplied
@@ -257,7 +258,7 @@ func Test_AppClient_GetDeployed_Empty(t *testing.T) {
 func Test_AppClient_GetDeployed_DefaultApp(t *testing.T) {
 	ac, _, _, pathToAppsJSON, _, teardown := setup(t)
 	defer teardown(t)
-	ctx := context.Background()
+	ctx := slackcontext.MockContext(t.Context())
 	jsonContents := []byte(`{
 		"apps":{
 			"twistandshout":{
@@ -281,7 +282,7 @@ func Test_AppClient_GetDeployed_DefaultApp(t *testing.T) {
 func Test_AppClient_GetDeployed_TeamID_NoDefault(t *testing.T) {
 	ac, _, _, pathToAppsJSON, _, teardown := setup(t)
 	defer teardown(t)
-	ctx := context.Background()
+	ctx := slackcontext.MockContext(t.Context())
 	jsonContents := []byte(`{
 		"apps":{
 			"T1":{
@@ -302,7 +303,7 @@ func Test_AppClient_GetDeployed_TeamID_NoDefault(t *testing.T) {
 func Test_AppClient_GetLocal_Empty(t *testing.T) {
 	ac, _, _, _, _, teardown := setup(t)
 	defer teardown(t)
-	ctx := context.Background()
+	ctx := slackcontext.MockContext(t.Context())
 	app, err := ac.GetLocal(ctx, "T123")
 	require.NoError(t, err)
 	assert.True(t, app.IsNew())
@@ -312,7 +313,7 @@ func Test_AppClient_GetLocal_Empty(t *testing.T) {
 func Test_AppClient_GetLocal_SingleApp(t *testing.T) {
 	ac, _, _, _, pathToDevAppsJSON, teardown := setup(t)
 	defer teardown(t)
-	ctx := context.Background()
+	ctx := slackcontext.MockContext(t.Context())
 	jsonContents := []byte(`{
 		"U123":{
 			"name":"dev",
@@ -332,7 +333,7 @@ func Test_AppClient_GetLocal_SingleApp(t *testing.T) {
 func Test_AppClient_GetDeployedAll_Empty(t *testing.T) {
 	ac, _, _, _, _, teardown := setup(t)
 	defer teardown(t)
-	ctx := context.Background()
+	ctx := slackcontext.MockContext(t.Context())
 	apps, defaultName, err := ac.GetDeployedAll(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, []types.App{}, apps)
@@ -343,7 +344,7 @@ func Test_AppClient_GetDeployedAll_Empty(t *testing.T) {
 func Test_AppClient_GetDeployedAll_SomeApps(t *testing.T) {
 	ac, _, _, pathToAppsJSON, _, teardown := setup(t)
 	defer teardown(t)
-	ctx := context.Background()
+	ctx := slackcontext.MockContext(t.Context())
 	jsonContents := []byte(`{
 		"apps":{
 			"twistandshout":{
@@ -372,7 +373,7 @@ func Test_AppClient_GetDeployedAll_SomeApps(t *testing.T) {
 func Test_AppClient_GetLocalAll_Empty(t *testing.T) {
 	ac, _, _, _, _, teardown := setup(t)
 	defer teardown(t)
-	ctx := context.Background()
+	ctx := slackcontext.MockContext(t.Context())
 	apps, err := ac.GetLocalAll(ctx)
 	require.NoError(t, err)
 	assert.Equal(t, []types.App{}, apps)
@@ -382,7 +383,7 @@ func Test_AppClient_GetLocalAll_Empty(t *testing.T) {
 func Test_AppClient_GetLocalAll_SomeApps(t *testing.T) {
 	ac, _, _, _, pathToDevAppsJSON, teardown := setup(t)
 	defer teardown(t)
-	ctx := context.Background()
+	ctx := slackcontext.MockContext(t.Context())
 	jsonContents := []byte(`{
 		"U123":{
 			"name":"dev",
@@ -401,7 +402,7 @@ func Test_AppClient_GetLocalAll_SomeApps(t *testing.T) {
 func Test_AppClient_Save_Empty(t *testing.T) {
 	ac, _, _, pathToAppsJSON, _, teardown := setup(t)
 	defer teardown(t)
-	ctx := context.Background()
+	ctx := slackcontext.MockContext(t.Context())
 	app := types.App{
 		TeamID:     "T123",
 		TeamDomain: "shouty-rooster",
@@ -430,7 +431,7 @@ func Test_AppClient_Save_Empty(t *testing.T) {
 func Test_AppClient_Save_NotEmpty(t *testing.T) {
 	ac, _, _, pathToAppsJSON, _, teardown := setup(t)
 	defer teardown(t)
-	ctx := context.Background()
+	ctx := slackcontext.MockContext(t.Context())
 	app := types.App{
 		TeamID:     "T123",
 		TeamDomain: "shouty-rooster",
@@ -467,7 +468,7 @@ func Test_AppClient_Save_NotEmpty(t *testing.T) {
 func Test_AppClient_SaveLocal_Empty(t *testing.T) {
 	ac, _, _, _, pathToDevAppsJSON, teardown := setup(t)
 	defer teardown(t)
-	ctx := context.Background()
+	ctx := slackcontext.MockContext(t.Context())
 	appTeamID := "T1"
 	app := types.App{
 		AppID:  "A123",
@@ -500,7 +501,7 @@ func Test_AppClient_SaveLocal_Empty(t *testing.T) {
 func Test_AppClient_SaveLocal_NotEmpty(t *testing.T) {
 	ac, _, _, _, pathToDevAppsJSON, teardown := setup(t)
 	defer teardown(t)
-	ctx := context.Background()
+	ctx := slackcontext.MockContext(t.Context())
 	appTeamID := "T1"
 	app := types.App{
 		AppID:  "A123",
@@ -533,7 +534,7 @@ func Test_AppClient_SaveLocal_NotEmpty(t *testing.T) {
 func Test_AppClient_RemoveDeployed(t *testing.T) {
 	ac, _, _, _, _, teardown := setup(t)
 	defer teardown(t)
-	ctx := context.Background()
+	ctx := slackcontext.MockContext(t.Context())
 	app := types.App{
 		TeamID:     "T123",
 		TeamDomain: "shouty-rooster",
@@ -557,7 +558,7 @@ func Test_AppClient_RemoveDeployed(t *testing.T) {
 func Test_AppClient_RemoveLocal(t *testing.T) {
 	ac, _, _, _, _, teardown := setup(t)
 	defer teardown(t)
-	ctx := context.Background()
+	ctx := slackcontext.MockContext(t.Context())
 	app := types.App{
 		AppID:  "A123",
 		UserID: "U123",
@@ -694,7 +695,7 @@ func TestAppClient_CleanupAppsJsonFiles(t *testing.T) {
 	for _, tt := range tests {
 		ac, _, _, pathToAppsJSON, pathToDevAppsJSON, teardown := setup(t)
 		defer teardown(t)
-		ctx := context.Background()
+		ctx := slackcontext.MockContext(t.Context())
 
 		err := afero.WriteFile(ac.fs, pathToAppsJSON, tt.appsJSON, 0600)
 		require.NoError(t, err)

--- a/internal/app/manifest_test.go
+++ b/internal/app/manifest_test.go
@@ -15,13 +15,13 @@
 package app
 
 import (
-	"context"
 	"testing"
 
 	"github.com/slackapi/slack-cli/internal/api"
 	"github.com/slackapi/slack-cli/internal/config"
 	"github.com/slackapi/slack-cli/internal/hooks"
 	"github.com/slackapi/slack-cli/internal/shared/types"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/internal/slackdeps"
 	"github.com/slackapi/slack-cli/internal/slackerror"
 	"github.com/stretchr/testify/assert"
@@ -177,6 +177,7 @@ func Test_AppManifest_GetManifestRemote(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
+			ctx := slackcontext.MockContext(t.Context())
 			fsMock := slackdeps.NewFsMock()
 			osMock := slackdeps.NewOsMock()
 			osMock.AddDefaultMocks()
@@ -186,7 +187,6 @@ func Test_AppManifest_GetManifestRemote(t *testing.T) {
 				Return(api.ExportAppResult{Manifest: tt.mockManifestResponse}, tt.mockManifestError)
 			manifestClient := NewManifestClient(apic, configMock)
 
-			ctx := context.Background()
 			manifest, err := manifestClient.GetManifestRemote(ctx, tt.mockToken, tt.mockAppID)
 			if tt.expectedError != nil {
 				assert.Equal(t, tt.expectedError, err)

--- a/internal/cache/manifest_test.go
+++ b/internal/cache/manifest_test.go
@@ -15,11 +15,11 @@
 package cache
 
 import (
-	"context"
 	"path/filepath"
 	"testing"
 
 	"github.com/slackapi/slack-cli/internal/shared/types"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/internal/slackdeps"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -43,13 +43,13 @@ func TestCache_Manifest(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
+			ctx := slackcontext.MockContext(t.Context())
 			fsMock := slackdeps.NewFsMock()
 			osMock := slackdeps.NewOsMock()
 			projectDirPath := "/path/to/project-name"
 			err := fsMock.MkdirAll(filepath.Dir(projectDirPath), 0o755)
 			require.NoError(t, err)
 			cache := NewCache(fsMock, osMock, projectDirPath)
-			ctx := context.Background()
 			err = cache.SetManifestHash(ctx, tt.mockAppID, tt.mockCache.Hash)
 			require.NoError(t, err)
 			cache.ManifestCache.Apps = map[string]ManifestCacheApp{
@@ -104,12 +104,12 @@ func TestCache_Manifest_NewManifestHash(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
+			ctx := slackcontext.MockContext(t.Context())
 			fsMock := slackdeps.NewFsMock()
 			osMock := slackdeps.NewOsMock()
 			projectDirPath := "/path/to/project-name"
 			err := fsMock.MkdirAll(filepath.Dir(projectDirPath), 0o755)
 			require.NoError(t, err)
-			ctx := context.Background()
 			cache := NewCache(fsMock, osMock, projectDirPath)
 			hash, err := cache.NewManifestHash(ctx, tt.mockManifest)
 			assert.NoError(t, err)

--- a/internal/cmdutil/project_test.go
+++ b/internal/cmdutil/project_test.go
@@ -15,7 +15,6 @@
 package cmdutil
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -23,6 +22,7 @@ import (
 	"github.com/slackapi/slack-cli/internal/config"
 	"github.com/slackapi/slack-cli/internal/shared"
 	"github.com/slackapi/slack-cli/internal/shared/types"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/internal/slackerror"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -79,6 +79,7 @@ func TestIsSlackHostedProject(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
+			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := shared.NewClientsMock()
 			manifestMock := &app.ManifestMockObject{}
 			manifestMock.On(
@@ -93,7 +94,6 @@ func TestIsSlackHostedProject(t *testing.T) {
 			projectConfigMock := config.NewProjectConfigMock()
 			projectConfigMock.On("GetManifestSource", mock.Anything).Return(tt.mockManifestSource, nil)
 			clientsMock.Config.ProjectConfig = projectConfigMock
-			ctx := context.Background()
 			clients := shared.NewClientFactory(clientsMock.MockClientFactory())
 			err := IsSlackHostedProject(ctx, clients)
 			assert.Equal(t, tt.expectedError, err)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/slackapi/slack-cli/internal/shared/types"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/internal/slackdeps"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
@@ -28,7 +29,7 @@ import (
 
 // setup
 func setup(t *testing.T) (context.Context, *slackdeps.FsMock, *slackdeps.OsMock, *Config, string, func(*testing.T)) {
-	ctx := context.Background()
+	ctx := slackcontext.MockContext(t.Context())
 	fs := slackdeps.NewFsMock()
 	os := slackdeps.NewOsMock()
 	os.AddDefaultMocks()

--- a/internal/config/project_test.go
+++ b/internal/config/project_test.go
@@ -15,7 +15,6 @@
 package config
 
 import (
-	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -23,6 +22,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/slackapi/slack-cli/internal/cache"
 	"github.com/slackapi/slack-cli/internal/shared/types"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/internal/slackdeps"
 	"github.com/slackapi/slack-cli/internal/slackerror"
 	"github.com/spf13/afero"
@@ -56,7 +56,7 @@ func Test_ProjectConfig_NewProjectConfig(t *testing.T) {
 
 func Test_ProjectConfig_InitProjectID(t *testing.T) {
 	t.Run("When not a project directory, should return an error", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := slackcontext.MockContext(t.Context())
 		fs := slackdeps.NewFsMock()
 		os := slackdeps.NewOsMock()
 
@@ -72,7 +72,7 @@ func Test_ProjectConfig_InitProjectID(t *testing.T) {
 	})
 
 	t.Run("When project_id is empty, should init project_id", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := slackcontext.MockContext(t.Context())
 		fs := slackdeps.NewFsMock()
 		os := slackdeps.NewOsMock()
 
@@ -90,7 +90,7 @@ func Test_ProjectConfig_InitProjectID(t *testing.T) {
 	})
 
 	t.Run("When project_id exists, should not overwrite project_id (overwrite: false)", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := slackcontext.MockContext(t.Context())
 		fs := slackdeps.NewFsMock()
 		os := slackdeps.NewOsMock()
 
@@ -114,7 +114,7 @@ func Test_ProjectConfig_InitProjectID(t *testing.T) {
 	})
 
 	t.Run("When project_id exists, should overwrite project_id (overwrite: true)", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := slackcontext.MockContext(t.Context())
 		fs := slackdeps.NewFsMock()
 		os := slackdeps.NewOsMock()
 
@@ -141,7 +141,7 @@ func Test_ProjectConfig_InitProjectID(t *testing.T) {
 
 func Test_ProjectConfig_GetProjectID(t *testing.T) {
 	t.Run("When not a project directory, should return an error", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := slackcontext.MockContext(t.Context())
 		fs := slackdeps.NewFsMock()
 		os := slackdeps.NewOsMock()
 
@@ -157,7 +157,7 @@ func Test_ProjectConfig_GetProjectID(t *testing.T) {
 	})
 
 	t.Run("When a project directory, should return trimmed project_id", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := slackcontext.MockContext(t.Context())
 		fs := slackdeps.NewFsMock()
 		os := slackdeps.NewOsMock()
 
@@ -183,7 +183,7 @@ func Test_ProjectConfig_GetProjectID(t *testing.T) {
 
 func Test_ProjectConfig_SetProjectID(t *testing.T) {
 	t.Run("When not a project directory, should return an error", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := slackcontext.MockContext(t.Context())
 		fs := slackdeps.NewFsMock()
 		os := slackdeps.NewOsMock()
 
@@ -200,7 +200,7 @@ func Test_ProjectConfig_SetProjectID(t *testing.T) {
 	})
 
 	t.Run("When a project directory, should update the project_id", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := slackcontext.MockContext(t.Context())
 		fs := slackdeps.NewFsMock()
 		os := slackdeps.NewOsMock()
 
@@ -254,7 +254,7 @@ func Test_ProjectConfig_ManifestSource(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := slackcontext.MockContext(t.Context())
 			fs := slackdeps.NewFsMock()
 			os := slackdeps.NewOsMock()
 			os.AddDefaultMocks()
@@ -274,7 +274,7 @@ func Test_ProjectConfig_ManifestSource(t *testing.T) {
 
 func Test_ProjectConfig_ReadProjectConfigFile(t *testing.T) {
 	t.Run("When not a project directory, should return an error", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := slackcontext.MockContext(t.Context())
 		fs := slackdeps.NewFsMock()
 		os := slackdeps.NewOsMock()
 
@@ -289,7 +289,7 @@ func Test_ProjectConfig_ReadProjectConfigFile(t *testing.T) {
 	})
 
 	t.Run("When project directory doesn't have a .slack/config.json, should return a default config.json", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := slackcontext.MockContext(t.Context())
 		fs := slackdeps.NewFsMock()
 		os := slackdeps.NewOsMock()
 
@@ -310,7 +310,7 @@ func Test_ProjectConfig_ReadProjectConfigFile(t *testing.T) {
 	})
 
 	t.Run("When a project directory has a .slack/config.json, should return config.json", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := slackcontext.MockContext(t.Context())
 		fs := slackdeps.NewFsMock()
 		os := slackdeps.NewOsMock()
 
@@ -335,7 +335,7 @@ func Test_ProjectConfig_ReadProjectConfigFile(t *testing.T) {
 	})
 
 	t.Run("errors on invalid formatting of project config file", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := slackcontext.MockContext(t.Context())
 		fs := slackdeps.NewFsMock()
 		os := slackdeps.NewOsMock()
 
@@ -360,7 +360,7 @@ func Test_ProjectConfig_ReadProjectConfigFile(t *testing.T) {
 
 func Test_ProjectConfig_WriteProjectConfigFile(t *testing.T) {
 	t.Run("When not a project directory, should return an error", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := slackcontext.MockContext(t.Context())
 		fs := slackdeps.NewFsMock()
 		os := slackdeps.NewOsMock()
 
@@ -379,7 +379,7 @@ func Test_ProjectConfig_WriteProjectConfigFile(t *testing.T) {
 	})
 
 	t.Run("When a project directory, should write the .slack/config.json file", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := slackcontext.MockContext(t.Context())
 		fs := slackdeps.NewFsMock()
 		os := slackdeps.NewOsMock()
 
@@ -502,11 +502,11 @@ func Test_ProjectConfig_Cache(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
+			ctx := slackcontext.MockContext(t.Context())
 			fs := slackdeps.NewFsMock()
 			os := slackdeps.NewOsMock()
 			os.AddDefaultMocks()
 			addProjectMocks(t, fs)
-			ctx := context.Background()
 			projectConfig := NewProjectConfig(fs, os)
 			cache := projectConfig.Cache()
 			if !tt.mockHash.Equals("") {
@@ -563,7 +563,7 @@ func Test_Config_CreateProjectConfigDir(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := slackcontext.MockContext(t.Context())
 			fs := afero.NewMemMapFs()
 			if tt.existingDir {
 				err := fs.MkdirAll(tt.projectDirPath+"/.slack", 0755)

--- a/internal/config/system_test.go
+++ b/internal/config/system_test.go
@@ -15,7 +15,6 @@
 package config
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	_os "os"
@@ -26,6 +25,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/internal/slackdeps"
 	"github.com/slackapi/slack-cli/internal/slackerror"
 	"github.com/spf13/afero"
@@ -54,7 +54,7 @@ func Test_SystemConfig_SetCustomConfigDirPath(t *testing.T) {
 
 func Test_SystemConfig_UserConfig(t *testing.T) {
 	t.Run("Error reading configuration directory", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := slackcontext.MockContext(t.Context())
 		fs := slackdeps.NewFsMock()
 		os := slackdeps.NewOsMock()
 
@@ -70,7 +70,7 @@ func Test_SystemConfig_UserConfig(t *testing.T) {
 	})
 
 	t.Run("Error when configuration file does not exist", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := slackcontext.MockContext(t.Context())
 		fs := slackdeps.NewFsMock()
 		os := slackdeps.NewOsMock()
 
@@ -86,7 +86,7 @@ func Test_SystemConfig_UserConfig(t *testing.T) {
 	})
 
 	t.Run("Error when configuration file has bad formatting", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := slackcontext.MockContext(t.Context())
 		fs := slackdeps.NewFsMock()
 		os := slackdeps.NewOsMock()
 
@@ -111,7 +111,7 @@ func Test_SystemConfig_UserConfig(t *testing.T) {
 
 func Test_Config_SlackConfigDir(t *testing.T) {
 	t.Run("Return home directory by default", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := slackcontext.MockContext(t.Context())
 		fs := slackdeps.NewFsMock()
 		os := slackdeps.NewOsMock()
 
@@ -126,7 +126,7 @@ func Test_Config_SlackConfigDir(t *testing.T) {
 	})
 
 	t.Run("Return custom directory when it exists", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := slackcontext.MockContext(t.Context())
 		fs := slackdeps.NewFsMock()
 		os := slackdeps.NewOsMock()
 
@@ -142,9 +142,8 @@ func Test_Config_SlackConfigDir(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	// TODO(@mbrooks) Uncomment
 	t.Run("Return error when custom directory is missing", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := slackcontext.MockContext(t.Context())
 		fs := slackdeps.NewFsMock()
 		os := slackdeps.NewOsMock()
 
@@ -161,7 +160,7 @@ func Test_Config_SlackConfigDir(t *testing.T) {
 	})
 
 	t.Run("Return error when home directory and working directory are unavailable", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := slackcontext.MockContext(t.Context())
 		fs := slackdeps.NewFsMock()
 		os := slackdeps.NewOsMock()
 
@@ -178,7 +177,7 @@ func Test_Config_SlackConfigDir(t *testing.T) {
 	})
 
 	t.Run("Return error when creating default config directory fails", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := slackcontext.MockContext(t.Context())
 		fs := slackdeps.NewFsMock()
 		os := slackdeps.NewOsMock()
 
@@ -195,7 +194,7 @@ func Test_Config_SlackConfigDir(t *testing.T) {
 	})
 
 	t.Run("Keep existing configuration files", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := slackcontext.MockContext(t.Context())
 		fs := slackdeps.NewFsMock()
 		os := slackdeps.NewOsMock()
 
@@ -215,7 +214,7 @@ func Test_Config_SlackConfigDir(t *testing.T) {
 
 func Test_SystemConfig_LogsDir(t *testing.T) {
 	t.Run("Create logs folder in .slack directory", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := slackcontext.MockContext(t.Context())
 		fs := slackdeps.NewFsMock()
 		os := slackdeps.NewOsMock()
 
@@ -233,7 +232,7 @@ func Test_SystemConfig_LogsDir(t *testing.T) {
 
 func Test_Config_GetLastUpdateCheckedAt(t *testing.T) {
 	t.Run("Error reading User Configuration file returns current time", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := slackcontext.MockContext(t.Context())
 		fs := slackdeps.NewFsMock()
 		os := slackdeps.NewOsMock()
 
@@ -252,7 +251,7 @@ func Test_Config_GetLastUpdateCheckedAt(t *testing.T) {
 	})
 
 	t.Run("Returns LastUpdateCheckedAt from User Configuration File", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := slackcontext.MockContext(t.Context())
 		fs := slackdeps.NewFsMock()
 		os := slackdeps.NewOsMock()
 
@@ -272,7 +271,7 @@ func Test_Config_GetLastUpdateCheckedAt(t *testing.T) {
 
 func Test_Config_SetLastUpdateCheckedAt(t *testing.T) {
 	t.Run("Error reading User Configuration file", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := slackcontext.MockContext(t.Context())
 		fs := slackdeps.NewFsMock()
 		os := slackdeps.NewOsMock()
 
@@ -290,7 +289,7 @@ func Test_Config_SetLastUpdateCheckedAt(t *testing.T) {
 	})
 
 	t.Run("Writes LastUpdateCheckedAt to User Configuration file", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := slackcontext.MockContext(t.Context())
 		fs := slackdeps.NewFsMock()
 		os := slackdeps.NewOsMock()
 
@@ -311,7 +310,7 @@ func Test_Config_SetLastUpdateCheckedAt(t *testing.T) {
 
 func Test_SystemConfig_GetSystemID(t *testing.T) {
 	t.Run("When no system_id is set, should return empty string", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := slackcontext.MockContext(t.Context())
 		fs := slackdeps.NewFsMock()
 		os := slackdeps.NewOsMock()
 
@@ -326,7 +325,7 @@ func Test_SystemConfig_GetSystemID(t *testing.T) {
 	})
 
 	t.Run("When system_id is set, should return system_id", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := slackcontext.MockContext(t.Context())
 		fs := slackdeps.NewFsMock()
 		os := slackdeps.NewOsMock()
 
@@ -351,7 +350,7 @@ func Test_SystemConfig_GetSystemID(t *testing.T) {
 
 func Test_SystemConfig_SetSystemID(t *testing.T) {
 	t.Run("Should update the system_id", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := slackcontext.MockContext(t.Context())
 		fs := slackdeps.NewFsMock()
 		os := slackdeps.NewOsMock()
 
@@ -385,7 +384,7 @@ func Test_SystemConfig_SetSystemID(t *testing.T) {
 
 func Test_SystemConfig_InitSystemID(t *testing.T) {
 	t.Run("When system_id is empty, should generate a new system_id", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := slackcontext.MockContext(t.Context())
 		fs := slackdeps.NewFsMock()
 		os := slackdeps.NewOsMock()
 
@@ -413,7 +412,7 @@ func Test_SystemConfig_InitSystemID(t *testing.T) {
 	})
 
 	t.Run("When system_id is not empty, should not overwrite it", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := slackcontext.MockContext(t.Context())
 		fs := slackdeps.NewFsMock()
 		os := slackdeps.NewOsMock()
 
@@ -596,7 +595,7 @@ func Test_SystemConfig_writeConfigFile(t *testing.T) {
 
 func Test_SystemConfig_GetTrustUnknownSources(t *testing.T) {
 	t.Run("When no trust_unknown_sources is set, should return false", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := slackcontext.MockContext(t.Context())
 		fs := slackdeps.NewFsMock()
 		os := slackdeps.NewOsMock()
 
@@ -611,7 +610,7 @@ func Test_SystemConfig_GetTrustUnknownSources(t *testing.T) {
 	})
 
 	t.Run("When trust_unknown_sources is set, should return true", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := slackcontext.MockContext(t.Context())
 		fs := slackdeps.NewFsMock()
 		os := slackdeps.NewOsMock()
 
@@ -635,7 +634,7 @@ func Test_SystemConfig_GetTrustUnknownSources(t *testing.T) {
 
 func Test_SystemConfig_SetTrustUnknownSources(t *testing.T) {
 	t.Run("Should update the trust_unknown_sources", func(t *testing.T) {
-		ctx := context.Background()
+		ctx := slackcontext.MockContext(t.Context())
 		fs := slackdeps.NewFsMock()
 		os := slackdeps.NewOsMock()
 

--- a/internal/iostreams/logfile_test.go
+++ b/internal/iostreams/logfile_test.go
@@ -16,7 +16,6 @@ package iostreams
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"log"
 	"os"
@@ -26,6 +25,7 @@ import (
 
 	"github.com/slackapi/slack-cli/internal/config"
 	"github.com/slackapi/slack-cli/internal/goutils"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/internal/slackdeps"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
@@ -162,6 +162,7 @@ func Test_FlushToLogFile(t *testing.T) {
 			stderrBuff := bytes.Buffer{}
 			stderrLogger := log.Logger{}
 			stderrLogger.SetOutput(&stderrBuff)
+			ctx := slackcontext.MockContext(t.Context())
 			fsMock := slackdeps.NewFsMock()
 			osMock := slackdeps.NewOsMock()
 			osMock.AddDefaultMocks()
@@ -173,7 +174,6 @@ func Test_FlushToLogFile(t *testing.T) {
 			io = NewIOStreams(config, fsMock, osMock)
 			io.Stderr = &stderrLogger
 
-			ctx := context.Background()
 			err := io.FlushToLogFile(ctx, tt.prefix, tt.errStr)
 			require.NoError(t, err)
 

--- a/internal/iostreams/printer_test.go
+++ b/internal/iostreams/printer_test.go
@@ -16,7 +16,6 @@ package iostreams
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"log"
 	"regexp"
@@ -24,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/slackapi/slack-cli/internal/config"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/internal/slackdeps"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -59,6 +59,7 @@ func Test_PrintDebug(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
+			ctx := slackcontext.MockContext(t.Context())
 			fsMock := slackdeps.NewFsMock()
 			osMock := slackdeps.NewOsMock()
 			osMock.AddDefaultMocks()
@@ -69,7 +70,6 @@ func Test_PrintDebug(t *testing.T) {
 			stdoutLogger := log.Logger{}
 			stdoutLogger.SetOutput(&stdoutBuffer)
 			io.Stdout = &stdoutLogger
-			ctx := context.Background()
 			io.PrintDebug(ctx, tt.format, tt.arguments...)
 
 			// Assert output lines match the pattern: [YYYY-MM-DD HH:MM:SS] line
@@ -127,6 +127,7 @@ func Test_PrintWarning(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
+			ctx := slackcontext.MockContext(t.Context())
 			fsMock := slackdeps.NewFsMock()
 			osMock := slackdeps.NewOsMock()
 			osMock.AddDefaultMocks()
@@ -136,7 +137,6 @@ func Test_PrintWarning(t *testing.T) {
 			stderrLogger := log.Logger{}
 			stderrLogger.SetOutput(&stderrBuffer)
 			io.Stderr = &stderrLogger
-			ctx := context.Background()
 			io.PrintWarning(ctx, tt.format, tt.arguments...)
 			assert.Equal(t, tt.expected, stderrBuffer.String())
 		})
@@ -185,13 +185,13 @@ func Test_IOStreams_PrintTrace(t *testing.T) {
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			// Setup
+			ctx := slackcontext.MockContext(t.Context())
 			var fsMock = slackdeps.NewFsMock()
 			var osMock = slackdeps.NewOsMock()
 
 			var config = config.NewConfig(fsMock, osMock)
 			config.SlackTestTraceFlag = tt.traceEnabled
 			var io = NewIOStreams(config, fsMock, osMock)
-			var ctx = context.Background()
 
 			var stdoutBuffer = bytes.Buffer{}
 			var stdoutLogger = log.Logger{}

--- a/internal/iostreams/survey_test.go
+++ b/internal/iostreams/survey_test.go
@@ -15,11 +15,11 @@
 package iostreams
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
 	"github.com/slackapi/slack-cli/internal/config"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/internal/slackdeps"
 	"github.com/slackapi/slack-cli/internal/slackerror"
 	"github.com/spf13/pflag"
@@ -74,7 +74,7 @@ func TestPasswordPrompt(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := slackcontext.MockContext(t.Context())
 			fsMock := slackdeps.NewFsMock()
 			osMock := slackdeps.NewOsMock()
 			if tt.IsInteractive {

--- a/internal/pkg/apps/delete_test.go
+++ b/internal/pkg/apps/delete_test.go
@@ -15,13 +15,13 @@
 package apps
 
 import (
-	"context"
 	"testing"
 
 	"github.com/slackapi/slack-cli/internal/api"
 	"github.com/slackapi/slack-cli/internal/logger"
 	"github.com/slackapi/slack-cli/internal/shared"
 	"github.com/slackapi/slack-cli/internal/shared/types"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -79,6 +79,7 @@ func TestAppsDelete(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
+			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := shared.NewClientsMock()
 			clientsMock.AuthInterface.On("ResolveApiHost", mock.Anything, mock.Anything, mock.Anything).Return("api host")
 			clientsMock.AuthInterface.On("ResolveLogstashHost", mock.Anything, mock.Anything, mock.Anything).Return("logstash host")
@@ -89,7 +90,6 @@ func TestAppsDelete(t *testing.T) {
 			clientsMock.ApiInterface.On("DeleteApp", mock.Anything, mock.Anything, tt.app.AppID).Return(nil)
 			clientsMock.AddDefaultMocks()
 
-			ctx := context.Background()
 			clients := shared.NewClientFactory(clientsMock.MockClientFactory())
 			if !tt.unsaved {
 				if !tt.app.IsDev {

--- a/internal/pkg/apps/install_test.go
+++ b/internal/pkg/apps/install_test.go
@@ -16,7 +16,6 @@ package apps
 
 import (
 	"bytes"
-	"context"
 	"testing"
 
 	"github.com/slackapi/slack-cli/internal/api"
@@ -27,6 +26,7 @@ import (
 	"github.com/slackapi/slack-cli/internal/logger"
 	"github.com/slackapi/slack-cli/internal/shared"
 	"github.com/slackapi/slack-cli/internal/shared/types"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/internal/slackerror"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -455,7 +455,7 @@ func TestInstall(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := shared.NewClientsMock()
 			clientsMock.IO.On("IsTTY").Return(tt.mockIsTTY)
 			clientsMock.AddDefaultMocks()
@@ -898,7 +898,7 @@ func TestInstallLocalApp(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := shared.NewClientsMock()
 			clientsMock.IO.On("IsTTY").Return(tt.mockIsTTY)
 			clientsMock.AddDefaultMocks()
@@ -1144,7 +1144,7 @@ func TestValidateManifestForInstall(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := shared.NewClientsMock()
 			tt.setup(clientsMock)
 			clientsMock.ApiInterface.On("ValidateAppManifest", mock.Anything, mock.Anything, mock.Anything, tt.app.AppID).
@@ -1217,6 +1217,7 @@ func TestSetAppEnvironmentTokens(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
+			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := shared.NewClientsMock()
 			clientsMock.IO.AddDefaultMocks()
 			if tt.envAppToken != "" {
@@ -1236,7 +1237,6 @@ func TestSetAppEnvironmentTokens(t *testing.T) {
 			clientsMock.IO.Stdout.SetOutput(output)
 
 			clients := shared.NewClientFactory(clientsMock.MockClientFactory())
-			ctx := context.Background()
 			err := setAppEnvironmentTokens(ctx, clients, tt.result)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expectedAppToken, clients.Os.Getenv("SLACK_APP_TOKEN"))

--- a/internal/pkg/auth/list_test.go
+++ b/internal/pkg/auth/list_test.go
@@ -15,7 +15,6 @@
 package auth
 
 import (
-	"context"
 	"errors"
 	"testing"
 	"time"
@@ -24,16 +23,17 @@ import (
 	"github.com/slackapi/slack-cli/internal/logger"
 	"github.com/slackapi/slack-cli/internal/shared"
 	"github.com/slackapi/slack-cli/internal/shared/types"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
 func TestAuthList(t *testing.T) {
+	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
 	clients := shared.NewClientFactory(clientsMock.MockClientFactory(), func(clients *shared.ClientFactory) {
 		clients.SDKConfig = hooks.NewSDKConfigMock()
 	})
-	ctx := context.Background()
 
 	authMockA := types.SlackAuth{
 		Token:               "xoxe.xoxp-",
@@ -58,11 +58,11 @@ func TestAuthList(t *testing.T) {
 }
 
 func TestAuthList_SortedAuths(t *testing.T) {
+	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
 	clients := shared.NewClientFactory(clientsMock.MockClientFactory(), func(clients *shared.ClientFactory) {
 		clients.SDKConfig = hooks.NewSDKConfigMock()
 	})
-	ctx := context.Background()
 
 	authZ := types.SlackAuth{
 		Token:       "xoxp-abc",

--- a/internal/pkg/create/create_test.go
+++ b/internal/pkg/create/create_test.go
@@ -15,7 +15,6 @@
 package create
 
 import (
-	"context"
 	"fmt"
 	"path/filepath"
 	"testing"
@@ -23,6 +22,7 @@ import (
 	"github.com/slackapi/slack-cli/internal/config"
 	"github.com/slackapi/slack-cli/internal/experiment"
 	"github.com/slackapi/slack-cli/internal/shared"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -220,17 +220,17 @@ func Test_Create_installProjectDependencies(t *testing.T) {
 			}()
 
 			// Setup parameters for test
-			ctx := context.Background()
 			projectDirPath := "/path/to/project-name"
 
 			// Create mocks
+			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := shared.NewClientsMock()
 			clientsMock.Os.On("Getwd").Return(projectDirPath, nil)
 			clientsMock.AddDefaultMocks()
 
 			// Set experiment flag
 			clientsMock.Config.ExperimentsFlag = append(clientsMock.Config.ExperimentsFlag, tt.experiments...)
-			clientsMock.Config.LoadExperiments(context.Background(), clientsMock.IO.PrintDebug)
+			clientsMock.Config.LoadExperiments(ctx, clientsMock.IO.PrintDebug)
 
 			// Create clients that is mocked for testing
 			clients := shared.NewClientFactory(clientsMock.MockClientFactory())

--- a/internal/pkg/datastore/bulk_delete_test.go
+++ b/internal/pkg/datastore/bulk_delete_test.go
@@ -15,12 +15,12 @@
 package datastore
 
 import (
-	"context"
 	"testing"
 
 	"github.com/slackapi/slack-cli/internal/logger"
 	"github.com/slackapi/slack-cli/internal/shared"
 	"github.com/slackapi/slack-cli/internal/shared/types"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -57,6 +57,7 @@ func TestDatastoreBulkDeleteArguments(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
+			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := shared.NewClientsMock()
 			log := logger.Logger{
 				Data: map[string]interface{}{},
@@ -65,7 +66,7 @@ func TestDatastoreBulkDeleteArguments(t *testing.T) {
 				Return(tt.Results, nil)
 			client := shared.NewClientFactory(clientsMock.MockClientFactory())
 
-			event, err := BulkDelete(context.Background(), client, &log, tt.Query)
+			event, err := BulkDelete(ctx, client, &log, tt.Query)
 			if assert.NoError(t, err) {
 				assert.Equal(t, tt.Results, event.Data["bulkDeleteResult"])
 			}

--- a/internal/pkg/datastore/bulk_get_test.go
+++ b/internal/pkg/datastore/bulk_get_test.go
@@ -15,12 +15,12 @@
 package datastore
 
 import (
-	"context"
 	"testing"
 
 	"github.com/slackapi/slack-cli/internal/logger"
 	"github.com/slackapi/slack-cli/internal/shared"
 	"github.com/slackapi/slack-cli/internal/shared/types"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -58,6 +58,7 @@ func TestDatastoreBulkGetArguments(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
+			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := shared.NewClientsMock()
 			log := logger.Logger{
 				Data: map[string]interface{}{},
@@ -66,7 +67,7 @@ func TestDatastoreBulkGetArguments(t *testing.T) {
 				Return(tt.Results, nil)
 			client := shared.NewClientFactory(clientsMock.MockClientFactory())
 
-			event, err := BulkGet(context.Background(), client, &log, tt.Query)
+			event, err := BulkGet(ctx, client, &log, tt.Query)
 			if assert.NoError(t, err) {
 				assert.Equal(t, tt.Results, event.Data["bulkGetResult"])
 			}

--- a/internal/pkg/datastore/bulk_put_test.go
+++ b/internal/pkg/datastore/bulk_put_test.go
@@ -15,12 +15,12 @@
 package datastore
 
 import (
-	"context"
 	"testing"
 
 	"github.com/slackapi/slack-cli/internal/logger"
 	"github.com/slackapi/slack-cli/internal/shared"
 	"github.com/slackapi/slack-cli/internal/shared/types"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -65,6 +65,7 @@ func TestDatastoreBulkPutArguments(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
+			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := shared.NewClientsMock()
 			log := logger.Logger{
 				Data: map[string]interface{}{},
@@ -73,7 +74,7 @@ func TestDatastoreBulkPutArguments(t *testing.T) {
 				Return(tt.Results, nil)
 			client := shared.NewClientFactory(clientsMock.MockClientFactory())
 
-			event, err := BulkPut(context.Background(), client, &log, tt.Query)
+			event, err := BulkPut(ctx, client, &log, tt.Query)
 			if assert.NoError(t, err) {
 				assert.Equal(t, tt.Results, event.Data["bulkPutResult"])
 			}

--- a/internal/pkg/datastore/delete_test.go
+++ b/internal/pkg/datastore/delete_test.go
@@ -15,12 +15,12 @@
 package datastore
 
 import (
-	"context"
 	"testing"
 
 	"github.com/slackapi/slack-cli/internal/logger"
 	"github.com/slackapi/slack-cli/internal/shared"
 	"github.com/slackapi/slack-cli/internal/shared/types"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -46,6 +46,7 @@ func TestDatastoreDeleteArguments(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
+			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := shared.NewClientsMock()
 			log := logger.Logger{
 				Data: map[string]interface{}{},
@@ -54,7 +55,7 @@ func TestDatastoreDeleteArguments(t *testing.T) {
 				Return(tt.Results, nil)
 			client := shared.NewClientFactory(clientsMock.MockClientFactory())
 
-			event, err := Delete(context.Background(), client, &log, tt.Query)
+			event, err := Delete(ctx, client, &log, tt.Query)
 			if assert.NoError(t, err) {
 				assert.Equal(t, tt.Results, event.Data["deleteResult"])
 			}

--- a/internal/pkg/datastore/get_test.go
+++ b/internal/pkg/datastore/get_test.go
@@ -15,12 +15,12 @@
 package datastore
 
 import (
-	"context"
 	"testing"
 
 	"github.com/slackapi/slack-cli/internal/logger"
 	"github.com/slackapi/slack-cli/internal/shared"
 	"github.com/slackapi/slack-cli/internal/shared/types"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -46,6 +46,7 @@ func TestDatastoreGetArguments(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
+			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := shared.NewClientsMock()
 			log := logger.Logger{
 				Data: map[string]interface{}{},
@@ -54,7 +55,7 @@ func TestDatastoreGetArguments(t *testing.T) {
 				Return(tt.Results, nil)
 			client := shared.NewClientFactory(clientsMock.MockClientFactory())
 
-			event, err := Get(context.Background(), client, &log, tt.Query)
+			event, err := Get(ctx, client, &log, tt.Query)
 			if assert.NoError(t, err) {
 				assert.Equal(t, tt.Results, event.Data["getResult"])
 			}

--- a/internal/pkg/datastore/put_test.go
+++ b/internal/pkg/datastore/put_test.go
@@ -15,12 +15,12 @@
 package datastore
 
 import (
-	"context"
 	"testing"
 
 	"github.com/slackapi/slack-cli/internal/logger"
 	"github.com/slackapi/slack-cli/internal/shared"
 	"github.com/slackapi/slack-cli/internal/shared/types"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -46,6 +46,7 @@ func TestDatastorePutArguments(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
+			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := shared.NewClientsMock()
 			log := logger.Logger{
 				Data: map[string]interface{}{},
@@ -54,7 +55,7 @@ func TestDatastorePutArguments(t *testing.T) {
 				Return(tt.Results, nil)
 			client := shared.NewClientFactory(clientsMock.MockClientFactory())
 
-			event, err := Put(context.Background(), client, &log, tt.Query)
+			event, err := Put(ctx, client, &log, tt.Query)
 			if assert.NoError(t, err) {
 				assert.Equal(t, tt.Results, event.Data["putResult"])
 			}

--- a/internal/pkg/datastore/query_test.go
+++ b/internal/pkg/datastore/query_test.go
@@ -15,12 +15,12 @@
 package datastore
 
 import (
-	"context"
 	"testing"
 
 	"github.com/slackapi/slack-cli/internal/logger"
 	"github.com/slackapi/slack-cli/internal/shared"
 	"github.com/slackapi/slack-cli/internal/shared/types"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -104,6 +104,7 @@ func TestDatastoreQueryArguments(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
+			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := shared.NewClientsMock()
 			log := logger.Logger{
 				Data: map[string]interface{}{},
@@ -112,7 +113,7 @@ func TestDatastoreQueryArguments(t *testing.T) {
 				Return(tt.Results, nil)
 			client := shared.NewClientFactory(clientsMock.MockClientFactory())
 
-			event, err := Query(context.Background(), client, &log, tt.Query)
+			event, err := Query(ctx, client, &log, tt.Query)
 			if assert.NoError(t, err) {
 				assert.Equal(t, tt.Results, event.Data["queryResult"])
 			}

--- a/internal/pkg/datastore/update_test.go
+++ b/internal/pkg/datastore/update_test.go
@@ -15,12 +15,12 @@
 package datastore
 
 import (
-	"context"
 	"testing"
 
 	"github.com/slackapi/slack-cli/internal/logger"
 	"github.com/slackapi/slack-cli/internal/shared"
 	"github.com/slackapi/slack-cli/internal/shared/types"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -46,6 +46,7 @@ func TestDatastoreUpdateArguments(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
+			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := shared.NewClientsMock()
 			log := logger.Logger{
 				Data: map[string]interface{}{},
@@ -54,7 +55,7 @@ func TestDatastoreUpdateArguments(t *testing.T) {
 				Return(tt.Results, nil)
 			client := shared.NewClientFactory(clientsMock.MockClientFactory())
 
-			event, err := Update(context.Background(), client, &log, tt.Query)
+			event, err := Update(ctx, client, &log, tt.Query)
 			if assert.NoError(t, err) {
 				assert.Equal(t, tt.Results, event.Data["updateResult"])
 			}

--- a/internal/pkg/externalauth/prompt_provider_auth_select_test.go
+++ b/internal/pkg/externalauth/prompt_provider_auth_select_test.go
@@ -15,23 +15,23 @@
 package externalauth
 
 import (
-	"context"
 	"testing"
 
 	"github.com/slackapi/slack-cli/internal/iostreams"
 	"github.com/slackapi/slack-cli/internal/shared"
 	"github.com/slackapi/slack-cli/internal/shared/types"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/internal/slackerror"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
 func TestPrompt_ProviderAuthSelectPrompt_empty_list(t *testing.T) {
+	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
 	clients := shared.NewClientFactory(clientsMock.MockClientFactory())
 	workflowsInfo := types.WorkflowsInfo{}
 	clientsMock.AddDefaultMocks()
-	ctx := context.Background()
 	selectedProvider, err := ProviderAuthSelectPrompt(ctx, clients, workflowsInfo)
 	require.Empty(t, selectedProvider)
 	require.Error(t, err, slackerror.New("No oauth2 providers found"))
@@ -84,6 +84,7 @@ func TestPrompt_ProviderAuthSelectPrompt_no_selected_auth(t *testing.T) {
 
 	for _, tt := range tests {
 		var mockProviderFlag string
+		ctx := slackcontext.MockContext(t.Context())
 		clientsMock := shared.NewClientsMock()
 		clients := shared.NewClientFactory(clientsMock.MockClientFactory())
 		clientsMock.Config.Flags.StringVar(&mockProviderFlag, "provider", "", "mock provider flag")
@@ -95,7 +96,6 @@ func TestPrompt_ProviderAuthSelectPrompt_no_selected_auth(t *testing.T) {
 		})).Return(tt.Selection, nil)
 
 		clientsMock.AddDefaultMocks()
-		ctx := context.Background()
 
 		selectedProvider, err := ProviderAuthSelectPrompt(ctx, clients, workflowsInfo)
 		require.Equal(t, selectedProvider.ProviderKey, "provider_a")
@@ -151,6 +151,7 @@ func TestPrompt_ProviderAuthSelectPrompt_with_selected_auth(t *testing.T) {
 
 	for _, tt := range tests {
 		var mockProviderFlag string
+		ctx := slackcontext.MockContext(t.Context())
 		clientsMock := shared.NewClientsMock()
 		clients := shared.NewClientFactory(clientsMock.MockClientFactory())
 		clientsMock.Config.Flags.StringVar(&mockProviderFlag, "provider", "", "mock provider flag")
@@ -158,7 +159,6 @@ func TestPrompt_ProviderAuthSelectPrompt_with_selected_auth(t *testing.T) {
 			Flag: clientsMock.Config.Flags.Lookup("provider"),
 		})).Return(tt.Selection, nil)
 		clientsMock.AddDefaultMocks()
-		ctx := context.Background()
 
 		selectedProvider, err := ProviderAuthSelectPrompt(ctx, clients, workflowsInfo)
 		require.Equal(t, selectedProvider.ProviderKey, "provider_b")

--- a/internal/pkg/externalauth/prompt_provider_select_test.go
+++ b/internal/pkg/externalauth/prompt_provider_select_test.go
@@ -15,23 +15,23 @@
 package externalauth
 
 import (
-	"context"
 	"testing"
 
 	"github.com/slackapi/slack-cli/internal/iostreams"
 	"github.com/slackapi/slack-cli/internal/shared"
 	"github.com/slackapi/slack-cli/internal/shared/types"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/internal/slackerror"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
 func TestPrompt_ProviderSelectPrompt_empty_list(t *testing.T) {
+	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
 	clients := shared.NewClientFactory(clientsMock.MockClientFactory())
 	authorizationInfoLists := types.ExternalAuthorizationInfoLists{}
 	clientsMock.AddDefaultMocks()
-	ctx := context.Background()
 	selectedProvider, err := ProviderSelectPrompt(ctx, clients, authorizationInfoLists)
 	require.Empty(t, selectedProvider)
 	require.Error(t, err, slackerror.New("No oauth2 providers found"))
@@ -74,6 +74,7 @@ func TestPrompt_ProviderSelectPrompt_no_token(t *testing.T) {
 
 	for _, tt := range tests {
 		var mockProviderFlag string
+		ctx := slackcontext.MockContext(t.Context())
 		clientsMock := shared.NewClientsMock()
 		clients := shared.NewClientFactory(clientsMock.MockClientFactory())
 		clientsMock.Config.Flags.StringVar(&mockProviderFlag, "provider", "", "mock provider flag")
@@ -81,7 +82,6 @@ func TestPrompt_ProviderSelectPrompt_no_token(t *testing.T) {
 			Flag: clientsMock.Config.Flags.Lookup("provider"),
 		})).Return(tt.Selection, nil)
 		clientsMock.AddDefaultMocks()
-		ctx := context.Background()
 
 		selectedProvider, err := ProviderSelectPrompt(ctx, clients, authorizationInfoLists)
 		require.Equal(t, selectedProvider.ProviderKey, "provider_a")
@@ -136,6 +136,7 @@ func TestPrompt_ProviderSelectPrompt_with_token(t *testing.T) {
 
 	for _, tt := range tests {
 		var mockProviderFlag string
+		ctx := slackcontext.MockContext(t.Context())
 		clientsMock := shared.NewClientsMock()
 		clients := shared.NewClientFactory(clientsMock.MockClientFactory())
 		clientsMock.Config.Flags.StringVar(&mockProviderFlag, "provider", "", "mock provider flag")
@@ -146,7 +147,6 @@ func TestPrompt_ProviderSelectPrompt_with_token(t *testing.T) {
 			Flag: clientsMock.Config.Flags.Lookup("provider"),
 		})).Return(tt.Selection, nil)
 		clientsMock.AddDefaultMocks()
-		ctx := context.Background()
 
 		selectedProvider, err := ProviderSelectPrompt(ctx, clients, authorizationInfoLists)
 		require.Equal(t, selectedProvider.ProviderKey, "provider_a")

--- a/internal/pkg/externalauth/prompt_token_select_test.go
+++ b/internal/pkg/externalauth/prompt_token_select_test.go
@@ -15,23 +15,23 @@
 package externalauth
 
 import (
-	"context"
 	"testing"
 
 	"github.com/slackapi/slack-cli/internal/iostreams"
 	"github.com/slackapi/slack-cli/internal/shared"
 	"github.com/slackapi/slack-cli/internal/shared/types"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/internal/slackerror"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
 func TestPrompt_TokenSelectPrompt_empty_list(t *testing.T) {
+	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
 	clients := shared.NewClientFactory(clientsMock.MockClientFactory())
 	authorizationInfo := types.ExternalAuthorizationInfo{}
 	clientsMock.AddDefaultMocks()
-	ctx := context.Background()
 
 	selectedToken, err := TokenSelectPrompt(ctx, clients, authorizationInfo)
 	require.Empty(t, selectedToken)
@@ -83,6 +83,7 @@ func TestPrompt_TokenSelectPrompt_with_token(t *testing.T) {
 
 	var externalAccountFlag string
 	for _, tt := range tests {
+		ctx := slackcontext.MockContext(t.Context())
 		clientsMock := shared.NewClientsMock()
 		clients := shared.NewClientFactory(clientsMock.MockClientFactory())
 		clientsMock.Config.Flags.StringVar(&externalAccountFlag, "external-account", "", "mock external-account flag")
@@ -93,7 +94,6 @@ func TestPrompt_TokenSelectPrompt_with_token(t *testing.T) {
 			Flag: clientsMock.Config.Flags.Lookup("external-account"),
 		})).Return(tt.Selection, nil)
 		clientsMock.AddDefaultMocks()
-		ctx := context.Background()
 
 		selectedToken, err := TokenSelectPrompt(ctx, clients, authorizationInfo)
 		require.NoError(t, err)

--- a/internal/pkg/externalauth/prompt_workflow_select_test.go
+++ b/internal/pkg/externalauth/prompt_workflow_select_test.go
@@ -15,12 +15,12 @@
 package externalauth
 
 import (
-	"context"
 	"testing"
 
 	"github.com/slackapi/slack-cli/internal/iostreams"
 	"github.com/slackapi/slack-cli/internal/shared"
 	"github.com/slackapi/slack-cli/internal/shared/types"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/internal/slackerror"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -29,13 +29,13 @@ import (
 func TestPrompt_WorkflowSelectPrompt_empty_list(t *testing.T) {
 	authorizationInfoLists := types.ExternalAuthorizationInfoLists{}
 
+	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
 	clients := shared.NewClientFactory(clientsMock.MockClientFactory())
 	clientsMock.IO.On("SelectPrompt", mock.Anything, "Select a workflow", mock.Anything, iostreams.MatchPromptConfig(iostreams.SelectPromptConfig{
 		Flag: clientsMock.Config.Flags.Lookup("workflow"),
 	})).Return(iostreams.SelectPromptResponse{}, slackerror.New(slackerror.ErrMissingOptions))
 	clientsMock.AddDefaultMocks()
-	ctx := context.Background()
 
 	selectedWorkflow, err := WorkflowSelectPrompt(ctx, clients, authorizationInfoLists)
 	require.Empty(t, selectedWorkflow)
@@ -55,13 +55,13 @@ func TestPrompt_WorkflowSelectPrompt_with_no_workflows(t *testing.T) {
 			},
 		}}
 
+	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
 	clients := shared.NewClientFactory(clientsMock.MockClientFactory())
 	clientsMock.IO.On("SelectPrompt", mock.Anything, "Select a workflow", mock.Anything, iostreams.MatchPromptConfig(iostreams.SelectPromptConfig{
 		Flag: clients.Config.Flags.Lookup("workflow"),
 	})).Return(iostreams.SelectPromptResponse{}, slackerror.New(slackerror.ErrMissingOptions))
 	clientsMock.AddDefaultMocks()
-	ctx := context.Background()
 
 	selectedWorkflow, err := WorkflowSelectPrompt(ctx, clients, authorizationInfoLists)
 	require.Empty(t, selectedWorkflow)
@@ -144,6 +144,7 @@ func TestPrompt_WorkflowSelectPrompt_with_workflows(t *testing.T) {
 
 	for _, tt := range tests {
 		var mockWorkflowFlag string
+		ctx := slackcontext.MockContext(t.Context())
 		clientsMock := shared.NewClientsMock()
 		clients := shared.NewClientFactory(clientsMock.MockClientFactory())
 		clientsMock.Config.Flags.StringVar(&mockWorkflowFlag, "workflow", "", "mock workflow flag")
@@ -154,7 +155,6 @@ func TestPrompt_WorkflowSelectPrompt_with_workflows(t *testing.T) {
 			Flag: clientsMock.Config.Flags.Lookup("workflow"),
 		})).Return(tt.Selection, nil)
 		clientsMock.AddDefaultMocks()
-		ctx := context.Background()
 
 		selectedWorkflow, err := WorkflowSelectPrompt(ctx, clients, authorizationInfoLists)
 		require.NoError(t, err)

--- a/internal/pkg/platform/activity_test.go
+++ b/internal/pkg/platform/activity_test.go
@@ -156,7 +156,7 @@ func TestPlatformActivity_StreamingLogs(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			// Create mocks
-			ctxMock := slackcontext.MockContext(context.Background())
+			ctxMock := slackcontext.MockContext(t.Context())
 			ctxMock = context.WithValue(ctxMock, config.CONTEXT_TOKEN, "sometoken")
 			clientsMock := shared.NewClientsMock()
 			// Create clients that is mocked for testing

--- a/internal/pkg/platform/localserver_test.go
+++ b/internal/pkg/platform/localserver_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/slackapi/slack-cli/internal/hooks"
 	"github.com/slackapi/slack-cli/internal/logger"
 	"github.com/slackapi/slack-cli/internal/shared"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/internal/slackerror"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -118,8 +119,8 @@ func Test_LocalServer_Start(t *testing.T) {
 				defer ts.Close()
 				wsFakeURL = "ws" + strings.TrimPrefix(ts.URL, "http")
 			}
-			ctx := context.Background()
 			// Create mocks
+			ctx := slackcontext.MockContext(t.Context())
 			conn := NewWebSocketConnMock()
 			clientsMock := shared.NewClientsMock()
 			// Create clients that is mocked for testing
@@ -330,8 +331,8 @@ func Test_LocalServer_Listen(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			ctx := context.Background()
 			// Create mocks
+			ctx := slackcontext.MockContext(t.Context())
 			conn := NewWebSocketConnMock()
 			clientsMock := shared.NewClientsMock()
 			// Create clients that is mocked for testing

--- a/internal/runtime/deno/deno_test.go
+++ b/internal/runtime/deno/deno_test.go
@@ -15,7 +15,6 @@
 package deno
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"os/exec"
@@ -26,6 +25,7 @@ import (
 	"github.com/slackapi/slack-cli/internal/hooks"
 	"github.com/slackapi/slack-cli/internal/iostreams"
 	"github.com/slackapi/slack-cli/internal/shared/types"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/internal/slackdeps"
 	"github.com/slackapi/slack-cli/internal/slackerror"
 	"github.com/spf13/afero"
@@ -134,7 +134,7 @@ func Test_Deno_InstallProjectDependencies(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Setup
-			ctx := context.Background()
+			ctx := slackcontext.MockContext(t.Context())
 			projectDirPath := "/path/to/project-name"
 
 			fs := slackdeps.NewFsMock()
@@ -347,7 +347,7 @@ func Test_Deno_IsRuntimeForProject(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Setup
-			ctx := context.Background()
+			ctx := slackcontext.MockContext(t.Context())
 			fs := slackdeps.NewFsMock()
 			projectDirPath := "/path/to/project-name"
 

--- a/internal/runtime/node/node_test.go
+++ b/internal/runtime/node/node_test.go
@@ -15,7 +15,6 @@
 package node
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -26,6 +25,7 @@ import (
 	"github.com/slackapi/slack-cli/internal/hooks"
 	"github.com/slackapi/slack-cli/internal/iostreams"
 	"github.com/slackapi/slack-cli/internal/shared/types"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/internal/slackdeps"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/mock"
@@ -191,7 +191,7 @@ func Test_Node_InstallProjectDependencies(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Setup
-			ctx := context.Background()
+			ctx := slackcontext.MockContext(t.Context())
 			projectDirPath := "/path/to/project-name"
 
 			fs := slackdeps.NewFsMock()
@@ -347,7 +347,7 @@ func Test_Node_IsRuntimeForProject(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Setup
-			ctx := context.Background()
+			ctx := slackcontext.MockContext(t.Context())
 			fs := slackdeps.NewFsMock()
 			projectDirPath := "/path/to/project-name"
 

--- a/internal/runtime/node/npm_test.go
+++ b/internal/runtime/node/npm_test.go
@@ -15,7 +15,6 @@
 package node
 
 import (
-	"context"
 	"errors"
 	"strings"
 	"testing"
@@ -23,6 +22,7 @@ import (
 	"github.com/slackapi/slack-cli/internal/config"
 	"github.com/slackapi/slack-cli/internal/hooks"
 	"github.com/slackapi/slack-cli/internal/iostreams"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/internal/slackdeps"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -62,7 +62,7 @@ func Test_NPMClient_InstallAllPackages(t *testing.T) {
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			// Setup
-			ctx := context.Background()
+			ctx := slackcontext.MockContext(t.Context())
 			projectDirPath := "/path/to/project-name"
 
 			fs := slackdeps.NewFsMock()
@@ -129,7 +129,7 @@ func Test_NPMClient_InstallDevPackage(t *testing.T) {
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			// Setup
-			ctx := context.Background()
+			ctx := slackcontext.MockContext(t.Context())
 			projectDirPath := "/path/to/project-name"
 
 			fs := slackdeps.NewFsMock()
@@ -203,7 +203,7 @@ func Test_NPMClient_ListPackage(t *testing.T) {
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			// Setup
-			ctx := context.Background()
+			ctx := slackcontext.MockContext(t.Context())
 			projectDirPath := "/path/to/project-name"
 
 			fs := slackdeps.NewFsMock()

--- a/internal/runtime/python/python_test.go
+++ b/internal/runtime/python/python_test.go
@@ -15,7 +15,6 @@
 package python
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"path/filepath"
@@ -25,6 +24,7 @@ import (
 	"github.com/slackapi/slack-cli/internal/hooks"
 	"github.com/slackapi/slack-cli/internal/iostreams"
 	"github.com/slackapi/slack-cli/internal/shared/types"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/internal/slackdeps"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/mock"
@@ -170,8 +170,7 @@ func Test_Python_InstallProjectDependencies(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Setup
-			ctx := context.Background()
-
+			ctx := slackcontext.MockContext(t.Context())
 			fs := slackdeps.NewFsMock()
 			os := slackdeps.NewOsMock()
 			os.AddDefaultMocks()
@@ -350,7 +349,7 @@ func Test_Python_IsRuntimeForProject(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Setup
-			ctx := context.Background()
+			ctx := slackcontext.MockContext(t.Context())
 			fs := slackdeps.NewFsMock()
 			projectDirPath := "/path/to/project-name"
 

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -15,13 +15,13 @@
 package runtime
 
 import (
-	"context"
 	"testing"
 
 	"github.com/slackapi/slack-cli/internal/hooks"
 	"github.com/slackapi/slack-cli/internal/runtime/deno"
 	"github.com/slackapi/slack-cli/internal/runtime/node"
 	"github.com/slackapi/slack-cli/internal/runtime/python"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
 )
@@ -92,7 +92,7 @@ func Test_Runtime_NewDetectProject(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			// Setup
-			ctx := context.Background()
+			ctx := slackcontext.MockContext(t.Context())
 			fs := afero.NewMemMapFs()
 			projectDirPath := "/path/to/project-name"
 

--- a/internal/slackcontext/slackcontext_test.go
+++ b/internal/slackcontext/slackcontext_test.go
@@ -41,7 +41,7 @@ func Test_SlackContext_OpenTracingSpan(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			ctx = opentracing.ContextWithSpan(ctx, tt.expectedSpan)
 			actualSpan, actualError := OpenTracingSpan(ctx)
 			require.Equal(t, tt.expectedSpan, actualSpan)
@@ -60,7 +60,7 @@ func Test_SlackContext_SetOpenTracingSpan(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			ctx = SetOpenTracingSpan(ctx, tt.expectedSpan)
 			actualSpan := opentracing.SpanFromContext(ctx)
 			require.Equal(t, tt.expectedSpan, actualSpan)
@@ -84,7 +84,7 @@ func Test_SlackContext_OpenTracingTraceID(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			ctx = context.WithValue(ctx, contextKeyOpenTracingTraceID, tt.expectedTraceID)
 			actualTraceID, actualError := OpenTracingTraceID(ctx)
 			require.Equal(t, tt.expectedTraceID, actualTraceID)
@@ -103,7 +103,7 @@ func Test_SlackContext_SetOpenTracingTraceID(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			ctx = SetOpenTracingTraceID(ctx, tt.expectedTraceID)
 			actualTraceID := ctx.Value(contextKeyOpenTracingTraceID).(string)
 			require.Equal(t, tt.expectedTraceID, actualTraceID)
@@ -129,7 +129,7 @@ func Test_SlackContext_OpenTracingTracer(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			ctx = context.WithValue(ctx, contextKeyOpenTracingTracer, tt.expectedTracer)
 			actualTracer, actualError := OpenTracingTracer(ctx)
 			require.Equal(t, tt.expectedTracer, actualTracer)
@@ -150,7 +150,7 @@ func Test_SlackContext_SetOpenTracingTracer(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			ctx = SetOpenTracingTracer(ctx, tt.expectedTracer)
 			actualTracer := ctx.Value(contextKeyOpenTracingTracer).(opentracing.Tracer)
 			require.Equal(t, tt.expectedTracer, actualTracer)
@@ -174,7 +174,7 @@ func Test_SlackContext_ProjectID(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			ctx = context.WithValue(ctx, contextKeyProjectID, tt.expectedProjectID)
 			actualProjectID, actualError := ProjectID(ctx)
 			require.Equal(t, tt.expectedProjectID, actualProjectID)
@@ -193,7 +193,7 @@ func Test_SlackContext_SetProjectID(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			ctx = SetProjectID(ctx, tt.expectedProjectID)
 			actualProjectID := ctx.Value(contextKeyProjectID).(string)
 			require.Equal(t, tt.expectedProjectID, actualProjectID)
@@ -217,7 +217,7 @@ func Test_SlackContext_SessionID(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			ctx = context.WithValue(ctx, contextKeySessionID, tt.expectedSessionID)
 			actualSessionID, actualError := SessionID(ctx)
 			require.Equal(t, tt.expectedSessionID, actualSessionID)
@@ -236,7 +236,7 @@ func Test_SlackContext_SetSessionID(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			ctx = SetSessionID(ctx, tt.expectedSessionID)
 			actualSessionID := ctx.Value(contextKeySessionID).(string)
 			require.Equal(t, tt.expectedSessionID, actualSessionID)
@@ -260,7 +260,7 @@ func Test_SlackContext_SystemID(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			ctx = context.WithValue(ctx, contextKeySystemID, tt.expectedSystemID)
 			actualSystemID, actualError := SystemID(ctx)
 			require.Equal(t, tt.expectedSystemID, actualSystemID)
@@ -279,7 +279,7 @@ func Test_SlackContext_SetSystemID(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			ctx = SetSystemID(ctx, tt.expectedSystemID)
 			actualSystemID := ctx.Value(contextKeySystemID).(string)
 			require.Equal(t, tt.expectedSystemID, actualSystemID)
@@ -303,7 +303,7 @@ func Test_SlackContext_Version(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			ctx = context.WithValue(ctx, contextKeyVersion, tt.expectedVersion)
 			actualVersion, actualError := Version(ctx)
 			require.Equal(t, tt.expectedVersion, actualVersion)
@@ -322,7 +322,7 @@ func Test_SlackContext_SetVersion(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			ctx := context.Background()
+			ctx := t.Context()
 			ctx = SetVersion(ctx, tt.expectedVersion)
 			actualVersion := ctx.Value(contextKeyVersion).(string)
 			require.Equal(t, tt.expectedVersion, actualVersion)

--- a/internal/slackerror/errors.go
+++ b/internal/slackerror/errors.go
@@ -812,13 +812,9 @@ Otherwise start your app for local development with: %s`,
 	},
 
 	ErrInvalidAppDirectory: {
-		Code:    ErrInvalidAppDirectory,
-		Message: "This is an invalid Slack app project directory",
-		Remediation: strings.Join([]string{
-			fmt.Sprintf("A valid Slack project includes the Slack hooks file: %s", filepath.Join(".slack", "hooks.json")),
-			"",
-			"If this is a Slack project, you can initialize it with " + style.Commandf("init", false),
-		}, "\n"),
+		Code:        ErrInvalidAppDirectory,
+		Message:     "This is an invalid Slack app project directory",
+		Remediation: fmt.Sprintf("A valid Slack project includes the Slack hooks file: %s", filepath.Join(".slack", "hooks.json")),
 	},
 
 	ErrInvalidAppFlag: {
@@ -1302,16 +1298,12 @@ Otherwise start your app for local development with: %s`,
 		Code:    ErrSDKHookNotFound,
 		Message: fmt.Sprintf("A script in %s was not found", style.Highlight(filepath.Join(".slack", "hooks.json"))),
 		Remediation: strings.Join([]string{
-			"Hook scripts are defined in one of these Slack hooks files:",
-			"- slack.json",
-			"- " + filepath.Join(".slack", "hooks.json"),
+			fmt.Sprintf("Hook scripts are defined in the Slack hooks file ('%s').", filepath.Join(".slack", "hooks.json")),
+			"Every app requires a Slack hooks file and you can find a working example at:",
 			"",
-			"Every app requires a Slack hooks file and you can find an example at:",
-			style.Highlight("https://github.com/slack-samples/deno-starter-template/blob/main/slack.json"),
+			style.Highlight("https://github.com/slack-samples/deno-starter-template/blob/main/.slack/hooks.json"),
 			"",
-			"You can create a hooks file manually or with the " + style.Commandf("init", false) + " command.",
-			"",
-			"When manually creating the hooks file, you must install the hook dependencies.",
+			"After creating the hooks file, you must install related hook dependencies.",
 		}, "\n"),
 	},
 

--- a/internal/slackerror/errors.go
+++ b/internal/slackerror/errors.go
@@ -812,9 +812,13 @@ Otherwise start your app for local development with: %s`,
 	},
 
 	ErrInvalidAppDirectory: {
-		Code:        ErrInvalidAppDirectory,
-		Message:     "This is an invalid Slack app project directory",
-		Remediation: fmt.Sprintf("A valid Slack project includes the Slack hooks file: %s", filepath.Join(".slack", "hooks.json")),
+		Code:    ErrInvalidAppDirectory,
+		Message: "This is an invalid Slack app project directory",
+		Remediation: strings.Join([]string{
+			fmt.Sprintf("A valid Slack project includes the Slack hooks file: %s", filepath.Join(".slack", "hooks.json")),
+			"",
+			"If this is a Slack project, you can initialize it with " + style.Commandf("init", false),
+		}, "\n"),
 	},
 
 	ErrInvalidAppFlag: {
@@ -1298,12 +1302,16 @@ Otherwise start your app for local development with: %s`,
 		Code:    ErrSDKHookNotFound,
 		Message: fmt.Sprintf("A script in %s was not found", style.Highlight(filepath.Join(".slack", "hooks.json"))),
 		Remediation: strings.Join([]string{
-			fmt.Sprintf("Hook scripts are defined in the Slack hooks file ('%s').", filepath.Join(".slack", "hooks.json")),
-			"Every app requires a Slack hooks file and you can find a working example at:",
+			"Hook scripts are defined in one of these Slack hooks files:",
+			"- slack.json",
+			"- " + filepath.Join(".slack", "hooks.json"),
 			"",
-			style.Highlight("https://github.com/slack-samples/deno-starter-template/blob/main/.slack/hooks.json"),
+			"Every app requires a Slack hooks file and you can find an example at:",
+			style.Highlight("https://github.com/slack-samples/deno-starter-template/blob/main/slack.json"),
 			"",
-			"After creating the hooks file, you must install related hook dependencies.",
+			"You can create a hooks file manually or with the " + style.Commandf("init", false) + " command.",
+			"",
+			"When manually creating the hooks file, you must install the hook dependencies.",
 		}, "\n"),
 	},
 

--- a/internal/update/cli_metadata_test.go
+++ b/internal/update/cli_metadata_test.go
@@ -15,13 +15,13 @@
 package update
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
@@ -70,6 +70,8 @@ func Test_CLI_Metadata_CheckForUpdate(t *testing.T) {
 
 	for name, s := range scenarios {
 		t.Run(name, func(t *testing.T) {
+			ctx := slackcontext.MockContext(t.Context())
+
 			// Mock an http.Response for the GitHub API
 			w := httptest.NewRecorder()
 			_, _ = io.WriteString(w, fmt.Sprintf(
@@ -84,7 +86,7 @@ func Test_CLI_Metadata_CheckForUpdate(t *testing.T) {
 
 			// Check for an update
 			md := Metadata{httpClient: httpClientMock}
-			releaseInfo, err := md.CheckForUpdate(context.Background(), metaDataUrl, s.CurrentVersion)
+			releaseInfo, err := md.CheckForUpdate(ctx, metaDataUrl, s.CurrentVersion)
 
 			// Assert expected results
 			if s.ExpectsResult {


### PR DESCRIPTION
### Summary

This pull request is part of the series that updates our tests to use `slackcontext.MockContext(...)` instead of `context.Background()`.

The motivation is to continue to have consistent and reliable unit tests. Right now, many of our test use empty context such as `context.Background()`, which can cause unexpected errors if a function brings to use values from the context. Now that we can mock "guaranteed" context values, this PR combs through to replace `.Background()` references.

_You might want a fresh cup of coffee ☕ to sip while scrolling through this one!_

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).