### PR TITLE
fix: 'upgrade' output includes SDK when inside a project dir

### DIFF
--- a/cmd/upgrade/upgrade.go
+++ b/cmd/upgrade/upgrade.go
@@ -69,8 +69,14 @@ func checkForUpdates(clients *shared.ClientFactory, cmd *cobra.Command) error {
 
 	// Update notification messages are printed by the root command's persistent post-run (cmd/root.go).
 	// So this command only needs to print a message when everything is up-to-date.
-	if !updateNotification.HasUpdate() {
-		cmd.Printf("%s You are using the latest Slack CLI and SDK\n", style.Styler().Green("✔").String())
+	if updateNotification.HasUpdate() {
+		return nil
+	}
+
+	if clients.SDKConfig.Hooks.CheckUpdate.IsAvailable() {
+		cmd.Printf("%s You are using the latest Slack CLI and SDK versions\n", style.Styler().Green("✔").String())
+	} else {
+		cmd.Printf("%s You are using the latest Slack CLI version\n", style.Styler().Green("✔").String())
 	}
 
 	return nil


### PR DESCRIPTION
### Summary

This PR updates outputs of the `upgrade` command to note if the latest SDK versions were checked.

### Preview

Outputs now change depending on the path used 👾

```sh
$ slack version
Using slack v3.0.4
$ slack upgrade
✔ You are using the latest Slack CLI version
$ slack create asdf
$ cd asdf
$ slack upgrade
✔ You are using the latest Slack CLI and SDK versions
```

### Reviewers

A handbuilt make of these changes might be useful for testing the shown version:

```
$ go build -ldflags="-X 'github.com/slackapi/slack-cli/internal/pkg/version.Version=3.0.4'" -o bin/slack
```

And these commands can be useful in testing cases with a `bolt` JS project:

```
$ npm install @slack/cli-hooks@1.0.0
$ npm install @slack/cli-hooks@latest
```

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).