### PR TITLE
refactor: rename root.Execute to root.ExecuteContext

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -323,10 +323,10 @@ func InitConfig(ctx context.Context, clients *shared.ClientFactory, rootCmd *cob
 	return clients.IO.InitLogFile(ctx)
 }
 
-// Execute sets up a cancellable context for use with IOStreams' interrupt channel. It also
-// listens for process interrupts and sends to IOStreams' GetInterruptChannel() for use in
+// ExecuteContext sets up a cancellable context for use with IOStreams' interrupt channel.
+// It listens for process interrupts and sends to IOStreams' GetInterruptChannel() for use in
 // in communicating process interrupts elsewhere in the code.
-func Execute(ctx context.Context, rootCmd *cobra.Command, clients *shared.ClientFactory) {
+func ExecuteContext(ctx context.Context, rootCmd *cobra.Command, clients *shared.ClientFactory) {
 	ctx, cancel := context.WithCancel(ctx)
 
 	completedChan := make(chan bool, 1)      // completed is used for signalling an end to command

--- a/main.go
+++ b/main.go
@@ -73,7 +73,7 @@ func main() {
 	ctx = slackcontext.SetOpenTracingSpan(ctx, span)
 
 	rootCmd, clients := cmd.Init(ctx)
-	cmd.Execute(ctx, rootCmd, clients)
+	cmd.ExecuteContext(ctx, rootCmd, clients)
 }
 
 // TODO(slackcontext) Use closure to pass in the ctx, which includes the sessionID


### PR DESCRIPTION
### Summary

This pull request is a minor refactor that updates our custom `root.Execute(ctx, cmd, clients)` to match the syntax of Cobra. 

In Cobra, when you execute with a provided context, then it should be `root.ExecuteContext(ctx, cmd, clients)`.

This is one of the last _(but not the last)_ pull requests that I'll make around context 😆 

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).