### PR TITLE
refactor: remove context.Background() references from hooks

### DIFF
--- a/cmd/app/add_test.go
+++ b/cmd/app/add_test.go
@@ -484,7 +484,7 @@ func prepareAddMocks(t *testing.T, clients *shared.ClientFactory, clientsMock *s
 		Return("logstash host")
 
 	manifestMock := &app.ManifestMockObject{}
-	manifestMock.On("GetManifestLocal", mock.Anything, mock.Anything).Return(types.SlackYaml{
+	manifestMock.On("GetManifestLocal", mock.Anything, mock.Anything, mock.Anything).Return(types.SlackYaml{
 		AppManifest: types.AppManifest{
 			DisplayInformation: types.DisplayInformation{
 				Name: team1TeamDomain,

--- a/cmd/app/uninstall_test.go
+++ b/cmd/app/uninstall_test.go
@@ -44,7 +44,6 @@ var fakeApp = types.App{
 var selectedProdApp = prompts.SelectedApp{Auth: types.SlackAuth{TeamDomain: "team1234"}, App: types.App{AppID: fakeAppID, TeamID: fakeAppTeamID}}
 
 func TestAppsUninstall(t *testing.T) {
-
 	testutil.TableTestCommand(t, testutil.CommandTests{
 		"Successfully uninstall": {
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
@@ -62,7 +61,7 @@ func TestAppsUninstall(t *testing.T) {
 				clientsMock.ApiInterface.On("UninstallApp", mock.Anything, mock.Anything, fakeAppID, fakeAppTeamID).
 					Return(nil).Once()
 				manifestMock := &app.ManifestMockObject{}
-				manifestMock.On("GetManifestLocal", mock.Anything, mock.Anything).
+				manifestMock.On("GetManifestLocal", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.SlackYaml{}, slackerror.New(slackerror.ErrSDKHookNotFound))
 				clients.AppClient().Manifest = manifestMock
 			},

--- a/cmd/datastore/bulk_delete_test.go
+++ b/cmd/datastore/bulk_delete_test.go
@@ -109,6 +109,7 @@ func TestBulkDeleteCommandPreRun(t *testing.T) {
 				"GetManifestLocal",
 				mock.Anything,
 				mock.Anything,
+				mock.Anything,
 			).Return(
 				tt.mockManifestResponse,
 				tt.mockManifestError,

--- a/cmd/datastore/bulk_get_test.go
+++ b/cmd/datastore/bulk_get_test.go
@@ -109,6 +109,7 @@ func TestBulkGetCommandPreRun(t *testing.T) {
 				"GetManifestLocal",
 				mock.Anything,
 				mock.Anything,
+				mock.Anything,
 			).Return(
 				tt.mockManifestResponse,
 				tt.mockManifestError,

--- a/cmd/datastore/bulk_put_test.go
+++ b/cmd/datastore/bulk_put_test.go
@@ -114,6 +114,7 @@ func TestBulkPutCommandPreRun(t *testing.T) {
 				"GetManifestLocal",
 				mock.Anything,
 				mock.Anything,
+				mock.Anything,
 			).Return(
 				tt.mockManifestResponse,
 				tt.mockManifestError,

--- a/cmd/datastore/count_test.go
+++ b/cmd/datastore/count_test.go
@@ -98,6 +98,7 @@ func TestCountCommandPreRun(t *testing.T) {
 				"GetManifestLocal",
 				mock.Anything,
 				mock.Anything,
+				mock.Anything,
 			).Return(
 				tt.mockManifestResponse,
 				tt.mockManifestError,

--- a/cmd/datastore/delete_test.go
+++ b/cmd/datastore/delete_test.go
@@ -111,6 +111,7 @@ func TestDeleteCommandPreRun(t *testing.T) {
 				"GetManifestLocal",
 				mock.Anything,
 				mock.Anything,
+				mock.Anything,
 			).Return(
 				tt.mockManifestResponse,
 				tt.mockManifestError,

--- a/cmd/datastore/get_test.go
+++ b/cmd/datastore/get_test.go
@@ -110,6 +110,7 @@ func TestGetCommandPreRun(t *testing.T) {
 				"GetManifestLocal",
 				mock.Anything,
 				mock.Anything,
+				mock.Anything,
 			).Return(
 				tt.mockManifestResponse,
 				tt.mockManifestError,

--- a/cmd/datastore/put_test.go
+++ b/cmd/datastore/put_test.go
@@ -111,6 +111,7 @@ func TestPutCommandPreRun(t *testing.T) {
 				"GetManifestLocal",
 				mock.Anything,
 				mock.Anything,
+				mock.Anything,
 			).Return(
 				tt.mockManifestResponse,
 				tt.mockManifestError,

--- a/cmd/datastore/query_test.go
+++ b/cmd/datastore/query_test.go
@@ -116,6 +116,7 @@ func TestQueryCommandPreRun(t *testing.T) {
 				"GetManifestLocal",
 				mock.Anything,
 				mock.Anything,
+				mock.Anything,
 			).Return(
 				tt.mockManifestResponse,
 				tt.mockManifestError,

--- a/cmd/datastore/update_test.go
+++ b/cmd/datastore/update_test.go
@@ -111,6 +111,7 @@ func TestUpdateCommandPreRun(t *testing.T) {
 				"GetManifestLocal",
 				mock.Anything,
 				mock.Anything,
+				mock.Anything,
 			).Return(
 				tt.mockManifestResponse,
 				tt.mockManifestError,

--- a/cmd/doctor/check_test.go
+++ b/cmd/doctor/check_test.go
@@ -206,7 +206,7 @@ func TestDoctorCheckProjectDeps(t *testing.T) {
 				mockHookUpdate := `{"name": "deno_slack_hooks", "current": "2.6.0", "latest": "2.7.0", "breaking": false, "update": true}`
 				mockUpdate := fmt.Sprintf(`{"name": "the Slack SDK", "releases": [%s, %s, %s]}`, mockSDKUpdate, mockAPIUpdate, mockHookUpdate)
 				mockUpdateScript := hooks.HookScript{Command: "echo updates"}
-				cm.HookExecutor.On("Execute", hooks.HookExecOpts{Hook: mockUpdateScript}).
+				cm.HookExecutor.On("Execute", mock.Anything, hooks.HookExecOpts{Hook: mockUpdateScript}).
 					Return(mockUpdate, nil)
 				return shared.NewClientFactory(cm.MockClientFactory(), func(clients *shared.ClientFactory) {
 					clients.SDKConfig.WorkingDirectory = "."
@@ -351,7 +351,7 @@ func TestDoctorCheckProjectTooling(t *testing.T) {
 			mockHookSetup: func(cm *shared.ClientsMock) *shared.ClientFactory {
 				mockDoctorHook := `{"versions": [{"name": "deno", "current": "1.0.0"}, {"name": "typescript", "current": "5.4.3"}]}`
 				mockDoctorScript := hooks.HookScript{Command: "echo checkup"}
-				cm.HookExecutor.On("Execute", hooks.HookExecOpts{Hook: mockDoctorScript}).
+				cm.HookExecutor.On("Execute", mock.Anything, hooks.HookExecOpts{Hook: mockDoctorScript}).
 					Return(mockDoctorHook, nil)
 				return shared.NewClientFactory(cm.MockClientFactory(), func(clients *shared.ClientFactory) {
 					clients.SDKConfig.WorkingDirectory = "."
@@ -379,7 +379,7 @@ func TestDoctorCheckProjectTooling(t *testing.T) {
 			mockHookSetup: func(cm *shared.ClientsMock) *shared.ClientFactory {
 				mockDoctorHook := `{"versions": [{"name": "deno", "current": "1.0.0", "message": "Secure runtimes make safer code", "error": {"message": "Something isn't right with this installation"}}]}`
 				mockDoctorScript := hooks.HookScript{Command: "echo checkup"}
-				cm.HookExecutor.On("Execute", hooks.HookExecOpts{Hook: mockDoctorScript}).
+				cm.HookExecutor.On("Execute", mock.Anything, hooks.HookExecOpts{Hook: mockDoctorScript}).
 					Return(mockDoctorHook, nil)
 				return shared.NewClientFactory(cm.MockClientFactory(), func(clients *shared.ClientFactory) {
 					clients.SDKConfig.WorkingDirectory = "."

--- a/cmd/doctor/doctor.go
+++ b/cmd/doctor/doctor.go
@@ -167,7 +167,7 @@ func doctorHook(ctx context.Context, clients *shared.ClientFactory) (DoctorHookJ
 	var hookExecOpts = hooks.HookExecOpts{
 		Hook: clients.SDKConfig.Hooks.Doctor,
 	}
-	getDoctorHookJSON, err := clients.HookExecutor.Execute(hookExecOpts)
+	getDoctorHookJSON, err := clients.HookExecutor.Execute(ctx, hookExecOpts)
 	if err != nil {
 		return DoctorHookJSON{}, err
 	}

--- a/cmd/doctor/doctor_test.go
+++ b/cmd/doctor/doctor_test.go
@@ -74,11 +74,11 @@ func TestDoctorCommand(t *testing.T) {
 		clientsMock.Config.SystemConfig = scm
 		mockDoctorScript := hooks.HookScript{Command: "echo checkup"}
 		mockDoctorHook := `{"versions": [{"name": "node", "current": "20.11.1"}]}`
-		clientsMock.HookExecutor.On("Execute", hooks.HookExecOpts{Hook: mockDoctorScript}).
+		clientsMock.HookExecutor.On("Execute", mock.Anything, hooks.HookExecOpts{Hook: mockDoctorScript}).
 			Return(mockDoctorHook, nil)
 		mockUpdateScript := hooks.HookScript{Command: "echo update"}
 		mockUpdateHook := `{"name": "the Slack SDK", "releases": [{"name": "@slack/bolt", "current": "1.0.0", "latest": "2.2.2", "breaking": true, "update": true}]}`
-		clientsMock.HookExecutor.On("Execute", hooks.HookExecOpts{Hook: mockUpdateScript}).
+		clientsMock.HookExecutor.On("Execute", mock.Anything, hooks.HookExecOpts{Hook: mockUpdateScript}).
 			Return(mockUpdateHook, nil)
 		clients := shared.NewClientFactory(clientsMock.MockClientFactory(), func(clients *shared.ClientFactory) {
 			clients.SDKConfig.WorkingDirectory = "."
@@ -357,7 +357,7 @@ func TestDoctorHook(t *testing.T) {
 			mockHookSetup: func(cm *shared.ClientsMock) *shared.ClientFactory {
 				mockDoctorHook := `{"versions": [{"name": "deno", "current": "1.0.0"}, {"name": "typescript", "current": "5.4.3"}]}`
 				mockDoctorScript := hooks.HookScript{Command: "echo checkup"}
-				cm.HookExecutor.On("Execute", hooks.HookExecOpts{Hook: mockDoctorScript}).
+				cm.HookExecutor.On("Execute", mock.Anything, hooks.HookExecOpts{Hook: mockDoctorScript}).
 					Return(mockDoctorHook, nil)
 				return shared.NewClientFactory(cm.MockClientFactory(), func(clients *shared.ClientFactory) {
 					clients.SDKConfig.WorkingDirectory = "."
@@ -390,7 +390,7 @@ func TestDoctorHook(t *testing.T) {
 			mockHookSetup: func(cm *shared.ClientsMock) *shared.ClientFactory {
 				mockDoctorHook := `{"versions": [{"name": "deno", "current": "1.0.0", "message": "Secure runtimes make safer code", "error": {"message": "Something isn't right with this installation"}}]}`
 				mockDoctorScript := hooks.HookScript{Command: "echo checkup"}
-				cm.HookExecutor.On("Execute", hooks.HookExecOpts{Hook: mockDoctorScript}).
+				cm.HookExecutor.On("Execute", mock.Anything, hooks.HookExecOpts{Hook: mockDoctorScript}).
 					Return(mockDoctorHook, nil)
 				return shared.NewClientFactory(cm.MockClientFactory(), func(clients *shared.ClientFactory) {
 					clients.SDKConfig.WorkingDirectory = "."

--- a/cmd/env/add_test.go
+++ b/cmd/env/add_test.go
@@ -111,6 +111,7 @@ func Test_Env_AddCommandPreRun(t *testing.T) {
 				"GetManifestLocal",
 				mock.Anything,
 				mock.Anything,
+				mock.Anything,
 			).Return(
 				tt.mockManifestResponse,
 				tt.mockManifestError,

--- a/cmd/env/list_test.go
+++ b/cmd/env/list_test.go
@@ -98,6 +98,7 @@ func Test_Env_ListCommandPreRun(t *testing.T) {
 				"GetManifestLocal",
 				mock.Anything,
 				mock.Anything,
+				mock.Anything,
 			).Return(
 				tt.mockManifestResponse,
 				tt.mockManifestError,

--- a/cmd/env/remove_test.go
+++ b/cmd/env/remove_test.go
@@ -99,6 +99,7 @@ func Test_Env_RemoveCommandPreRun(t *testing.T) {
 				"GetManifestLocal",
 				mock.Anything,
 				mock.Anything,
+				mock.Anything,
 			).Return(
 				tt.mockManifestResponse,
 				tt.mockManifestError,

--- a/cmd/externalauth/add_secret_test.go
+++ b/cmd/externalauth/add_secret_test.go
@@ -99,6 +99,7 @@ func TestExternalAuthAddClientSecretCommandPreRun(t *testing.T) {
 				"GetManifestLocal",
 				mock.Anything,
 				mock.Anything,
+				mock.Anything,
 			).Return(
 				tt.mockManifestResponse,
 				tt.mockManifestError,

--- a/cmd/externalauth/add_test.go
+++ b/cmd/externalauth/add_test.go
@@ -99,6 +99,7 @@ func TestExternalAuthAddCommandPreRun(t *testing.T) {
 				"GetManifestLocal",
 				mock.Anything,
 				mock.Anything,
+				mock.Anything,
 			).Return(
 				tt.mockManifestResponse,
 				tt.mockManifestError,

--- a/cmd/externalauth/remove_test.go
+++ b/cmd/externalauth/remove_test.go
@@ -98,6 +98,7 @@ func TestExternalAuthRemoveCommandPreRun(t *testing.T) {
 				"GetManifestLocal",
 				mock.Anything,
 				mock.Anything,
+				mock.Anything,
 			).Return(
 				tt.mockManifestResponse,
 				tt.mockManifestError,

--- a/cmd/externalauth/select_auth_test.go
+++ b/cmd/externalauth/select_auth_test.go
@@ -99,6 +99,7 @@ func TestExternalAuthSelectAuthCommandPreRun(t *testing.T) {
 				"GetManifestLocal",
 				mock.Anything,
 				mock.Anything,
+				mock.Anything,
 			).Return(
 				tt.mockManifestResponse,
 				tt.mockManifestError,

--- a/cmd/manifest/info.go
+++ b/cmd/manifest/info.go
@@ -106,7 +106,7 @@ func getManifestInfo(ctx context.Context, clients *shared.ClientFactory, cmd *co
 	}
 	switch {
 	case source.Equals(config.MANIFEST_SOURCE_LOCAL):
-		return getManifestInfoProject(clients)
+		return getManifestInfoProject(ctx, clients)
 	case source.Equals(config.MANIFEST_SOURCE_REMOTE):
 		return getManifestInfoRemote(ctx, clients)
 	default:
@@ -115,8 +115,9 @@ func getManifestInfo(ctx context.Context, clients *shared.ClientFactory, cmd *co
 }
 
 // getManifestInfoProject gathers app manifest information from "get-manifest"
-func getManifestInfoProject(clients *shared.ClientFactory) (types.AppManifest, error) {
+func getManifestInfoProject(ctx context.Context, clients *shared.ClientFactory) (types.AppManifest, error) {
 	slackManifest, err := clients.AppClient().Manifest.GetManifestLocal(
+		ctx,
 		clients.SDKConfig,
 		clients.HookExecutor,
 	)

--- a/cmd/manifest/info_test.go
+++ b/cmd/manifest/info_test.go
@@ -52,7 +52,7 @@ func TestInfoCommand(t *testing.T) {
 			CmdArgs: []string{"--source", "paper"},
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
 				cf.SDKConfig = hooks.NewSDKConfigMock()
-				cm.HookExecutor.On("Execute", mock.Anything).Return("", nil)
+				cm.HookExecutor.On("Execute", mock.Anything, mock.Anything).Return("", nil)
 			},
 			ExpectedError: slackerror.New(slackerror.ErrInvalidFlag).
 				WithMessage("The \"--source\" flag must be \"local\" or \"remote\""),
@@ -61,7 +61,7 @@ func TestInfoCommand(t *testing.T) {
 			CmdArgs: []string{"--source", "local"},
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
 				manifestMock := &app.ManifestMockObject{}
-				manifestMock.On("GetManifestLocal", mock.Anything, mock.Anything).Return(types.SlackYaml{
+				manifestMock.On("GetManifestLocal", mock.Anything, mock.Anything, mock.Anything).Return(types.SlackYaml{
 					AppManifest: types.AppManifest{
 						DisplayInformation: types.DisplayInformation{
 							Name: "app001",
@@ -125,7 +125,7 @@ func TestInfoCommand(t *testing.T) {
 				cm.Os.AddDefaultMocks()
 				cf.SDKConfig.WorkingDirectory = "."
 				manifestMock := &app.ManifestMockObject{}
-				manifestMock.On("GetManifestLocal", mock.Anything, mock.Anything).Return(types.SlackYaml{
+				manifestMock.On("GetManifestLocal", mock.Anything, mock.Anything, mock.Anything).Return(types.SlackYaml{
 					AppManifest: types.AppManifest{
 						DisplayInformation: types.DisplayInformation{
 							Name: "app002",

--- a/cmd/platform/deploy.go
+++ b/cmd/platform/deploy.go
@@ -164,7 +164,7 @@ func hasValidDeploymentMethod(
 	}
 	switch {
 	case manifestSource.Equals(config.MANIFEST_SOURCE_LOCAL):
-		manifest, err = clients.AppClient().Manifest.GetManifestLocal(clients.SDKConfig, clients.HookExecutor)
+		manifest, err = clients.AppClient().Manifest.GetManifestLocal(ctx, clients.SDKConfig, clients.HookExecutor)
 		if err != nil {
 			return err
 		}
@@ -212,7 +212,7 @@ func deployHook(ctx context.Context, clients *shared.ClientFactory) (*logger.Log
 	shell := hooks.HookExecutorDefaultProtocol{
 		IO: clients.IO,
 	}
-	if _, err := shell.Execute(hookExecOpts); err != nil {
+	if _, err := shell.Execute(ctx, hookExecOpts); err != nil {
 		return &log, err
 	}
 	// Follow successful hook executions with a newline to match section formatting

--- a/cmd/platform/deploy_test.go
+++ b/cmd/platform/deploy_test.go
@@ -87,7 +87,7 @@ func TestDeployCommand(t *testing.T) {
 	teamAppSelectPromptFunc = appSelectMock.TeamAppSelectPrompt
 
 	manifestMock := &app.ManifestMockObject{}
-	manifestMock.On("GetManifestLocal", mock.Anything, mock.Anything).Return(types.SlackYaml{
+	manifestMock.On("GetManifestLocal", mock.Anything, mock.Anything, mock.Anything).Return(types.SlackYaml{
 		AppManifest: types.AppManifest{
 			Settings: &types.AppSettings{
 				FunctionRuntime: types.SLACK_HOSTED,
@@ -150,7 +150,7 @@ func TestDeployCommand_HasValidDeploymentMethod(t *testing.T) {
 			clientsMock := shared.NewClientsMock()
 			clients := shared.NewClientFactory(clientsMock.MockClientFactory(), func(clients *shared.ClientFactory) {
 				manifestMock := &app.ManifestMockObject{}
-				manifestMock.On("GetManifestLocal", mock.Anything, mock.Anything).Return(tt.manifest, tt.manifestError)
+				manifestMock.On("GetManifestLocal", mock.Anything, mock.Anything, mock.Anything).Return(tt.manifest, tt.manifestError)
 				clients.AppClient().Manifest = manifestMock
 				projectConfigMock := config.NewProjectConfigMock()
 				projectConfigMock.On("GetManifestSource", mock.Anything).

--- a/cmd/triggers/create.go
+++ b/cmd/triggers/create.go
@@ -123,7 +123,7 @@ func runCreateCommand(clients *shared.ClientFactory, cmd *cobra.Command) error {
 
 	var triggerArg api.TriggerRequest
 	if createFlags.triggerDef != "" {
-		triggerArg, err = triggerRequestFromDef(clients, createFlags, app.IsDev)
+		triggerArg, err = triggerRequestFromDef(ctx, clients, createFlags, app.IsDev)
 		if err != nil {
 			return err
 		}
@@ -305,7 +305,7 @@ func triggerRequestFromFlags(flags createCmdFlags, isDev bool) api.TriggerReques
 	return req
 }
 
-func triggerRequestViaHook(clients *shared.ClientFactory, path string, isDev bool) (api.TriggerRequest, error) {
+func triggerRequestViaHook(ctx context.Context, clients *shared.ClientFactory, path string, isDev bool) (api.TriggerRequest, error) {
 	if !clients.SDKConfig.Hooks.GetTrigger.IsAvailable() {
 		return api.TriggerRequest{}, slackerror.New(slackerror.ErrSDKHookGetTriggerNotFound)
 	}
@@ -319,6 +319,7 @@ func triggerRequestViaHook(clients *shared.ClientFactory, path string, isDev boo
 		hookExecOpts.Env[name] = val
 	}
 	triggerDefAsStr, err := clients.HookExecutor.Execute(
+		ctx,
 		hookExecOpts,
 	)
 	if err != nil {
@@ -350,10 +351,10 @@ func triggerRequestFromJSONFile(clients *shared.ClientFactory, path string, isDe
 	return req, nil
 }
 
-func triggerRequestFromDef(clients *shared.ClientFactory, flags createCmdFlags, isDev bool) (api.TriggerRequest, error) {
+func triggerRequestFromDef(ctx context.Context, clients *shared.ClientFactory, flags createCmdFlags, isDev bool) (api.TriggerRequest, error) {
 	if strings.HasSuffix(flags.triggerDef, ".json") {
 		return triggerRequestFromJSONFile(clients, flags.triggerDef, isDev)
 	}
 
-	return triggerRequestViaHook(clients, flags.triggerDef, isDev)
+	return triggerRequestViaHook(ctx, clients, flags.triggerDef, isDev)
 }

--- a/cmd/triggers/create_test.go
+++ b/cmd/triggers/create_test.go
@@ -256,7 +256,7 @@ func TestTriggersCreateCommand(t *testing.T) {
 				appSelectTeardown = setupMockCreateAppSelection(installedProdApp)
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
-				clientsMock.HookExecutor.On("Execute", mock.Anything).Return("", nil)
+				clientsMock.HookExecutor.On("Execute", mock.Anything, mock.Anything).Return("", nil)
 				err := clients.AppClient().SaveDeployed(ctx, fakeApp)
 				require.NoError(t, err, "Cant write apps.json")
 			},
@@ -275,7 +275,7 @@ func TestTriggersCreateCommand(t *testing.T) {
 					Return(types.EVERYONE, []string{}, nil).Once()
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
-				clientsMock.HookExecutor.On("Execute", mock.Anything).Return(`{}`, nil)
+				clientsMock.HookExecutor.On("Execute", mock.Anything, mock.Anything).Return(`{}`, nil)
 				err := clients.AppClient().SaveDeployed(ctx, fakeApp)
 				require.NoError(t, err, "Cant write apps.json")
 				var content = `export default {}`
@@ -287,7 +287,7 @@ func TestTriggersCreateCommand(t *testing.T) {
 				appSelectTeardown()
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.HookExecutor.AssertCalled(t, "Execute", mock.Anything)
+				clientsMock.HookExecutor.AssertCalled(t, "Execute", mock.Anything, mock.Anything)
 				clientsMock.ApiInterface.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything)
 			},
 		},

--- a/cmd/triggers/generate.go
+++ b/cmd/triggers/generate.go
@@ -106,7 +106,7 @@ func TriggerGenerate(ctx context.Context, clients *shared.ClientFactory, app typ
 		selectedTriggerDef = selection.Option
 	}
 
-	triggerArg, err := triggerRequestFromDef(clients, createCmdFlags{triggerDef: selectedTriggerDef}, app.IsDev)
+	triggerArg, err := triggerRequestFromDef(ctx, clients, createCmdFlags{triggerDef: selectedTriggerDef}, app.IsDev)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/triggers/generate_test.go
+++ b/cmd/triggers/generate_test.go
@@ -461,7 +461,7 @@ func prepareMocks(t *testing.T, triggersListResponse []types.DeployedTrigger, gl
 	clientsMock.ApiInterface.On("WorkflowsTriggersList", mock.Anything, mock.Anything, mock.Anything).Return(triggersListResponse, "", nil)
 	clientsMock.Os.On("Glob", mock.Anything).Return(globResponse, nil)
 	clientsMock.ApiInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).Return(triggersCreateResponse, triggersCreateResponseError)
-	clientsMock.HookExecutor.On("Execute", mock.Anything).Return(`{}`, nil)
+	clientsMock.HookExecutor.On("Execute", mock.Anything, mock.Anything).Return(`{}`, nil)
 
 	clientsMock.AddDefaultMocks()
 

--- a/cmd/triggers/update.go
+++ b/cmd/triggers/update.go
@@ -117,7 +117,7 @@ func runUpdateCommand(clients *shared.ClientFactory, cmd *cobra.Command) error {
 
 	var triggerArg api.TriggerRequest
 	if updateFlags.triggerDef != "" {
-		triggerArg, err = triggerRequestFromDef(clients, updateFlags.createCmdFlags, app.IsDev)
+		triggerArg, err = triggerRequestFromDef(ctx, clients, updateFlags.createCmdFlags, app.IsDev)
 		if err != nil {
 			return err
 		}

--- a/cmd/triggers/update_test.go
+++ b/cmd/triggers/update_test.go
@@ -340,7 +340,7 @@ func TestTriggersUpdateCommand(t *testing.T) {
 					Return(types.EVERYONE, []string{}, nil).Once()
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
-				clientsMock.HookExecutor.On("Execute", mock.Anything).Return(`{`, nil)
+				clientsMock.HookExecutor.On("Execute", mock.Anything, mock.Anything).Return(`{`, nil)
 				err := clients.AppClient().SaveDeployed(ctx, fakeApp)
 				require.NoError(t, err, "Cant write apps.json")
 				var content = `export default {}`
@@ -354,7 +354,7 @@ func TestTriggersUpdateCommand(t *testing.T) {
 			},
 
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.HookExecutor.AssertCalled(t, "Execute", mock.Anything)
+				clientsMock.HookExecutor.AssertCalled(t, "Execute", mock.Anything, mock.Anything)
 			},
 		},
 	}, func(clients *shared.ClientFactory) *cobra.Command {

--- a/internal/app/manifest.go
+++ b/internal/app/manifest.go
@@ -34,7 +34,7 @@ type ManifestClient struct {
 }
 
 type ManifestClientInterface interface {
-	GetManifestLocal(sdkConfig hooks.SDKCLIConfig, hookExecutor hooks.HookExecutor) (types.SlackYaml, error)
+	GetManifestLocal(ctx context.Context, sdkConfig hooks.SDKCLIConfig, hookExecutor hooks.HookExecutor) (types.SlackYaml, error)
 	GetManifestRemote(ctx context.Context, token string, appID string) (types.SlackYaml, error)
 }
 
@@ -69,7 +69,7 @@ func NewManifestClient(
 }
 
 // GetManifestLocal gathers manifest content from the "get-manifest" hook
-func (c *ManifestClient) GetManifestLocal(sdkConfig hooks.SDKCLIConfig, hookExecutor hooks.HookExecutor) (types.SlackYaml, error) {
+func (c *ManifestClient) GetManifestLocal(ctx context.Context, sdkConfig hooks.SDKCLIConfig, hookExecutor hooks.HookExecutor) (types.SlackYaml, error) {
 	var sl types.SlackYaml
 
 	if !sdkConfig.Hooks.GetManifest.IsAvailable() {
@@ -91,7 +91,7 @@ func (c *ManifestClient) GetManifestLocal(sdkConfig hooks.SDKCLIConfig, hookExec
 		manifestHookOpts.Env[name] = val
 	}
 
-	slackManifestInfo, err := hookExecutor.Execute(manifestHookOpts)
+	slackManifestInfo, err := hookExecutor.Execute(ctx, manifestHookOpts)
 	if err != nil {
 		return sl, slackerror.New("Failed to get app manifest details. Please check your manifest file.").
 			WithRootCause(err).

--- a/internal/app/manifest_mock.go
+++ b/internal/app/manifest_mock.go
@@ -26,8 +26,8 @@ type ManifestMockObject struct {
 	mock.Mock
 }
 
-func (m *ManifestMockObject) GetManifestLocal(sdkConfig hooks.SDKCLIConfig, hookExecutor hooks.HookExecutor) (types.SlackYaml, error) {
-	args := m.Called(sdkConfig, hookExecutor)
+func (m *ManifestMockObject) GetManifestLocal(ctx context.Context, sdkConfig hooks.SDKCLIConfig, hookExecutor hooks.HookExecutor) (types.SlackYaml, error) {
+	args := m.Called(ctx, sdkConfig, hookExecutor)
 	return args.Get(0).(types.SlackYaml), args.Error(1)
 }
 

--- a/internal/app/manifest_test.go
+++ b/internal/app/manifest_test.go
@@ -109,6 +109,7 @@ func Test_AppManifest_GetManifestLocal(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
+			ctx := slackcontext.MockContext(t.Context())
 			mockManifestEnv := map[string]string{"EXAMPLE": "12"}
 			mockSDKConfig := hooks.NewSDKConfigMock()
 			mockHookExecutor := &hooks.MockHookExecutor{}
@@ -130,7 +131,7 @@ func Test_AppManifest_GetManifestLocal(t *testing.T) {
 			configMock.ManifestEnv = mockManifestEnv
 			manifestClient := NewManifestClient(&api.ApiMock{}, configMock)
 
-			actualManifest, err := manifestClient.GetManifestLocal(mockSDKConfig, mockHookExecutor)
+			actualManifest, err := manifestClient.GetManifestLocal(ctx, mockSDKConfig, mockHookExecutor)
 			if tt.expectedErr != nil {
 				require.Error(t, err)
 				assert.Equal(t,

--- a/internal/app/manifest_test.go
+++ b/internal/app/manifest_test.go
@@ -118,7 +118,7 @@ func Test_AppManifest_GetManifestLocal(t *testing.T) {
 					Name:    "GetManifest",
 					Command: "cat manifest.json",
 				}
-				mockHookExecutor.On("Execute", mock.Anything).
+				mockHookExecutor.On("Execute", mock.Anything, mock.Anything).
 					Return(tt.mockManifestInfo, tt.mockManifestErr)
 			} else {
 				mockSDKConfig.Hooks.GetManifest = hooks.HookScript{Name: "GetManifest"}

--- a/internal/cmdutil/project.go
+++ b/internal/cmdutil/project.go
@@ -31,7 +31,7 @@ func IsSlackHostedProject(ctx context.Context, clients *shared.ClientFactory) er
 	}
 	switch {
 	case manifestSource.Equals(config.MANIFEST_SOURCE_LOCAL):
-		manifest, err := clients.AppClient().Manifest.GetManifestLocal(clients.SDKConfig, clients.HookExecutor)
+		manifest, err := clients.AppClient().Manifest.GetManifestLocal(ctx, clients.SDKConfig, clients.HookExecutor)
 		if err != nil {
 			return err
 		}

--- a/internal/cmdutil/project_test.go
+++ b/internal/cmdutil/project_test.go
@@ -86,6 +86,7 @@ func TestIsSlackHostedProject(t *testing.T) {
 				"GetManifestLocal",
 				mock.Anything,
 				mock.Anything,
+				mock.Anything,
 			).Return(
 				tt.mockManifestResponse,
 				tt.mockManifestError,

--- a/internal/hooks/hook_executor_default.go
+++ b/internal/hooks/hook_executor_default.go
@@ -31,7 +31,7 @@ type HookExecutorDefaultProtocol struct {
 }
 
 // Execute processes the data received by the SDK.
-func (e *HookExecutorDefaultProtocol) Execute(opts HookExecOpts) (string, error) {
+func (e *HookExecutorDefaultProtocol) Execute(ctx context.Context, opts HookExecOpts) (string, error) {
 	cmdArgs, cmdArgVars, cmdEnvVars, err := processExecOpts(opts)
 	if err != nil {
 		return "", err
@@ -41,11 +41,11 @@ func (e *HookExecutorDefaultProtocol) Execute(opts HookExecOpts) (string, error)
 		opts.Exec = ShellExec{}
 	}
 
-	e.IO.PrintDebug(context.Background(),
+	e.IO.PrintDebug(ctx,
 		"starting hook command: %s %s\n", cmdArgs[0], strings.Join(cmdArgVars, " "),
 	)
 	defer func() {
-		e.IO.PrintDebug(context.Background(),
+		e.IO.PrintDebug(ctx,
 			"finished hook command: %s %s\n", cmdArgs[0], strings.Join(cmdArgVars, " "),
 		)
 	}()
@@ -56,14 +56,14 @@ func (e *HookExecutorDefaultProtocol) Execute(opts HookExecOpts) (string, error)
 		Buff: &buffout,
 		Stream: iostreams.BufferedWriter{
 			Buff:   opts.Stdout,
-			Stream: e.IO.WriteDebug(context.Background()),
+			Stream: e.IO.WriteDebug(ctx),
 		},
 	}
 	stderr := iostreams.BufferedWriter{
 		Buff: &bufferr,
 		Stream: iostreams.BufferedWriter{
 			Buff:   opts.Stderr,
-			Stream: e.IO.WriteDebug(context.Background()),
+			Stream: e.IO.WriteDebug(ctx),
 		},
 	}
 

--- a/internal/hooks/hook_executor_v2.go
+++ b/internal/hooks/hook_executor_v2.go
@@ -38,7 +38,7 @@ type HookExecutorMessageBoundaryProtocol struct {
 var generateBoundary = generateMD5FromRandomString
 
 // Execute processes the data received by the SDK.
-func (e *HookExecutorMessageBoundaryProtocol) Execute(opts HookExecOpts) (string, error) {
+func (e *HookExecutorMessageBoundaryProtocol) Execute(ctx context.Context, opts HookExecOpts) (string, error) {
 	cmdArgs, cmdArgVars, cmdEnvVars, err := processExecOpts(opts)
 	if err != nil {
 		return "", err
@@ -51,11 +51,11 @@ func (e *HookExecutorMessageBoundaryProtocol) Execute(opts HookExecOpts) (string
 	boundary := generateBoundary()
 	cmdArgVars = append(cmdArgVars, "--protocol="+HOOK_PROTOCOL_V2.String(), "--boundary="+boundary)
 
-	e.IO.PrintDebug(context.Background(),
+	e.IO.PrintDebug(ctx,
 		"starting hook command: %s %s\n", cmdArgs[0], strings.Join(cmdArgVars, " "),
 	)
 	defer func() {
-		e.IO.PrintDebug(context.Background(),
+		e.IO.PrintDebug(ctx,
 			"finished hook command: %s %s\n", cmdArgs[0], strings.Join(cmdArgVars, " "),
 		)
 	}()
@@ -70,7 +70,7 @@ func (e *HookExecutorMessageBoundaryProtocol) Execute(opts HookExecOpts) (string
 				Bounds: boundary,
 				Stream: opts.Stdout,
 			},
-			Stream: e.IO.WriteDebug(context.Background()),
+			Stream: e.IO.WriteDebug(ctx),
 		},
 	}
 	stderr := iostreams.BufferedWriter{
@@ -80,7 +80,7 @@ func (e *HookExecutorMessageBoundaryProtocol) Execute(opts HookExecOpts) (string
 				Bounds: boundary,
 				Stream: opts.Stderr,
 			},
-			Stream: e.IO.WriteDebug(context.Background()),
+			Stream: e.IO.WriteDebug(ctx),
 		},
 	}
 

--- a/internal/hooks/hook_executor_v2_test.go
+++ b/internal/hooks/hook_executor_v2_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/slackapi/slack-cli/internal/config"
 	"github.com/slackapi/slack-cli/internal/iostreams"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/internal/slackdeps"
 	"github.com/slackapi/slack-cli/internal/slackerror"
 	"github.com/stretchr/testify/assert"
@@ -158,6 +159,7 @@ func Test_Hook_Execute_V2_Protocol(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
+			ctx := slackcontext.MockContext(t.Context())
 			generateBoundary = mockBoundaryStringGenerator
 			fs := slackdeps.NewFsMock()
 			os := slackdeps.NewOsMock()
@@ -167,7 +169,7 @@ func Test_Hook_Execute_V2_Protocol(t *testing.T) {
 			hookExecutor := &HookExecutorMessageBoundaryProtocol{
 				IO: ios,
 			}
-			response, err := hookExecutor.Execute(tt.opts)
+			response, err := hookExecutor.Execute(ctx, tt.opts)
 			tt.check(t, response, err, tt.opts.Exec)
 		})
 	}

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -15,6 +15,7 @@
 package hooks
 
 import (
+	"context"
 	"os"
 	"strings"
 
@@ -23,7 +24,7 @@ import (
 )
 
 type HookExecutor interface {
-	Execute(opts HookExecOpts) (response string, err error)
+	Execute(ctx context.Context, opts HookExecOpts) (response string, err error)
 }
 
 func GetHookExecutor(ios iostreams.IOStreamer, cfg SDKCLIConfig) HookExecutor {

--- a/internal/hooks/shell_mock.go
+++ b/internal/hooks/shell_mock.go
@@ -15,6 +15,7 @@
 package hooks
 
 import (
+	"context"
 	"io"
 
 	"github.com/stretchr/testify/mock"
@@ -83,7 +84,7 @@ type MockHookExecutor struct {
 	mock.Mock
 }
 
-func (m *MockHookExecutor) Execute(opts HookExecOpts) (string, error) {
-	args := m.Called(opts)
+func (m *MockHookExecutor) Execute(ctx context.Context, opts HookExecOpts) (string, error) {
+	args := m.Called(ctx, opts)
 	return args.String(0), args.Error(1)
 }

--- a/internal/pkg/apps/install.go
+++ b/internal/pkg/apps/install.go
@@ -81,7 +81,7 @@ func Install(ctx context.Context, clients *shared.ClientFactory, log *logger.Log
 		app.EnterpriseID = *authSession.EnterpriseID
 	}
 
-	slackYaml, err := clients.AppClient().Manifest.GetManifestLocal(clients.SDKConfig, clients.HookExecutor)
+	slackYaml, err := clients.AppClient().Manifest.GetManifestLocal(ctx, clients.SDKConfig, clients.HookExecutor)
 	if err != nil {
 		return app, "", err
 	}
@@ -365,7 +365,7 @@ func InstallLocalApp(ctx context.Context, clients *shared.ClientFactory, orgGran
 		clients.EventTracker.SetAuthEnterpriseID(*authSession.EnterpriseID)
 	}
 
-	slackYaml, err := clients.AppClient().Manifest.GetManifestLocal(clients.SDKConfig, clients.HookExecutor)
+	slackYaml, err := clients.AppClient().Manifest.GetManifestLocal(ctx, clients.SDKConfig, clients.HookExecutor)
 	if err != nil {
 		return app, api.DeveloperAppInstallResult{}, "", err
 	}
@@ -663,7 +663,7 @@ func shouldCacheManifest(ctx context.Context, clients *shared.ClientFactory, app
 	if manifestSource.Equals(config.MANIFEST_SOURCE_REMOTE) {
 		return false, nil
 	}
-	manifest, err := clients.AppClient().Manifest.GetManifestLocal(clients.SDKConfig, clients.HookExecutor)
+	manifest, err := clients.AppClient().Manifest.GetManifestLocal(ctx, clients.SDKConfig, clients.HookExecutor)
 	if err != nil {
 		return false, err
 	}
@@ -701,7 +701,7 @@ func shouldUpdateManifest(ctx context.Context, clients *shared.ClientFactory, ap
 	if clients.Config.ForceFlag {
 		return true, nil
 	}
-	manifest, err := clients.AppClient().Manifest.GetManifestLocal(clients.SDKConfig, clients.HookExecutor)
+	manifest, err := clients.AppClient().Manifest.GetManifestLocal(ctx, clients.SDKConfig, clients.HookExecutor)
 	if err != nil {
 		return false, err
 	}

--- a/internal/pkg/apps/install_test.go
+++ b/internal/pkg/apps/install_test.go
@@ -535,7 +535,7 @@ func TestInstall(t *testing.T) {
 				)
 			}
 			manifestMock := &app.ManifestMockObject{}
-			manifestMock.On("GetManifestLocal", mock.Anything, mock.Anything).Return(tt.mockManifest, nil)
+			manifestMock.On("GetManifestLocal", mock.Anything, mock.Anything, mock.Anything).Return(tt.mockManifest, nil)
 			clientsMock.AppClient.Manifest = manifestMock
 			mockProjectConfig := config.NewProjectConfigMock()
 			if tt.mockBoltExperiment {
@@ -978,7 +978,7 @@ func TestInstallLocalApp(t *testing.T) {
 				)
 			}
 			manifestMock := &app.ManifestMockObject{}
-			manifestMock.On("GetManifestLocal", mock.Anything, mock.Anything).Return(tt.mockManifest, nil)
+			manifestMock.On("GetManifestLocal", mock.Anything, mock.Anything, mock.Anything).Return(tt.mockManifest, nil)
 			clientsMock.AppClient.Manifest = manifestMock
 			mockProjectConfig := config.NewProjectConfigMock()
 			if tt.mockBoltExperiment {

--- a/internal/pkg/manifest/validate.go
+++ b/internal/pkg/manifest/validate.go
@@ -45,7 +45,7 @@ func ManifestValidate(ctx context.Context, clients *shared.ClientFactory, log *l
 		return nil, nil, slackerror.New(slackerror.ErrAuthToken).WithRootCause(err)
 	}
 
-	slackManifest, err := clients.AppClient().Manifest.GetManifestLocal(clients.SDKConfig, clients.HookExecutor)
+	slackManifest, err := clients.AppClient().Manifest.GetManifestLocal(ctx, clients.SDKConfig, clients.HookExecutor)
 	if err != nil {
 		return nil, nil, slackerror.Wrap(err, slackerror.ErrAppManifestGenerate)
 	}

--- a/internal/pkg/manifest/validate_test.go
+++ b/internal/pkg/manifest/validate_test.go
@@ -35,7 +35,7 @@ func Test_ManifestValidate_GetManifestLocal_Error(t *testing.T) {
 
 	// Mock the manifest to return error on get
 	manifestMock := &app.ManifestMockObject{}
-	manifestMock.On("GetManifestLocal", mock.Anything, mock.Anything).Return(types.SlackYaml{}, slackerror.New("An error"))
+	manifestMock.On("GetManifestLocal", mock.Anything, mock.Anything, mock.Anything).Return(types.SlackYaml{}, slackerror.New("An error"))
 	clients.AppClient().Manifest = manifestMock
 
 	// Test
@@ -248,7 +248,7 @@ func setupCommonMocks(t *testing.T) (ctx context.Context, clients *shared.Client
 
 	// Mock the manifest
 	manifestMock := &app.ManifestMockObject{}
-	manifestMock.On("GetManifestLocal", mock.Anything, mock.Anything).Return(types.SlackYaml{}, nil)
+	manifestMock.On("GetManifestLocal", mock.Anything, mock.Anything, mock.Anything).Return(types.SlackYaml{}, nil)
 	clients.AppClient().Manifest = manifestMock
 
 	// Setup logger

--- a/internal/pkg/platform/deploy.go
+++ b/internal/pkg/platform/deploy.go
@@ -223,7 +223,7 @@ func packageArchive(ctx context.Context, clients *shared.ClientFactory, projectR
 		DstDirPath: tmpDir,
 		AuthTokens: authTokens,
 	}
-	if err := clients.Runtime.PreparePackage(clients.SDKConfig, clients.HookExecutor, preparePackageOpts); err != nil {
+	if err := clients.Runtime.PreparePackage(ctx, clients.SDKConfig, clients.HookExecutor, preparePackageOpts); err != nil {
 		return packageResult{}, slackerror.Wrap(err, "preparing the app package for deployment")
 	}
 

--- a/internal/pkg/platform/localserver.go
+++ b/internal/pkg/platform/localserver.go
@@ -215,7 +215,7 @@ func (r *LocalServer) Listen(ctx context.Context, errChan chan<- error, done cha
 					Stderr: r.clients.IO.WriteSecondary(r.clients.IO.WriteErr()),
 				}
 
-				out, err := r.clients.HookExecutor.Execute(startHookOpts)
+				out, err := r.clients.HookExecutor.Execute(ctx, startHookOpts)
 
 				if err != nil {
 					// Log the error but do not return because the user may be able to recover inside their app code

--- a/internal/pkg/platform/localserver_test.go
+++ b/internal/pkg/platform/localserver_test.go
@@ -273,7 +273,7 @@ func Test_LocalServer_Listen(t *testing.T) {
 				// Simulate receiving an event, then a disconnect message
 				conn.On("ReadMessage").Return(websocket.TextMessage, []byte("{\"type\":\"event\",\"payload\":{}}"), nil).Once()
 				conn.On("ReadMessage").Return(websocket.TextMessage, []byte("{\"type\":\"disconnect\"}"), nil).Once()
-				cm.HookExecutor.On("Execute", mock.Anything).Return("{}", nil)
+				cm.HookExecutor.On("Execute", mock.Anything, mock.Anything).Return("{}", nil)
 			},
 			Test: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, server LocalServer, conn *WebSocketConnMock) {
 				errChan := make(chan error)
@@ -294,7 +294,7 @@ func Test_LocalServer_Listen(t *testing.T) {
 				// Simulate receiving an event, then a disconnect message
 				conn.On("ReadMessage").Return(websocket.TextMessage, []byte("{\"type\":\"event\",\"payload\":{}}"), nil).Once()
 				conn.On("ReadMessage").Return(websocket.TextMessage, []byte("{\"type\":\"disconnect\"}"), nil).Once()
-				cm.HookExecutor.On("Execute", mock.Anything).Return("{}", slackerror.New("typescript error, probably"))
+				cm.HookExecutor.On("Execute", mock.Anything, mock.Anything).Return("{}", slackerror.New("typescript error, probably"))
 			},
 			Test: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, server LocalServer, conn *WebSocketConnMock) {
 				errChan := make(chan error)
@@ -314,7 +314,7 @@ func Test_LocalServer_Listen(t *testing.T) {
 				clients.SDKConfig.Hooks.Start = hooks.HookScript{Command: "echo '{}'", Name: "start"}
 				// Simulate receiving an event, then a disconnect message
 				conn.On("ReadMessage").Return(websocket.TextMessage, []byte("{\"type\":\"event\",\"payload\":{}}"), nil).Once()
-				cm.HookExecutor.On("Execute", mock.Anything).Return("{}", nil)
+				cm.HookExecutor.On("Execute", mock.Anything, mock.Anything).Return("{}", nil)
 				conn.On("WriteMessage", mock.Anything, mock.Anything).Return(slackerror.New("socket pipe severed"))
 			},
 			Test: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, server LocalServer, conn *WebSocketConnMock) {

--- a/internal/runtime/deno/deno.go
+++ b/internal/runtime/deno/deno.go
@@ -103,7 +103,7 @@ func (d *Deno) HooksJSONTemplate() []byte {
 }
 
 // PreparePackage will prepare and copy the app in srcDirPath to dstDirPath as a release-ready bundle.
-func (d *Deno) PreparePackage(sdkConfig hooks.SDKCLIConfig, hookExecutor hooks.HookExecutor, opts types.PreparePackageOpts) error {
+func (d *Deno) PreparePackage(ctx context.Context, sdkConfig hooks.SDKCLIConfig, hookExecutor hooks.HookExecutor, opts types.PreparePackageOpts) error {
 	// Generate the bundle.js in the dstDirPath
 	var packageHookOpts = hooks.HookExecOpts{
 		Directory: opts.SrcDirPath,
@@ -118,7 +118,7 @@ func (d *Deno) PreparePackage(sdkConfig hooks.SDKCLIConfig, hookExecutor hooks.H
 	}
 
 	// Execute the package hook and ignore the output because it's always 0 length
-	_, err := hookExecutor.Execute(packageHookOpts)
+	_, err := hookExecutor.Execute(ctx, packageHookOpts)
 	if err != nil {
 		return err
 	}
@@ -195,7 +195,7 @@ func cacheDenoDependencies(
 			Stdout: &stdout,
 		}
 
-		if _, err := hookExecutor.Execute(hookExecOpts); err != nil {
+		if _, err := hookExecutor.Execute(ctx, hookExecOpts); err != nil {
 			ios.PrintDebug(ctx, "failed to cache project dependencies")
 			return "", err
 		}

--- a/internal/runtime/deno/deno_test.go
+++ b/internal/runtime/deno/deno_test.go
@@ -285,6 +285,8 @@ func Test_Deno_PreparePackage(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			ctx := slackcontext.MockContext(t.Context())
+
 			// Setup SDKConfig
 			mockSDKConfig := hooks.NewSDKConfigMock()
 			mockSDKConfig.Hooks.BuildProject = hooks.HookScript{
@@ -304,7 +306,7 @@ func Test_Deno_PreparePackage(t *testing.T) {
 
 			// Run tests
 			d := New()
-			err := d.PreparePackage(mockSDKConfig, mockHookExecutor, mockOpts)
+			err := d.PreparePackage(ctx, mockSDKConfig, mockHookExecutor, mockOpts)
 
 			// Assertions
 			require.Equal(t, tt.expectedPreparePackageError, err)

--- a/internal/runtime/deno/deno_test.go
+++ b/internal/runtime/deno/deno_test.go
@@ -148,7 +148,7 @@ func Test_Deno_InstallProjectDependencies(t *testing.T) {
 			ios.AddDefaultMocks()
 
 			mockHookExecutor := &hooks.MockHookExecutor{}
-			mockHookExecutor.On("Execute", mock.Anything).Return("text output", tt.hookExecutorError)
+			mockHookExecutor.On("Execute", mock.Anything, mock.Anything).Return("text output", tt.hookExecutorError)
 
 			// Create files
 			for _, filePath := range tt.existingFilePaths {
@@ -296,7 +296,7 @@ func Test_Deno_PreparePackage(t *testing.T) {
 
 			// Setup HookExecutor
 			mockHookExecutor := &hooks.MockHookExecutor{}
-			mockHookExecutor.On("Execute", mock.Anything).Return("text output", tt.hookExecutorError)
+			mockHookExecutor.On("Execute", mock.Anything, mock.Anything).Return("text output", tt.hookExecutorError)
 
 			// Setup
 			mockOpts := types.PreparePackageOpts{}

--- a/internal/runtime/node/node.go
+++ b/internal/runtime/node/node.go
@@ -124,7 +124,7 @@ func (n *Node) HooksJSONTemplate() []byte {
 }
 
 // PreparePackage will prepare and copy the app in projectDirPath to tmpDirPath as a release-ready bundle.
-func (n *Node) PreparePackage(sdkConfig hooks.SDKCLIConfig, hookExecutor hooks.HookExecutor, opts types.PreparePackageOpts) error {
+func (n *Node) PreparePackage(ctx context.Context, sdkConfig hooks.SDKCLIConfig, hookExecutor hooks.HookExecutor, opts types.PreparePackageOpts) error {
 	return nil // Unsupported
 }
 

--- a/internal/runtime/node/node_test.go
+++ b/internal/runtime/node/node_test.go
@@ -291,6 +291,8 @@ func Test_Node_PreparePackage(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			ctx := slackcontext.MockContext(t.Context())
+
 			// Setup SDKConfig
 			mockSDKConfig := hooks.NewSDKConfigMock()
 			mockSDKConfig.Hooks.BuildProject = hooks.HookScript{
@@ -310,7 +312,7 @@ func Test_Node_PreparePackage(t *testing.T) {
 
 			// Run tests
 			d := New()
-			err := d.PreparePackage(mockSDKConfig, mockHookExecutor, mockOpts)
+			err := d.PreparePackage(ctx, mockSDKConfig, mockHookExecutor, mockOpts)
 
 			// Assertions
 			require.Equal(t, tt.expectedPreparePackageError, err)

--- a/internal/runtime/node/node_test.go
+++ b/internal/runtime/node/node_test.go
@@ -302,7 +302,7 @@ func Test_Node_PreparePackage(t *testing.T) {
 
 			// Setup HookExecutor
 			mockHookExecutor := &hooks.MockHookExecutor{}
-			mockHookExecutor.On("Execute", mock.Anything).Return("text output", tt.hookExecutorError)
+			mockHookExecutor.On("Execute", mock.Anything, mock.Anything).Return("text output", tt.hookExecutorError)
 
 			// Setup
 			mockOpts := types.PreparePackageOpts{}

--- a/internal/runtime/node/npm.go
+++ b/internal/runtime/node/npm.go
@@ -59,7 +59,7 @@ func (n *NPMClient) InstallAllPackages(ctx context.Context, dirPath string, hook
 		Directory: dirPath,
 	}
 
-	_, err := hookExecutor.Execute(hookExecOpts)
+	_, err := hookExecutor.Execute(ctx, hookExecOpts)
 	output := strings.TrimSpace(stdout.String())
 
 	if err != nil {
@@ -90,7 +90,7 @@ func (n *NPMClient) InstallDevPackage(ctx context.Context, pkgName string, dirPa
 		Directory: dirPath,
 	}
 
-	_, err := hookExecutor.Execute(hookExecOpts)
+	_, err := hookExecutor.Execute(ctx, hookExecOpts)
 	output := strings.TrimSpace(stdout.String())
 
 	if err != nil {
@@ -121,7 +121,7 @@ func (n *NPMClient) ListPackage(ctx context.Context, pkgName string, dirPath str
 		Directory: dirPath,
 	}
 
-	_, err := hookExecutor.Execute(hookExecOpts)
+	_, err := hookExecutor.Execute(ctx, hookExecOpts)
 	output := strings.TrimSpace(stdout.String())
 
 	if err != nil {

--- a/internal/runtime/node/npm_test.go
+++ b/internal/runtime/node/npm_test.go
@@ -73,9 +73,9 @@ func Test_NPMClient_InstallAllPackages(t *testing.T) {
 
 			// Mock hook
 			mockHookExecutor := &hooks.MockHookExecutor{}
-			mockHookExecutor.On("Execute", mock.Anything).
+			mockHookExecutor.On("Execute", mock.Anything, mock.Anything).
 				Run(func(args mock.Arguments) {
-					opts := args.Get(0).(hooks.HookExecOpts)
+					opts := args.Get(1).(hooks.HookExecOpts)
 					_, err := opts.Stdout.Write([]byte(tt.hookExecuteStdout))
 					require.NoError(t, err)
 				}).
@@ -140,9 +140,9 @@ func Test_NPMClient_InstallDevPackage(t *testing.T) {
 
 			// Mock hook
 			mockHookExecutor := &hooks.MockHookExecutor{}
-			mockHookExecutor.On("Execute", mock.Anything).
+			mockHookExecutor.On("Execute", mock.Anything, mock.Anything).
 				Run(func(args mock.Arguments) {
-					opts := args.Get(0).(hooks.HookExecOpts)
+					opts := args.Get(1).(hooks.HookExecOpts)
 					_, err := opts.Stdout.Write([]byte(tt.hookExecuteStdout))
 					require.NoError(t, err)
 				}).
@@ -214,9 +214,9 @@ func Test_NPMClient_ListPackage(t *testing.T) {
 
 			// Mock hook
 			mockHookExecutor := &hooks.MockHookExecutor{}
-			mockHookExecutor.On("Execute", mock.Anything).
+			mockHookExecutor.On("Execute", mock.Anything, mock.Anything).
 				Run(func(args mock.Arguments) {
-					opts := args.Get(0).(hooks.HookExecOpts)
+					opts := args.Get(1).(hooks.HookExecOpts)
 					_, err := opts.Stdout.Write([]byte(tt.hookExecuteStdout))
 					require.NoError(t, err)
 				}).

--- a/internal/runtime/python/python.go
+++ b/internal/runtime/python/python.go
@@ -163,7 +163,7 @@ func (p *Python) HooksJSONTemplate() []byte {
 }
 
 // PreparePackage will prepare and copy the app in projectDirPath to tmpDirPath as a release-ready bundle.
-func (p *Python) PreparePackage(sdkConfig hooks.SDKCLIConfig, hookExecutor hooks.HookExecutor, opts types.PreparePackageOpts) error {
+func (p *Python) PreparePackage(ctx context.Context, sdkConfig hooks.SDKCLIConfig, hookExecutor hooks.HookExecutor, opts types.PreparePackageOpts) error {
 	return nil // Unsupported
 }
 

--- a/internal/runtime/python/python_test.go
+++ b/internal/runtime/python/python_test.go
@@ -178,7 +178,7 @@ func Test_Python_InstallProjectDependencies(t *testing.T) {
 			ios := iostreams.NewIOStreamsMock(cfg, fs, os)
 
 			mockHookExecutor := &hooks.MockHookExecutor{}
-			mockHookExecutor.On("Execute", mock.Anything).Return("text output", nil)
+			mockHookExecutor.On("Execute", mock.Anything, mock.Anything).Return("text output", nil)
 
 			projectDirPath := "/path/to/project-name"
 
@@ -304,7 +304,7 @@ func Test_Python_PreparePackage(t *testing.T) {
 
 			// Setup HookExecutor
 			mockHookExecutor := &hooks.MockHookExecutor{}
-			mockHookExecutor.On("Execute", mock.Anything).Return("text output", tt.hookExecutorError)
+			mockHookExecutor.On("Execute", mock.Anything, mock.Anything).Return("text output", tt.hookExecutorError)
 
 			// Setup
 			mockOpts := types.PreparePackageOpts{}

--- a/internal/runtime/python/python_test.go
+++ b/internal/runtime/python/python_test.go
@@ -293,6 +293,8 @@ func Test_Python_PreparePackage(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			ctx := slackcontext.MockContext(t.Context())
+
 			// Setup SDKConfig
 			mockSDKConfig := hooks.NewSDKConfigMock()
 			mockSDKConfig.Hooks.BuildProject = hooks.HookScript{
@@ -312,7 +314,7 @@ func Test_Python_PreparePackage(t *testing.T) {
 
 			// Run tests
 			p := New()
-			err := p.PreparePackage(mockSDKConfig, mockHookExecutor, mockOpts)
+			err := p.PreparePackage(ctx, mockSDKConfig, mockHookExecutor, mockOpts)
 
 			// Assertions
 			require.Equal(t, tt.expectedPreparePackageError, err)

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -41,7 +41,7 @@ type Runtime interface {
 	Version() string
 	SetVersion(string)
 	HooksJSONTemplate() []byte
-	PreparePackage(hooks.SDKCLIConfig, hooks.HookExecutor, types.PreparePackageOpts) error
+	PreparePackage(context.Context, hooks.SDKCLIConfig, hooks.HookExecutor, types.PreparePackageOpts) error
 }
 
 // New creates a new runtime using runtimeName to choose the runtime

--- a/internal/shared/clients.go
+++ b/internal/shared/clients.go
@@ -292,7 +292,7 @@ func (c *ClientFactory) InitSDKConfigFromJSON(ctx context.Context, configFileByt
 		defaultExecutor := hooks.HookExecutorDefaultProtocol{
 			IO: c.IO,
 		}
-		if SDKHooksResponse, err = defaultExecutor.Execute(hookExecOpts); err != nil {
+		if SDKHooksResponse, err = defaultExecutor.Execute(ctx, hookExecOpts); err != nil {
 			return err
 		}
 	}

--- a/internal/update/sdk.go
+++ b/internal/update/sdk.go
@@ -131,7 +131,7 @@ func CheckUpdateHook(ctx context.Context, clients *shared.ClientFactory) (SDKRel
 	var hookExecOpts = hooks.HookExecOpts{
 		Hook: clients.SDKConfig.Hooks.CheckUpdate,
 	}
-	checkUpdateResponse, err := clients.HookExecutor.Execute(hookExecOpts)
+	checkUpdateResponse, err := clients.HookExecutor.Execute(ctx, hookExecOpts)
 	if err != nil {
 		return SDKReleaseInfo{}, err
 	}
@@ -164,7 +164,7 @@ func (c *SDKDependency) InstallUpdate(ctx context.Context) error {
 
 		fmt.Print(style.SectionSecondaryf("Starting the auto-update..."))
 
-		installUpdateJSON, err := c.clients.HookExecutor.Execute(hookExecOpts)
+		installUpdateJSON, err := c.clients.HookExecutor.Execute(ctx, hookExecOpts)
 		if err != nil {
 			return err
 		}

--- a/internal/update/sdk_test.go
+++ b/internal/update/sdk_test.go
@@ -285,7 +285,7 @@ func Test_SDK_InstallUpdate(t *testing.T) {
 		clientsMock.HookExecutor.On("Execute", mock.Anything).Return(string(mockInstallUpdateJSON), nil)
 
 		// Execute `install-update` hook
-		_, err := clients.HookExecutor.Execute(hooks.HookExecOpts{Hook: clients.SDKConfig.Hooks.InstallUpdate})
+		_, err := clients.HookExecutor.Execute(ctx, hooks.HookExecOpts{Hook: clients.SDKConfig.Hooks.InstallUpdate})
 		if err != nil {
 			assert.Fail(t, "Running the `install-update` encountered an unexpected error")
 		}

--- a/internal/update/sdk_test.go
+++ b/internal/update/sdk_test.go
@@ -282,7 +282,7 @@ func Test_SDK_InstallUpdate(t *testing.T) {
 		// Mock the returned value from executing the `install-update` hook
 		mockInstallUpdateHook := hooks.HookScript{Command: fmt.Sprintf(`echo %s`, string(mockInstallUpdateJSON))}
 		clients.SDKConfig.Hooks.InstallUpdate = mockInstallUpdateHook
-		clientsMock.HookExecutor.On("Execute", mock.Anything).Return(string(mockInstallUpdateJSON), nil)
+		clientsMock.HookExecutor.On("Execute", mock.Anything, mock.Anything).Return(string(mockInstallUpdateJSON), nil)
 
 		// Execute `install-update` hook
 		_, err := clients.HookExecutor.Execute(ctx, hooks.HookExecOpts{Hook: clients.SDKConfig.Hooks.InstallUpdate})
@@ -307,7 +307,7 @@ func Test_SDK_InstallUpdate(t *testing.T) {
 				assert.Fail(t, "InstallUpdate had unexpected error")
 			}
 
-			clientsMock.HookExecutor.AssertCalled(t, "Execute", mock.Anything)
+			clientsMock.HookExecutor.AssertCalled(t, "Execute", mock.Anything, mock.Anything)
 
 			// TODO :: Test Case: `install-update` hook is available
 			// == TODO :: Assert:  Updates are present; printed output contains updates


### PR DESCRIPTION
### Summary

~~_Draft until after our upcoming release._~~ [Release v3.0.5 is ready](https://github.com/slackapi/slack-cli/releases/tag/v3.0.5)

This pull request updates the `package hooks` by removing all references to `context.Background()`.

### Reviewers

This is a bit of a nasty change, so I've dedicated a PR to it.

The key change updates `.Execute(opts)` to `.Execute(ctx, opts)`. This causes a ripple effect of changes in order to pass `ctx` into the hooks executor. The majority of the changes occur in the tests, where mocks must be updated to work with the new argument. 🪝 

Really appreciate the time of reviewer going through these changes!

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).