### PR TITLE
refactor: remove context.Background() references from create and deploy

### DIFF
--- a/cmd/project/create_template.go
+++ b/cmd/project/create_template.go
@@ -15,7 +15,6 @@
 package project
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -248,7 +247,7 @@ func confirmExternalTemplateSelection(cmd *cobra.Command, clients *shared.Client
 		return true, nil
 	}
 
-	clients.IO.PrintWarning(context.Background(), style.Sectionf(style.TextSection{
+	clients.IO.PrintWarning(ctx, style.Sectionf(style.TextSection{
 		Text: style.Bold("You are trying to use code published by an unknown author"),
 		Secondary: []string{
 			"We strongly advise reviewing the source code and dependencies of external",

--- a/internal/pkg/platform/deploy.go
+++ b/internal/pkg/platform/deploy.go
@@ -228,7 +228,7 @@ func packageArchive(ctx context.Context, clients *shared.ClientFactory, projectR
 	}
 
 	// Install the project's production dependencies with a timeout in case there are issues
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
 	defer cancel()
 
 	if _, err := clients.Runtime.InstallProjectDependencies(ctx, tmpDir, clients.HookExecutor, clients.IO, clients.Fs, clients.Os); err != nil {


### PR DESCRIPTION
### Summary

This pull request is another minor refactor to shore up our usage of `ctx context.Context`. It removes 2 low-hanging fruit 🍒 references to `context.Background()`.

There are at least 2 more areas that need to be updated in future PRs, but they will require broader refactors to carry the context over. So, I'll leave those for separate PRs to make the reviewing easier 😎 

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).