### PR TITLE
ci: set minimum amount of permission needed for each workflow

### DIFF
--- a/.github/workflows/delete-pr-build-on-close.yml
+++ b/.github/workflows/delete-pr-build-on-close.yml
@@ -21,6 +21,8 @@ jobs:
   delete-pre-release:
     name: Delete pre-release if exists
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Delete pre-release and tag named after branch
         env:

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -7,6 +7,8 @@ jobs:
   golang:
     name: Bump the Golang version
     runs-on: ubuntu-latest
+    permissions:
+      contents: none # Permissions are set with an application token
     steps:
       - name: Gather credentials
         id: credentials

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -17,6 +17,8 @@ jobs:
   execute:
     name: Start tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: none
     steps:
       - name: Trigger CircleCI 'local' workflow
         if: ${{ github.event.inputs.status == 'false' }}

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -10,6 +10,8 @@ jobs:
   check-headers:
     name: Check that license headers are in place
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4.2.2
         with:

--- a/.github/workflows/sync-docs-from-cli-repo.yml
+++ b/.github/workflows/sync-docs-from-cli-repo.yml
@@ -17,7 +17,8 @@ jobs:
   config-sync:
     name: Sync docs to docs site repo
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: read
     steps:
       - name: Generate a GitHub token
         id: ghtoken

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,8 @@ jobs:
   lint-test:
     name: Lints and Unit tests
     runs-on: macos-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4.2.2
         with:
@@ -49,6 +51,8 @@ jobs:
   health-score:
     needs: lint-test
     runs-on: macos-latest
+    permissions:
+      checks: write
     steps:
       - uses: actions/checkout@v4.2.2
       - name: Set up Go

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -53,6 +53,7 @@ jobs:
     runs-on: macos-latest
     permissions:
       checks: write
+      contents: read
     steps:
       - uses: actions/checkout@v4.2.2
       - name: Set up Go

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,3 +1,0 @@
-changelog - a log of changes
-
-1. commit this file for testing a license workflow

--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,0 +1,3 @@
+changelog - a log of changes
+
+1. commit this file for testing a license workflow


### PR DESCRIPTION
### Summary

This PR sets the minimum amount of permission needed for each workflow without breaking the existing steps setup.

### Reviewers

Testing is happening within this PR and notes left below! 👾

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).