### PR TITLE
ci: delete testing fork pre-releases using upstream tag names

### DIFF
--- a/.github/workflows/delete-pr-build-on-close.yml
+++ b/.github/workflows/delete-pr-build-on-close.yml
@@ -5,13 +5,13 @@ name: Delete pre-release when a branch is deleted
 # This workflow action deletes that pre-release when a PR is merged or closed.
 on:
   pull_request:
-    # types:
-    #   - closed
+    types:
+      - closed
 
 jobs:
   delete-pre-release:
     name: Delete pre-release if exists
-    # if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Delete pre-release and tag named after branch
@@ -29,9 +29,6 @@ jobs:
           # Escape tags to create a semantic version
           REF=$(echo "${BRANCH}" | sed 's/\//-/g')
           RELEASE_FOUND=1
-
-          echo "REF=$REF" # TODO: delete
-          exit 0
 
           # Delete tags matching the pull request branch from forks
           if GH_DEBUG=1 gh release --repo="slackapi/slack-cli" delete "${REF}" -y --cleanup-tag; then

--- a/.github/workflows/delete-pr-build-on-close.yml
+++ b/.github/workflows/delete-pr-build-on-close.yml
@@ -4,12 +4,14 @@ name: Delete pre-release when a branch is deleted
 # The circleci config builds CLI binaries when a PR is opened and hosts them under a GitHub (pre-)release named after the PR branch
 # This workflow action deletes that pre-release when a PR is merged or closed.
 on:
-  delete:
-    branches:
+  pull_request:
+    types:
+      - closed
 
 jobs:
   delete-pre-release:
     name: Delete pre-release if exists
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Delete pre-release and tag named after branch
@@ -17,8 +19,15 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
+          # Use either an upstream or fork PR branch
+          if [[ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]; then
+            BRANCH="pull/${{ github.event.pull_request.number }}/head"
+          else
+            BRANCH="${{ github.event.pull_request.head.ref }}"
+          fi
+
           # Escape tags to create a semantic version
-          REF=$(echo "${{ github.event.ref }}" | sed 's/\//-/g')
+          REF=$(echo "${BRANCH}" | sed 's/\//-/g')
           RELEASE_FOUND=1
 
           # Delete tags matching the pull request branch from forks

--- a/.github/workflows/delete-pr-build-on-close.yml
+++ b/.github/workflows/delete-pr-build-on-close.yml
@@ -11,7 +11,6 @@ on:
 jobs:
   delete-pre-release:
     name: Delete pre-release if exists
-    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Delete pre-release and tag named after branch

--- a/.github/workflows/delete-pr-build-on-close.yml
+++ b/.github/workflows/delete-pr-build-on-close.yml
@@ -5,13 +5,13 @@ name: Delete pre-release when a branch is deleted
 # This workflow action deletes that pre-release when a PR is merged or closed.
 on:
   pull_request:
-    types:
-      - closed
+    # types:
+    #   - closed
 
 jobs:
   delete-pre-release:
     name: Delete pre-release if exists
-    if: github.event.pull_request.merged == true
+    # if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - name: Delete pre-release and tag named after branch
@@ -29,6 +29,9 @@ jobs:
           # Escape tags to create a semantic version
           REF=$(echo "${BRANCH}" | sed 's/\//-/g')
           RELEASE_FOUND=1
+
+          echo "REF=$REF" # TODO: delete
+          exit 0
 
           # Delete tags matching the pull request branch from forks
           if GH_DEBUG=1 gh release --repo="slackapi/slack-cli" delete "${REF}" -y --cleanup-tag; then


### PR DESCRIPTION
### Summary

This PR uses either an upstream or fork PR branch when deleting a pre-release after a pull request is merged.

Fixes an issue where upstream tag names use different convention from forks and also where this workflow runs.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).