### PR TITLE
ci: delete testing fork pre-releases in the upstream context

### DIFF
--- a/.github/workflows/delete-pr-build-on-close.yml
+++ b/.github/workflows/delete-pr-build-on-close.yml
@@ -4,7 +4,7 @@ name: Delete pre-release when a branch is deleted
 # The circleci config builds CLI binaries when a PR is opened and hosts them under a GitHub (pre-)release named after the PR branch
 # This workflow action deletes that pre-release when a PR is merged or closed.
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
 


### PR DESCRIPTION
### Summary

This PR replaces the `pull_request` event with [`pull_request_target`](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request_target) to delete pre-releases in the context of this upstream base branch.

Fixes an [issue](https://github.com/slackapi/slack-cli/pull/48#issuecomment-2814224290) where deleting or closing forked PRs errored with an unauthorized token.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).