### PR TITLE
refactor: remove context.Background() references from triggers command

### DIFF
--- a/cmd/triggers/create.go
+++ b/cmd/triggers/create.go
@@ -116,7 +116,7 @@ func runCreateCommand(clients *shared.ClientFactory, cmd *cobra.Command) error {
 		app = _app
 	}
 
-	err = validateCreateCmdFlags(clients, &createFlags)
+	err = validateCreateCmdFlags(ctx, clients, &createFlags)
 	if err != nil {
 		return err
 	}

--- a/cmd/triggers/create_test.go
+++ b/cmd/triggers/create_test.go
@@ -653,8 +653,8 @@ func TestTriggersCreateCommand_promptShouldDisplayTriggerDefinitionFiles(t *test
 
 	for _, testcase := range testcases {
 		t.Run(testcase.name, func(t *testing.T) {
-
 			// Prepare mocks
+			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := shared.NewClientsMock()
 			testcase.prepareMocks(clientsMock)
 			clients := shared.NewClientFactory(clientsMock.MockClientFactory())
@@ -663,7 +663,7 @@ func TestTriggersCreateCommand_promptShouldDisplayTriggerDefinitionFiles(t *test
 
 			var err error
 			createFlags := createCmdFlags{}
-			err = maybeSetTriggerDefFlag(clients, &createFlags)
+			err = maybeSetTriggerDefFlag(ctx, clients, &createFlags)
 			testcase.check(t, createFlags, err)
 		})
 	}

--- a/cmd/triggers/generate.go
+++ b/cmd/triggers/generate.go
@@ -78,7 +78,7 @@ func TriggerGenerate(ctx context.Context, clients *shared.ClientFactory, app typ
 		},
 	})))
 
-	triggerFilePaths, err := getFullyQualifiedTriggerFilePaths(clients, triggerPaths)
+	triggerFilePaths, err := getFullyQualifiedTriggerFilePaths(ctx, clients, triggerPaths)
 	if err != nil {
 		return nil, err
 	}
@@ -171,8 +171,7 @@ func getTriggerPaths(sdkCLIConfig *hooks.SDKCLIConfig) []string {
 
 // getFullyQualifiedTriggerFilePaths returns an array of file paths that
 // are validated
-func getFullyQualifiedTriggerFilePaths(clients *shared.ClientFactory, triggerPaths []string) ([]string, error) {
-	ctx := context.Background()
+func getFullyQualifiedTriggerFilePaths(ctx context.Context, clients *shared.ClientFactory, triggerPaths []string) ([]string, error) {
 	projectDir, err := clients.Os.Getwd()
 	if err != nil {
 		return nil, err
@@ -239,7 +238,7 @@ func isValidTriggerFilePath(triggerPath string) bool {
 	return true
 }
 
-func validateCreateCmdFlags(clients *shared.ClientFactory, createFlags *createCmdFlags) error {
+func validateCreateCmdFlags(ctx context.Context, clients *shared.ClientFactory, createFlags *createCmdFlags) error {
 	if createFlags.triggerDef != "" {
 		exists, err := afero.Exists(clients.Fs, createFlags.triggerDef)
 		if err != nil {
@@ -280,7 +279,7 @@ func validateCreateCmdFlags(clients *shared.ClientFactory, createFlags *createCm
 	}
 
 	if createFlags.triggerDef == "" && createFlags.workflow == "" {
-		return maybeSetTriggerDefFlag(clients, createFlags)
+		return maybeSetTriggerDefFlag(ctx, clients, createFlags)
 	}
 
 	if createFlags.description == "" {
@@ -290,8 +289,7 @@ func validateCreateCmdFlags(clients *shared.ClientFactory, createFlags *createCm
 	return nil
 }
 
-func maybeSetTriggerDefFlag(clients *shared.ClientFactory, createFlags *createCmdFlags) error {
-	ctx := context.Background()
+func maybeSetTriggerDefFlag(ctx context.Context, clients *shared.ClientFactory, createFlags *createCmdFlags) error {
 	triggerPaths := getTriggerPaths(&clients.SDKConfig)
 
 	fmt.Printf("%s", style.Sectionf(style.TextSection{
@@ -299,7 +297,7 @@ func maybeSetTriggerDefFlag(clients *shared.ClientFactory, createFlags *createCm
 		Text:  fmt.Sprintf("Searching for trigger definition files under '%s'...", strings.Join(triggerPaths, ", ")),
 	}))
 
-	triggerFilePaths, err := getFullyQualifiedTriggerFilePaths(clients, triggerPaths)
+	triggerFilePaths, err := getFullyQualifiedTriggerFilePaths(ctx, clients, triggerPaths)
 	if err != nil {
 		return err
 	}

--- a/cmd/triggers/generate_test.go
+++ b/cmd/triggers/generate_test.go
@@ -372,6 +372,7 @@ func Test_TriggerGenerate_MismatchedFlags(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
+			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := shared.NewClientsMock()
 			clientsMock.Os.On("Glob", mock.Anything).Return([]string{definitionFile}, nil)
 			clientsMock.AddDefaultMocks()
@@ -383,7 +384,7 @@ func Test_TriggerGenerate_MismatchedFlags(t *testing.T) {
 			err = afero.WriteFile(clients.Fs, definitionFile, []byte(""), 0600)
 			require.NoError(t, err, "Cant write apps.json")
 
-			err = validateCreateCmdFlags(clients, &tt.flags)
+			err = validateCreateCmdFlags(ctx, clients, &tt.flags)
 			if tt.err != nil {
 				assert.NotNil(t, err)
 				assert.Equal(t, slackerror.ToSlackError(tt.err).Code, slackerror.ToSlackError(err).Code)

--- a/cmd/triggers/update.go
+++ b/cmd/triggers/update.go
@@ -105,7 +105,7 @@ func runUpdateCommand(clients *shared.ClientFactory, cmd *cobra.Command) error {
 		}
 	}
 
-	err = validateCreateCmdFlags(clients, &updateFlags.createCmdFlags)
+	err = validateCreateCmdFlags(ctx, clients, &updateFlags.createCmdFlags)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Summary

_Context delivery, get it while it's hot!_ 💁🍕 

This pull request updates the `trigger` command to no longer use `context.Background()`. Not too exciting, but I've separated this into a single PR because its changes span a few files

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).