### PR TITLE
build: set the complete semver version of github action steps

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -10,17 +10,17 @@ jobs:
     steps:
       - name: Gather credentials
         id: credentials
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v2.0.2
         with:
           app-id: ${{ secrets.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
       - name: Checkout the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
         with:
           ref: main
           token: ${{ steps.credentials.outputs.token }}
       - name: Install Golang
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v5.4.0
         with:
           go-version: "stable"
       - name: Get the latest version

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger CircleCI build-beta workflow.
-        uses: promiseofcake/circleci-trigger-action@v1
+        uses: promiseofcake/circleci-trigger-action@v1.7.8
         with:
           user-token: ${{ secrets.CIRCLECI_TOKEN }}
           project-slug: slackapi/slack-cli

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -11,7 +11,7 @@ jobs:
     name: Check that license headers are in place
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
         with:
           # Number of commits to fetch. 0 indicates all history for all branches and tags.
           # Default: 1

--- a/.github/workflows/sync-docs-from-cli-repo.yml
+++ b/.github/workflows/sync-docs-from-cli-repo.yml
@@ -5,12 +5,12 @@ on:
     branches:
       - main
     paths:
-      - "docs/**" 
+      - "docs/**"
   pull_request:
     branches:
       - main
     paths:
-      - "docs/**" 
+      - "docs/**"
   workflow_dispatch:
 
 jobs:
@@ -21,17 +21,17 @@ jobs:
     steps:
       - name: Generate a GitHub token
         id: ghtoken
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v2.0.2
         with:
           app-id: ${{ secrets.GH_APP_ID }}
           owner: slackapi
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
 
       - name: Checkout the tool repo (source)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
 
       - name: Checkout the docs site repo (destination)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
         with:
           repository: slackapi/slackapi.github.io
           path: "docs_repo"
@@ -40,7 +40,7 @@ jobs:
 
       - name: Update docs in docs site repo
         run: |
-            rsync -av --delete ./docs/ ./docs_repo/content/${{ github.event.repository.name }}/
+          rsync -av --delete ./docs/ ./docs_repo/content/${{ github.event.repository.name }}/
 
       - name: Install dependencies
         run: |
@@ -55,7 +55,7 @@ jobs:
       - name: Create a pull request
         if: ${{ github.event.pull_request.merged || github.event_name == 'workflow_dispatch' }}
         id: site-pr
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v7.0.8
         with:
           token: ${{ steps.ghtoken.outputs.token }}
           title: "From ${{ github.event.repository.name }}: ${{ github.event.pull_request.title || 'manual docs sync' }}"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     name: Lints and Unit tests
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
         with:
           # Number of commits to fetch. 0 indicates all history for all branches and tags.
           # Default: 1
@@ -26,11 +26,11 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v5.4.0
         with:
           go-version: "1.24.2"
       - name: Lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@v7.0.0
         with:
           version: latest
           args: --timeout=5m
@@ -39,7 +39,7 @@ jobs:
         run: make test
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v5.4.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.out
@@ -50,13 +50,13 @@ jobs:
     needs: lint-test
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v5.4.0
         with:
           go-version: "1.24.2"
       - name: Report health score
-        uses: slackapi/slack-health-score@v0
+        uses: slackapi/slack-health-score@v0.1.1
         with:
           extension: "go"
           codecov_token: ${{ secrets.ELAINES_CODECOV_API_TOKEN }}


### PR DESCRIPTION
### Summary

This PR updates the GitHub Actions workflows of this repository to use the complete semver version tag.

Fixes issues where unexpected updates can cause different behaviors when versions are left unspecified since the latest tag is often updated in releases. Example: `@4` can match `@4.32.1` and later `@4.4.4`!

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).