### PR TITLE
feat: 'app link' supports run-on-slack apps with local manifest source

### DIFF
--- a/cmd/app/link.go
+++ b/cmd/app/link.go
@@ -115,7 +115,7 @@ func LinkCommandRunE(ctx context.Context, clients *shared.ClientFactory, app *ty
 // explaining how to link apps, in case the user declines.
 func LinkAppHeaderSection(ctx context.Context, clients *shared.ClientFactory, shouldConfirm bool) {
 	var secondaryText = []string{
-		"Add an existing app created on app settings",
+		"Add an existing app from app settings",
 		"Find your existing apps at: " + style.Underline("https://api.slack.com/apps"),
 	}
 
@@ -156,10 +156,12 @@ func LinkExistingApp(ctx context.Context, clients *shared.ClientFactory, app *ty
 		}
 	}
 
-	// Confirm to update manifest source to remote
+	// Confirm to update manifest source to remote.
+	// - Update the manifest source to remote when its a GBP project with a local manifest.
+	// - Do not update manifest source for ROSI projects, because they can only be local manifests.
 	manifestSource, err := clients.Config.ProjectConfig.GetManifestSource(ctx)
 
-	if !manifestSource.Equals(config.MANIFEST_SOURCE_REMOTE) || err != nil {
+	if err != nil || (!manifestSource.Equals(config.MANIFEST_SOURCE_REMOTE) && cmdutil.IsSlackHostedProject(ctx, clients) != nil) {
 		// When undefined, the default is config.MANIFEST_SOURCE_LOCAL
 		if !manifestSource.Exists() {
 			manifestSource = config.MANIFEST_SOURCE_LOCAL


### PR DESCRIPTION
### Summary

This pull request updates the **`app link`** command to **work with run-on-Slack apps** that have **a local manifest source**.

Perhaps, this as the beginning of loosening up the `app link` command to not always require a remote manifest source. 

This work came about from the GitHub Issue https://github.com/slackapi/deno-slack-sdk/issues/451. In the issue, I wasn't able to suggest using the `app link` command because it would force the Deno SDK app to have a remote manifest. This seemed silly, since all Deno SDK apps have a local manifest. Since developer can now see their Deno SDK apps in https://api.slack.com/apps, we should allow them to link the app in their project.

### Preview

#### Deno SDK
> Should not display the manifest source warning prompt and should keep manifest source as local

https://github.com/user-attachments/assets/a304ac0c-29c8-4050-bcc3-b5c803ff5fc8

#### Bolt for JavaScript
> Should display the manifest source warning prompt

https://github.com/user-attachments/assets/a9aa8a44-6b1c-4b62-92ab-9a9486376784

### Reviewers

```bash
# Test Deno SDK
$ lack create asdf/ -t slack-samples/deno-starter-template
$ cd asdf/
$ lack app link
# → Confirm NO manifest source prompt
# → CTRL+C (or, extra mile if you want to add an App ID and confirm it's still a local manifest)
# Update manifest source to be remote
$ vim .slack/config.json
# → Change "local" to "remote"
$ lack app link
# → Confirm NO manifest source prompt
# → CTRL+C
$ cd ../
$ rm -rf asdf/

# Test Bolt for JavaScript
$ lack create asdf/ -t slack-samples/bolt-js-custom-function-template
$ cd asdf/
$ lack app link
# → Confirm manifest source prompt
# → CTRL+C
# Update manifest source to be remote
$ vim .slack/config.json
# → Change "local" to "remote"
$ lack app link
# → Confirm NO manifest source prompt
# → CTRL+C
$ cd ../
$ rm -rf asdf/
```

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).