### PR TITLE
ci: escape pull request branch tag before creating releases to test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -267,7 +267,8 @@ jobs:
             # - PR builds pass the branch name in as release_ref, so massage it if it is missing a semver prefix.
               echo "Branch (PR) build detected, sanitizing release tag..."
               LAST_SEMVER_TAG=$(git describe --tags --match 'v*.*.*' --abbrev=0 | cut -d"-" -f1)
-              RELEASE_REF="${LAST_SEMVER_TAG}-<< parameters.release_ref >>"
+              BRANCH_NAME=$(echo "<< parameters.release_ref >>" | sed 's/\//-/g')
+              RELEASE_REF="${LAST_SEMVER_TAG}-${BRANCH_NAME}"
             fi
             echo "Will use RELEASE_REF=${RELEASE_REF}"
             echo "export RELEASE_REF=${RELEASE_REF}" >> $BASH_ENV
@@ -386,10 +387,16 @@ jobs:
           command: |
             # TODO: once CircleCI updates its pipeline-invocation API, move off of Cheng's personal CircleCI access token, which is saved to both of the slackapi CircleCI "contexts" as an env var:
             # https://app.circleci.com/settings/organization/github/slackapi/contexts
+            if [[ -z "$CIRCLE_BRANCH" || "$CIRCLE_BRANCH" == pull/* ]]; then
+              BRANCH_NAME="main"
+              echo "Performing the standard test suite found on the \"main\" branch of the end-to-end tests"
+            else
+              BRANCH_NAME="$CIRCLE_BRANCH"
+            fi
             TEST_JOB_WORKFLOW_ID=$(curl --location --request POST 'https://circleci.com/api/v2/project/gh/slackapi/platform-devxp-test/pipeline' \
               --header 'Content-Type: application/json' \
               -u "${CCHEN_CIRCLECI_PERSONAL_TOKEN}:" \
-              --data "{\"branch\":\"${CIRCLE_BRANCH}\",\"parameters\":{\"slack_cli_build_tag\":\"${RELEASE_REF}\"}}" | jq '.id')
+              --data "{\"branch\":\"${BRANCH_NAME}\",\"parameters\":{\"slack_cli_build_tag\":\"${RELEASE_REF}\"}}" | jq '.id')
             if [ $TEST_JOB_WORKFLOW_ID = "null" ]; then
               echo "Performing the standard test suite found on the \"main\" branch of the end-to-end tests"
               TEST_JOB_WORKFLOW_ID=$(curl --location --request POST 'https://circleci.com/api/v2/project/gh/slackapi/platform-devxp-test/pipeline' \
@@ -397,7 +404,7 @@ jobs:
                 -u "${CCHEN_CIRCLECI_PERSONAL_TOKEN}:" \
                 --data "{\"branch\":\"main\",\"parameters\":{\"slack_cli_build_tag\":\"${RELEASE_REF}\"}}" | jq '.id')
             else
-              echo "Performing the changed tests on the \"$CIRCLE_BRANCH\" branch of the end-to-end tests"
+              echo "Performing the changed tests on the \"$BRANCH_NAME\" branch of the end-to-end tests"
             fi
             if [ $TEST_JOB_WORKFLOW_ID = "null" ]; then
               echo "Failed to start the testing workflow"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -389,7 +389,7 @@ jobs:
             # https://app.circleci.com/settings/organization/github/slackapi/contexts
             if [[ -z "$CIRCLE_BRANCH" || "$CIRCLE_BRANCH" == pull/* ]]; then
               BRANCH_NAME="main"
-              echo "Performing the standard test suite found on the \"main\" branch of the end-to-end tests"
+              echo "Performing the standard end-to-end test suite for changes from a pull request"
             else
               BRANCH_NAME="$CIRCLE_BRANCH"
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -389,7 +389,7 @@ jobs:
             # https://app.circleci.com/settings/organization/github/slackapi/contexts
             if [[ -z "$CIRCLE_BRANCH" || "$CIRCLE_BRANCH" == pull/* ]]; then
               BRANCH_NAME="main"
-              echo "Performing the standard end-to-end test suite for changes from a pull request"
+              echo "Performing the standard end-to-end test suite for changes of a forked branch"
             else
               BRANCH_NAME="$CIRCLE_BRANCH"
             fi


### PR DESCRIPTION
### Summary

This PR escapes the branch name of pull requests for use in tests started with #36.

### Preview

- Before changes: `v3.0.4-pull/38/head`
- After changes: [`v3.0.4-pull-38-head`](https://github.com/slackapi/slack-cli/releases/tag/v3.0.4-pull-38-head)

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).