### PR TITLE
ci: use environment variables to process pull request conclusions

### DIFF
--- a/.github/workflows/delete-pr-build-on-close.yml
+++ b/.github/workflows/delete-pr-build-on-close.yml
@@ -25,13 +25,16 @@ jobs:
       - name: Delete pre-release and tag named after branch
         env:
           GH_TOKEN: ${{ github.token }}
+          PR_BRANCH: ${{ github.event.pull_request.head.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_REPO: ${{ github.event.pull_request.head.repo.full_name }}
         shell: bash
         run: |
           # Use either an upstream or fork PR branch
-          if [[ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.repository }}" ]]; then
-            BRANCH="pull/${{ github.event.pull_request.number }}/head"
+          if [[ "$PR_REPO" != "slackapi/slack-cli" ]]; then
+            BRANCH="pull/$PR_NUMBER/head"
           else
-            BRANCH="${{ github.event.pull_request.head.ref }}"
+            BRANCH="$PR_BRANCH"
           fi
 
           # Escape tags to create a semantic version


### PR DESCRIPTION
### Summary

This PR uses environment variables to process pull request conclusions when deleting pre-releases while avoiding potential unescaped inputs.

[Reference](https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions?_bhlid=a791b2d00d1463ce9cf1d53929098a0231b0002a#using-secrets-in-a-workflow) 📚

> To escape these special characters, use quoting with your environment variables.

### Notes

This PR is created on a forked branch to check the checked out workflow file used upon merge or deletion otherwise.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).