### PR TITLE
docs: update Slack CLI and Install Scripts to use the new https://slack.dev docs

### DIFF
--- a/.github/MAINTAINERS_GUIDE.md
+++ b/.github/MAINTAINERS_GUIDE.md
@@ -766,7 +766,7 @@ Steps to merge a pull request:
 When in doubt, find the other maintainers and ask.
 
 [circleci]: ../.circleci/config.yml
-[commands]: https://api.slack.com/automation/cli/commands
+[commands]: https://tools.slack.dev/slack-cli/reference/commands/slack
 [commit]: https://www.conventionalcommits.org/en/v1.0.0/
 [contributing]: ./CONTRIBUTING.md
 [dev-release]: https://github.com/slackapi/slack-cli/releases/tag/dev-build

--- a/.github/cli-sdk-specification.md
+++ b/.github/cli-sdk-specification.md
@@ -141,7 +141,7 @@ Implementing this hook signals to the CLI that the SDK manages the [application 
 
 #### Output
 
-The [application manifest](https://api.slack.com/concepts/manifests#fields) in JSON format to `STDOUT`.
+The [app manifest](https://docs.slack.dev/reference/app-manifest) in JSON format to `STDOUT`.
 
 #### Support
 | Deno | Bolt JS | Bolt Python | Bolt Java |

--- a/.github/cli-sdk-specification.md
+++ b/.github/cli-sdk-specification.md
@@ -137,7 +137,7 @@ This hook should return the CLI-SDK interface in [JSON](#interface-format) forma
 
 This hook allows for the application under development to be created on `api.slack.com/apps` as well as installed to workspaces that the CLI has been authorized to.
 
-Implementing this hook signals to the CLI that the SDK manages the [application manifest](https://api.slack.com/concepts/manifests#fields). Even if this hook is not present, the CLI should fall back to checking if a `manifest.json` or `manifest.yaml` exists in the project directory and read that file directly.
+Implementing this hook signals to the CLI that the SDK manages the [application manifest](https://docs.slack.dev/app-manifests/). Even if this hook is not present, the CLI should fall back to checking if a `manifest.json` or `manifest.yaml` exists in the project directory and read that file directly.
 
 #### Output
 
@@ -207,7 +207,7 @@ Several parameters are passed to the SDK over `STDIN` as JSON. The format of thi
 
 | Field       | Description | Required |
 | ------- | ----------- | -------- |
-| body | Object whose keys represent the incoming Slack event payload as described in [Events API Event Types](https://api.slack.com/events?filter=Events). The particular content of this key is dependent on the incoming event type. | Yes |
+| body | Object whose keys represent the incoming Slack event payload as described in [Events API Event Types](https://docs.slack.dev/reference/events?APIs=Events). The particular content of this key is dependent on the incoming event type. | Yes |
 | context | Object representing variables relevant for the locally-running application. | Yes |
 | context.bot_access_token | String; a bot access token that the SDK can provide to developer functions for issuing calls to the Slack API. | Yes |
 | context.app_id | String; the current application ID. | Yes |

--- a/.github/cli-sdk-specification.md
+++ b/.github/cli-sdk-specification.md
@@ -233,7 +233,7 @@ Implementing the `start` hook with `config.sdk-managed-connection-enabled` set t
 
 ##### Input
 
-The application's app-level token and bot access token will be provided as environment variables to the hook process (`SLACK_CLI_XAPP` and `SLACK_CLI_XOXB` respectively, as well as `SLACK_APP_TOKEN` and `SLACK_BOT_TOKEN`). The SDK should use the app token to [create a socket connection](https://api.slack.com/apis/socket-mode#call) with the Slack backend on behalf of the app. Additionally, the SDK may use the provided bot token to facilitate API calls to the Slack API.
+The application's app-level token and bot access token will be provided as environment variables to the hook process (`SLACK_CLI_XAPP` and `SLACK_CLI_XOXB` respectively, as well as `SLACK_APP_TOKEN` and `SLACK_BOT_TOKEN`). The SDK should use the app token to [create a socket connection](https://docs.slack.dev/apis/events-api/using-socket-mode/#call) with the Slack backend on behalf of the app. Additionally, the SDK may use the provided bot token to facilitate API calls to the Slack API.
 
 All Bolt SDKs leverage this `start` hook operating mode.
 

--- a/.github/cli-sdk-specification.md
+++ b/.github/cli-sdk-specification.md
@@ -229,7 +229,7 @@ Each incoming event from the socket connection will invoke this hook separately.
 
 This section applies when `config.sdk-managed-connection-enabled` is set to `true` in `hooks.json` or in the [`get-hooks`](#get-hooks) hook response.
 
-Implementing the `start` hook with `config.sdk-managed-connection-enabled` set to `true` will instruct the CLI to delegate connection management to the hook implementation as defined in our [Implementing Socket Mode documentation](https://api.slack.com/apis/socket-mode#implementing). Because establishing a network connection and handling incoming events is assumed to be a long-running process, invoking this hook will block the CLI process.
+Implementing the `start` hook with `config.sdk-managed-connection-enabled` set to `true` will instruct the CLI to delegate connection management to the hook implementation as defined in our [Implementing Socket Mode documentation](https://docs.slack.dev/apis/events-api/using-socket-mode/#implementing). Because establishing a network connection and handling incoming events is assumed to be a long-running process, invoking this hook will block the CLI process.
 
 ##### Input
 

--- a/.github/cli-sdk-specification.md
+++ b/.github/cli-sdk-specification.md
@@ -184,7 +184,7 @@ The `slack run` CLI command will invoke the `start` hook to initiate a local-run
 
 This section applies when `config.sdk-managed-connection-enabled` is undefined or set to `false` in `hooks.json` or in the [`get-hooks`](#get-hooks) hook response.
 
-When the app developer wants to initiate a development-mode local run of their application via the `slack run` CLI command, by default the CLI will create a [Socket Mode](https://api.slack.com/apis/socket-mode) connection to the Slack backend and start listening for events on behalf of the app.
+When the app developer wants to initiate a development-mode local run of their application via the `slack run` CLI command, by default the CLI will create a [Socket Mode](https://docs.slack.dev/apis/events-api/using-socket-mode/) connection to the Slack backend and start listening for events on behalf of the app.
 
 Any events coming down the wire from Slack will be fed over `STDIN` to this hook for the SDK to process. *Each event incoming from Slack will invoke this hook independently*, meaning one `start` hook process will be spawned per incoming event. The SDK should process each incoming event and output a JSON object to `STDOUT` representing the response to send back to Slack over the socket connection managed by the CLI.
 

--- a/.github/cli-sdk-specification.md
+++ b/.github/cli-sdk-specification.md
@@ -178,7 +178,7 @@ No further output over STDOUT required from the SDK other than writing the appli
 
 ### 🪝 `start` (optional)
 
-The `slack run` CLI command will invoke the `start` hook to initiate a local-run development mode allowing for quick iteration during app development. This hook is responsible for actually running the app, but has two operating modes: one where the hook manages the connection to Slack via [Socket Mode](https://api.slack.com/apis/socket-mode), and one where it does not. Which mode should be employed by the CLI when invoking this hook is dictated by the `config.sdk-managed-connection-enabled` property in the response from [`get-hooks`](#get-hooks).
+The `slack run` CLI command will invoke the `start` hook to initiate a local-run development mode allowing for quick iteration during app development. This hook is responsible for actually running the app, but has two operating modes: one where the hook manages the connection to Slack via [Socket Mode](https://docs.slack.dev/apis/events-api/using-socket-mode/), and one where it does not. Which mode should be employed by the CLI when invoking this hook is dictated by the `config.sdk-managed-connection-enabled` property in the response from [`get-hooks`](#get-hooks).
 
 #### Non-SDK-managed connection
 

--- a/.github/cli-sdk-specification.md
+++ b/.github/cli-sdk-specification.md
@@ -218,7 +218,7 @@ Note: The CLI always provides the `SLACK_APP_TOKEN` and `SLACK_BOT_TOKEN` enviro
 
 ##### Output
 
-Each incoming event from the socket connection will invoke this hook separately. As such, this hook's response to `STDOUT` should be the JSON response to the Slack event sent to the app. The CLI will handle [acknowledging events](https://api.slack.com/apis/socket-mode#acknowledge) by sending back the proper `envelope_id` attribute to the Slack backend. Therefore, the SDK’s `start` hook response `STDOUT` should be the `payload` of the response and nothing else. It is recommended to use the `v2` (`message-boundaries`) [protocol](#protocol) to more easily delineate logging/diagnostics from event responses to be sent to Slack.
+Each incoming event from the socket connection will invoke this hook separately. As such, this hook's response to `STDOUT` should be the JSON response to the Slack event sent to the app. The CLI will handle [acknowledging events](https://docs.slack.dev/apis/events-api/using-socket-mode/#acknowledge) by sending back the proper `envelope_id` attribute to the Slack backend. Therefore, the SDK’s `start` hook response `STDOUT` should be the `payload` of the response and nothing else. It is recommended to use the `v2` (`message-boundaries`) [protocol](#protocol) to more easily delineate logging/diagnostics from event responses to be sent to Slack.
 
 ##### Support
 | Deno | Bolt JS | Bolt Python | Bolt Java |

--- a/cmd/datastore/datastore.go
+++ b/cmd/datastore/datastore.go
@@ -53,7 +53,7 @@ func NewCommand(clients *shared.ClientFactory) *cobra.Command {
 			"This command is supported for apps deployed to Slack managed infrastructure but",
 			"other apps can attempt to run the command with the --force flag.",
 			"",
-			`Discover the datastores: {{LinkText "https://api.slack.com/automation/datastores"}}`,
+			`Discover the datastores: {{LinkText "https://tools.slack.dev/deno-slack-sdk/guides/using-datastores"}}`,
 		}, "\n"),
 		Example: style.ExampleCommandsf([]style.ExampleCommand{
 			{

--- a/cmd/env/env.go
+++ b/cmd/env/env.go
@@ -42,7 +42,7 @@ func NewCommand(clients *shared.ClientFactory) *cobra.Command {
 			"This command is supported for apps deployed to Slack managed infrastructure but",
 			"other apps can attempt to run the command with the --force flag.",
 			"",
-			`Explore more: {{LinkText "https://api.slack.com/automation/environment-variables"}}`,
+			`Explore more: {{LinkText "https://tools.slack.dev/slack-cli/guides/using-environment-variables-with-the-slack-cli"}}`,
 		}, "\n"),
 		Example: style.ExampleCommandsf([]style.ExampleCommand{
 			{

--- a/cmd/externalauth/externalauth.go
+++ b/cmd/externalauth/externalauth.go
@@ -39,7 +39,7 @@ func NewCommand(clients *shared.ClientFactory) *cobra.Command {
 			"This command is supported for apps deployed to Slack managed infrastructure but",
 			"other apps can attempt to run the command with the --force flag.",
 			"",
-			`Explore providers: {{LinkText "https://api.slack.com/automation/external-auth"}}`,
+			`Explore providers: {{LinkText "https://tools.slack.dev/deno-slack-sdk/guides/integrating-with-services-requiring-external-authentication"}}`,
 		}, "\n"),
 		Example: style.ExampleCommandsf([]style.ExampleCommand{
 			{

--- a/cmd/function/function.go
+++ b/cmd/function/function.go
@@ -40,7 +40,7 @@ func NewCommand(clients *shared.ClientFactory) *cobra.Command {
 			"Inspect and configure the custom functions included in an app with this command.",
 			"Functions can be added as a step in Workflow Builder and shared among teammates.",
 			"",
-			`Learn more about functions: {{LinkText "https://api.slack.com/automation/functions/overview"}}`,
+			`Learn more about functions: {{LinkText "https://tools.slack.dev/deno-slack-sdk/guides/creating-functions"}}`,
 		}, "\n"),
 		Example: style.ExampleCommandsf([]style.ExampleCommand{
 			{Command: "function distribute", Meaning: "Select a function and choose distribution options"},

--- a/cmd/help/help.go
+++ b/cmd/help/help.go
@@ -106,6 +106,6 @@ const helpTemplate string = `{{.Long}}
   For more information about a specific command, run:
   $ {{.CommandPath}}{{if eq .Name (GetProcessName)}} <command>{{end}} <subcommand> --help
 
-  For guides and documentation, head over to {{LinkText "https://api.slack.com/automation"}}{{end}}
+  For guides and documentation, head over to {{LinkText "https://tools.slack.dev/slack-cli"}}{{end}}
 
 `

--- a/cmd/project/create.go
+++ b/cmd/project/create.go
@@ -200,7 +200,7 @@ func printCreateSuccess(ctx context.Context, clients *shared.ClientFactory, appP
 			Emoji: "compass",
 			Text:  "Explore the documentation to learn more",
 			Secondary: []string{
-				"Read the README.md or peruse the docs over at " + style.Highlight("api.slack.com/automation"),
+				"Read the README.md or peruse the docs over at " + style.Highlight("https://tools.slack.dev/deno-slack-sdk"),
 				"Find available commands and usage info with " + style.Commandf("help", false),
 			},
 		}))

--- a/cmd/project/create_template.go
+++ b/cmd/project/create_template.go
@@ -274,7 +274,7 @@ func confirmExternalTemplateSelection(cmd *cobra.Command, clients *shared.Client
 // getSelectionTemplate returns a custom formatted template used for selecting a
 // project template during creation
 func getSelectionTemplate(clients *shared.ClientFactory) string {
-	samplesURL := style.LinkText("api.slack.com/automation/samples")
+	samplesURL := style.LinkText("https://api.slack.com/samples")
 	switch clients.Config.WithExperimentOn(experiment.BoltFrameworks) {
 	case true:
 		return fmt.Sprintf(`

--- a/cmd/project/create_template.go
+++ b/cmd/project/create_template.go
@@ -274,7 +274,7 @@ func confirmExternalTemplateSelection(cmd *cobra.Command, clients *shared.Client
 // getSelectionTemplate returns a custom formatted template used for selecting a
 // project template during creation
 func getSelectionTemplate(clients *shared.ClientFactory) string {
-	samplesURL := style.LinkText("https://api.slack.com/samples")
+	samplesURL := style.LinkText("https://docs.slack.dev/samples")
 	switch clients.Config.WithExperimentOn(experiment.BoltFrameworks) {
 	case true:
 		return fmt.Sprintf(`

--- a/cmd/project/samples.tmpl
+++ b/cmd/project/samples.tmpl
@@ -12,5 +12,5 @@
   {{- range $ix, $option := .PageEntries}}
   {{- template "option" $.IterateOption $ix $option}}
   {{- end}}
-{{- "  Guided tutorials can be found at "}}{{color "32+u"}}{{"api.slack.com/automation/samples"}}{{color "reset"}}
+{{- "  Guided tutorials can be found at "}}{{color "32+u"}}{{"https://api.slack.com/samples"}}{{color "reset"}}
 {{end}}

--- a/cmd/project/samples.tmpl
+++ b/cmd/project/samples.tmpl
@@ -12,5 +12,5 @@
   {{- range $ix, $option := .PageEntries}}
   {{- template "option" $.IterateOption $ix $option}}
   {{- end}}
-{{- "  Guided tutorials can be found at "}}{{color "32+u"}}{{"https://api.slack.com/samples"}}{{color "reset"}}
+{{- "  Guided tutorials can be found at "}}{{color "32+u"}}{{"https://docs.slack.dev/samples"}}{{color "reset"}}
 {{end}}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -99,7 +99,7 @@ func NewRootCommand(clients *shared.ClientFactory, updateNotification *update.Up
 		Long: strings.Join([]string{
 			`{{Emoji "sparkles"}}CLI to create, run, and deploy Slack apps`,
 			"",
-			`{{Emoji "books"}}Get started by reading the docs: {{LinkText "https://api.slack.com/automation"}}`,
+			`{{Emoji "books"}}Get started by reading the docs: {{LinkText "https://tools.slack.dev/slack-cli"}}`,
 		}, "\n"),
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			clients.IO.SetCmdIO(cmd)

--- a/cmd/triggers/generate.go
+++ b/cmd/triggers/generate.go
@@ -196,7 +196,7 @@ func getFullyQualifiedTriggerFilePaths(clients *shared.ClientFactory, triggerPat
 
 	if len(triggerFilePaths) <= 0 {
 		clients.IO.PrintInfo(ctx, false, style.SectionSecondaryf(
-			"No trigger definition files found\nLearn more about triggers: https://api.slack.com/automation/triggers/link",
+			"No trigger definition files found\nLearn more about triggers:\nhttps://tools.slack.dev/deno-slack-sdk/guides/creating-link-triggers",
 		))
 		return nil, nil
 	} else {

--- a/cmd/upgrade/upgrade.go
+++ b/cmd/upgrade/upgrade.go
@@ -28,7 +28,7 @@ import (
 // checkForUpdatesFunc is a function pointer for tests to mock the checkForUpdates function
 var checkForUpdatesFunc = checkForUpdates
 
-const changelogURL = "https://api.slack.com/automation/changelog"
+const changelogURL = "https://docs.slack.dev/changelog"
 
 func NewCommand(clients *shared.ClientFactory) *cobra.Command {
 	return &cobra.Command{

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -324,7 +324,7 @@ func (c *Client) DoWithRetry(ctx context.Context, request *http.Request, span op
 }
 
 // getRetryAfter returns the value of the Retry-After header for applicable requests.
-// More information can be found here: https://api.slack.com/apis/rate-limits
+// More information can be found here: https://docs.slack.dev/apis/web-api/rate-limits/
 func getRetryAfter(r *http.Response) (time.Duration, bool) {
 	if !(r.StatusCode == http.StatusTooManyRequests || r.StatusCode == http.StatusServiceUnavailable) {
 		return 0, false

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -324,7 +324,7 @@ func (c *Client) DoWithRetry(ctx context.Context, request *http.Request, span op
 }
 
 // getRetryAfter returns the value of the Retry-After header for applicable requests.
-// More information can be found here: https://api.slack.com/docs/rate-limits
+// More information can be found here: https://api.slack.com/apis/rate-limits
 func getRetryAfter(r *http.Response) (time.Duration, bool) {
 	if !(r.StatusCode == http.StatusTooManyRequests || r.StatusCode == http.StatusServiceUnavailable) {
 		return 0, false

--- a/internal/shared/types/channel.go
+++ b/internal/shared/types/channel.go
@@ -31,7 +31,7 @@ func (c *SlackChannel) String() string {
 }
 
 // Channel model with fields that match what is returned from the conversations.info method
-// Method documentation: https://api.slack.com/methods/conversations.info
+// Method documentation: https://docs.slack.dev/reference/methods/conversations.info
 type ChannelInfo struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`

--- a/internal/shared/types/team.go
+++ b/internal/shared/types/team.go
@@ -34,7 +34,7 @@ func (c *SlackTeam) String() string {
 }
 
 // Team model with fields that match what is returned from the team.info method
-// Method documentation: https://api.slack.com/methods/team.info
+// Method documentation: https://docs.slack.dev/reference/methods/team.info
 type TeamInfo struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`

--- a/internal/shared/types/user.go
+++ b/internal/shared/types/user.go
@@ -62,7 +62,7 @@ type FunctionDistributionUser struct {
 }
 
 // User model with fields that match what is returned from the users.info method
-// Method documentation: https://api.slack.com/methods/users.info
+// Method documentation: https://docs.slack.dev/reference/methods/users.info
 type UserInfo struct {
 	ID       string      `json:"id"`
 	Name     string      `json:"name"`

--- a/internal/slackerror/errors.go
+++ b/internal/slackerror/errors.go
@@ -341,12 +341,14 @@ var ErrorCodeMap = map[string]Error{
 		Details: ErrorDetails{
 			ErrorDetail{Message: "Deployment to Slack is currently supported for apps written with the Deno Slack SDK."},
 		},
-		Remediation: fmt.Sprintf(`Learn about building apps with the Deno Slack SDK: api.slack.com/automation
-If you are using a Bolt framework, deployment is supported under an experiment.
-Add a deploy hook then run: %s
+		Remediation: fmt.Sprintf(`Learn about building apps with the Deno Slack SDK:
+
+https://tools.slack.dev/deno-slack-sdk
+
+If you are using a Bolt framework, add a deploy hook then run: %s
 
 Otherwise start your app for local development with: %s`,
-			style.Commandf("deploy --experiment=bolt", true),
+			style.Commandf("deploy", true),
 			style.Commandf("run", true),
 		),
 	},
@@ -551,7 +553,7 @@ Otherwise start your app for local development with: %s`,
 	ErrCliAutoupdate: {
 		Code:        ErrCliAutoupdate,
 		Message:     "Couldn't auto-update this command-line tool",
-		Remediation: "You can manually install the latest version from https://api.slack.com/automation/cli/install.",
+		Remediation: "You can manually install the latest version from:\nhttps://tools.slack.dev/slack-cli",
 	},
 
 	ErrCliConfigLocationError: {

--- a/internal/slackerror/errors.go
+++ b/internal/slackerror/errors.go
@@ -430,7 +430,7 @@ Otherwise start your app for local development with: %s`,
 		Message: "App is not configured to be deployed to the Slack platform",
 		Remediation: strings.Join([]string{
 			"Deploy an app containing workflow automations to Slack managed infrastructure",
-			"Read about ROSI: https://api.slack.com/concepts/rosi",
+			"Read about ROSI: https://docs.slack.dev/workflows/run-on-slack-infrastructure",
 		}, "\n"),
 	},
 

--- a/internal/update/cli.go
+++ b/internal/update/cli.go
@@ -78,7 +78,7 @@ func (c *CLIDependency) PrintUpdateNotification(cmd *cobra.Command) (bool, error
 		style.Secondary(c.version),
 		style.CommandText(c.releaseInfo.Version),
 		"   You can read the release notes at:",
-		style.CommandText("https://api.slack.com/automation/changelog"),
+		style.CommandText("https://docs.slack.dev/changelog"),
 	)
 
 	if isHomebrew {
@@ -89,7 +89,7 @@ func (c *CLIDependency) PrintUpdateNotification(cmd *cobra.Command) (bool, error
 	} else {
 		cmd.Printf(
 			"\n   To manually update, visit the download page:\n   %s\n\n",
-			style.CommandText("https://api.slack.com/automation/cli/install"),
+			style.CommandText("https://tools.slack.dev/slack-cli"),
 		)
 		selfUpdatePrompt := fmt.Sprintf("%sDo you want to auto-update to the latest version now?", style.Emoji("rocket"))
 		return c.clients.IO.ConfirmPrompt(cmd.Context(), selfUpdatePrompt, false)

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -125,7 +125,7 @@ install_slack_cli() {
         else
                 echo "🛑 Error: This installer is only supported on Linux and macOS"
                 echo "🔖 Try using a different installation method:"
-                echo "🔗 https://api.slack.com/automation/cli/install"
+                echo "🔗 https://tools.slack.dev/slack-cli"
                 exit 1
         fi
 

--- a/scripts/install-windows-dev.ps1
+++ b/scripts/install-windows-dev.ps1
@@ -339,7 +339,7 @@ function next_step_message {
       Write-Host "   Then, authorize your CLI in your workspace with ``$confirmed_alias login``.`n"
     }
     catch {
-      throw "`nSlack CLI is not installed.`nPlease reach out to feedback@slack.com to share the issues you are facing.`nMeanwhile you can try the manual installation: https://api.slack.com/automation/quickstart.`n"
+      throw "`nSlack CLI is not installed.`nPlease reach out to feedback@slack.com to share the issues you are facing.`nMeanwhile you can try the manual installation: https://tools.slack.dev/slack-cli.`n"
     }
   }
 }

--- a/scripts/install-windows.ps1
+++ b/scripts/install-windows.ps1
@@ -330,7 +330,7 @@ function next_step_message {
       Write-Host "   Then, authorize your CLI in your workspace with ``$confirmed_alias login``.`n"
     }
     catch {
-      throw "`nSlack CLI is not installed.`nPlease reach out to feedback@slack.com to share the issues you are facing.`nMeanwhile you can try the manual installation: https://api.slack.com/automation/quickstart.`n"
+      throw "`nSlack CLI is not installed.`nPlease reach out to feedback@slack.com to share the issues you are facing.`nMeanwhile you can try the manual installation: https://tools.slack.dev/slack-cli`n"
     }
   }
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -109,7 +109,7 @@ install_slack_cli() {
                 LATEST_SLACK_CLI_VERSION=$(curl --silent "https://api.slack.com/slackcli/metadata.json" | grep -o '"version": "[^"]*' | grep -o '[^"]*$' | head -1)
                 if [ -z "$LATEST_SLACK_CLI_VERSION" ]; then
                     echo "🛑 Error: Installer cannot find the latest Slack CLI version!"
-                    echo "🔖 Check the status of https://api.slack.com and try again"
+                    echo "🔖 Check the status of https://slack-status.com/ and try again"
                     exit 1
                 fi
                 echo -e "💾 Release v$LATEST_SLACK_CLI_VERSION was found! Downloading now..."
@@ -127,7 +127,7 @@ install_slack_cli() {
         else
                 echo "🛑 Error: This installer is only supported on Linux and macOS"
                 echo "🔖 Try using a different installation method:"
-                echo "🔗 https://api.slack.com/automation/cli/install"
+                echo "🔗 https://tools.slack.dev/slack-cli"
                 exit 1
         fi
 


### PR DESCRIPTION
### Summary

🤾🏻 _Kudos to @zimeg for pointing this out!_

This pull request updates all references to https://api.slack.com to https://slack.dev, when available.

In most cases, this just prevents a redirect from happening.

The main benefit is the promote our new CHANGELOG page whenever the Slack CLI has an update:

<img width="762" alt="image" src="https://github.com/user-attachments/assets/1c76148c-30c5-434a-bef5-2f1331e5c678" />

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).