### PR TITLE
ci: update upstream documentation if the event referenced on the main branch

### DIFF
--- a/.github/workflows/sync-docs-from-cli-repo.yml
+++ b/.github/workflows/sync-docs-from-cli-repo.yml
@@ -53,7 +53,7 @@ jobs:
           npm run build
 
       - name: Create a pull request
-        if: ${{ github.event.pull_request.merged || github.event_name == 'workflow_dispatch' }}
+        if: ${{ github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' }}
         id: site-pr
         uses: peter-evans/create-pull-request@v7.0.8
         with:

--- a/.github/workflows/sync-docs-from-cli-repo.yml
+++ b/.github/workflows/sync-docs-from-cli-repo.yml
@@ -53,7 +53,7 @@ jobs:
           npm run build
 
       - name: Create a pull request
-        if: ${{ github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' }}
+        if: ${{ github.ref_name == github.event.repository.default_branch || github.event_name == 'workflow_dispatch' }}
         id: site-pr
         uses: peter-evans/create-pull-request@v7.0.8
         with:

--- a/docs/guides/deploying-with-the-slack-cli-and-github-actions.md
+++ b/docs/guides/deploying-with-the-slack-cli-and-github-actions.md
@@ -29,7 +29,7 @@ Once created, copy the link and share it in a Slack channel. You'll see a button
 
 ## Obtain a service token {#obtain-service-token}
 
-To automate subsequent deployments, we'll need to obtain a [service token](/slack-cli/guides/authorizing-the-slack-cli#ci-cd) for the app. 
+To automate subsequent deployments, we'll need to obtain a [service token](/slack-cli/guides/authorizing-the-slack-cli#ci-cd) for the app.
 
 Navigate to the root directory of your project and run the `slack auth token` command. You'll be prompted to run a slash command called `slackauthticket`, similar to the way you authorized your app earlier. Copy that command and run it in Slack, then copy the challenge code you receive and enter it into your terminal. You'll see a service token that starts with `xoxp-` &mdash; make sure you save this token. Note that this token is connected to a specific workspace and organization.
 
@@ -78,7 +78,7 @@ jobs:
         slack deploy -s --token $SLACK_SERVICE_TOKEN
 ```
 
-This file instructs the Slack CLI to deploy the latest revision of your repository to the Slack platform when any changes are pushed to the main branch. 
+This file instructs the Slack CLI to deploy the latest revision of your repository to the Slack platform when any changes are pushed to the main branch.
 
 You can go with any other Linux option you prefer for the GitHub-hosted runner; refer to [About GitHub-hosted runners](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#viewing-available-runners-for-a-repository) for more details.
 
@@ -90,7 +90,7 @@ Your GitHub repository is now set up for team collaboration! Your team members c
 
 ## Further reading {#read}
 
-Check out these articles to expand your knowledge and skills of automated deployments and the Slack CLI: 
+Check out these articles to expand your knowledge and skills of automated deployments and the Slack CLI:
 
 ➡️ [CI/CD overview and setup](https://tools.slack.dev/slack-cli/guides/setting-up-ci-cd-with-the-slack-cli)
 


### PR DESCRIPTION
### Summary

This PR opens more PRs for the **docs** [`sync`](https://github.com/slackapi/slack-cli/actions/workflows/sync-docs-from-cli-repo.yml) workflow if the workflow event happens on the `main` branch. Or if it was a `workflow_dispatch`.

Fixes an issue where changes were not being shared upstream - note no pull request link is created:
https://github.com/slackapi/slack-cli/actions/runs/14581033334/job/40897589695

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).