### PR TITLE
ci: skip artifact creation for upstream testing for forks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -518,7 +518,7 @@ workflows:
           release_ref: << pipeline.git.branch >>
           filters:
             branches:
-              ignore: "^pull/[0-9]+/head$"
+              ignore: "^pull/[0-9]+/head$" # Skip fork branches
       - e2e-test:
           e2e_target_branch: "main"
           requires:
@@ -526,7 +526,7 @@ workflows:
           context: slack-cli-e2e
           filters:
             branches:
-              ignore: "^pull/[0-9]+/head$"
+              ignore: "^pull/[0-9]+/head$" # Skip fork branches
 
   # nightly build will build from main branch nightly at 12:00 am UTC
   nightly-build-test-code-sign-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -518,7 +518,7 @@ workflows:
           release_ref: << pipeline.git.branch >>
           filters:
             branches:
-              ignore: "^pull\/.*"
+              ignore: "^pull/[0-9]+/head$"
       - e2e-test:
           e2e_target_branch: "main"
           requires:
@@ -526,7 +526,7 @@ workflows:
           context: slack-cli-e2e
           filters:
             branches:
-              ignore: "^pull\/.*"
+              ignore: "^pull/[0-9]+/head$"
 
   # nightly build will build from main branch nightly at 12:00 am UTC
   nightly-build-test-code-sign-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -518,7 +518,7 @@ workflows:
           release_ref: << pipeline.git.branch >>
           filters:
             branches:
-              ignore: ^pull\/.*
+              ignore: "^pull\/.*"
       - e2e-test:
           e2e_target_branch: "main"
           requires:
@@ -526,7 +526,7 @@ workflows:
           context: slack-cli-e2e
           filters:
             branches:
-              ignore: ^pull\/.*
+              ignore: "^pull\/.*"
 
   # nightly build will build from main branch nightly at 12:00 am UTC
   nightly-build-test-code-sign-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -516,11 +516,17 @@ workflows:
             - build
           context: slack-cli-release
           release_ref: << pipeline.git.branch >>
+          filters:
+            branches:
+              ignore: ^pull\/.*
       - e2e-test:
           e2e_target_branch: "main"
           requires:
             - create-github-release-and-artifacts
           context: slack-cli-e2e
+          filters:
+            branches:
+              ignore: ^pull\/.*
 
   # nightly build will build from main branch nightly at 12:00 am UTC
   nightly-build-test-code-sign-deploy:

--- a/.github/workflows/delete-pr-build-on-close.yml
+++ b/.github/workflows/delete-pr-build-on-close.yml
@@ -4,12 +4,14 @@ name: Delete pre-release when a branch is deleted
 # The circleci config builds CLI binaries when a PR is opened and hosts them under a GitHub (pre-)release named after the PR branch
 # This workflow action deletes that pre-release when a PR is merged or closed.
 on:
-  delete:
-    branches:
+  pull_request:
+    # types:
+    #   - closed
 
 jobs:
   delete-pre-release:
     name: Delete pre-release if exists
+    # if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Delete pre-release and tag named after branch
@@ -17,9 +19,19 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
+          # Use either an upstream or fork PR branch
+          if [[ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]; then
+            BRANCH="pull/${{ github.event.pull_request.number }}/head"
+          else
+            BRANCH="${{ github.event.pull_request.head.ref }}"
+          fi
+
           # Escape tags to create a semantic version
-          REF=$(echo "${{ github.event.ref }}" | sed 's/\//-/g')
+          REF=$(echo "${BRANCH}" | sed 's/\//-/g')
           RELEASE_FOUND=1
+
+          echo "REF=$REF" # TODO: delete
+          exit 0
 
           # Delete tags matching the pull request branch from forks
           if GH_DEBUG=1 gh release --repo="slackapi/slack-cli" delete "${REF}" -y --cleanup-tag; then

--- a/.github/workflows/delete-pr-build-on-close.yml
+++ b/.github/workflows/delete-pr-build-on-close.yml
@@ -4,14 +4,12 @@ name: Delete pre-release when a branch is deleted
 # The circleci config builds CLI binaries when a PR is opened and hosts them under a GitHub (pre-)release named after the PR branch
 # This workflow action deletes that pre-release when a PR is merged or closed.
 on:
-  pull_request:
-    # types:
-    #   - closed
+  delete:
+    branches:
 
 jobs:
   delete-pre-release:
     name: Delete pre-release if exists
-    # if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Delete pre-release and tag named after branch
@@ -19,19 +17,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
-          # Use either an upstream or fork PR branch
-          if [[ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]; then
-            BRANCH="pull/${{ github.event.pull_request.number }}/head"
-          else
-            BRANCH="${{ github.event.pull_request.head.ref }}"
-          fi
-
           # Escape tags to create a semantic version
-          REF=$(echo "${BRANCH}" | sed 's/\//-/g')
+          REF=$(echo "${{ github.event.ref }}" | sed 's/\//-/g')
           RELEASE_FOUND=1
-
-          echo "REF=$REF" # TODO: delete
-          exit 0
 
           # Delete tags matching the pull request branch from forks
           if GH_DEBUG=1 gh release --repo="slackapi/slack-cli" delete "${REF}" -y --cleanup-tag; then


### PR DESCRIPTION
### Summary

This PR skips artifact creation and E2E tests for PRs created from forked branches. Workaround for edges of `git` in CI.

### Notes

- The "build-lint-test-e2e-test" workflow is required and can be started for forked PRs with [these](https://github.com/slackapi/slack-cli/blob/main/.github/MAINTAINERS_GUIDE.md#pull-request-merge) steps 📚 
- The "build-lint-test-e2e-test" workflow includes a step with `goreleaser` that is kept as a `build` test 👾  

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).