### PR TITLE
refactor: update CobraCommand.Execute to CobraCommand.ExecuteContext

### DIFF
--- a/cmd/app/app_test.go
+++ b/cmd/app/app_test.go
@@ -19,12 +19,14 @@ import (
 
 	"github.com/slackapi/slack-cli/internal/hooks"
 	"github.com/slackapi/slack-cli/internal/shared"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/test/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestWorkspaceCommand(t *testing.T) {
 	// Create mocks
+	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
 
 	// Create clients that is mocked for testing
@@ -40,42 +42,10 @@ func TestWorkspaceCommand(t *testing.T) {
 	listFunc = listPkgMock.List
 	listPkgMock.On("List").Return(nil)
 
-	err := cmd.Execute()
+	err := cmd.ExecuteContext(ctx)
 	if err != nil {
 		assert.Fail(t, "cmd.Execute had unexpected error")
 	}
 
 	listPkgMock.AssertCalled(t, "List")
 }
-
-// TODO: this test may need a stubbed out parent (root) command to get aliasing working
-/*
-func TestPostRunWorkspaceDeprecationMessage(t *testing.T) {
-
-	// Create mocks
-	clientsMock := shared.NewClientsMock()
-	clientsMock.AddDefaultMocks()
-
-	// Create clients that is mocked for testing
-	clients := shared.NewClientFactory(clientsMock.MockClientFactory(), func(clients *shared.ClientFactory) {
-		clients.SDKConfig = hooks.NewSDKConfigMock()
-	})
-	clients.IO = clientsMock.IO
-	cmd := NewCommand(clients)
-	// TODO: could maybe refactor this to the os/fs mocks level to more clearly communicate "fake being in an app directory"
-	cmd.PreRunE = func(cmd *cobra.Command, args []string) error { return nil }
-	args := []string{"team"}
-	cmd.SetArgs(args)
-
-	testutil.MockCmdIO(clientsMock.IO, cmd)
-	listPkgMock := new(ListPkgMock)
-	listFunc = listPkgMock.List
-	listPkgMock.On("List").Return(nil)
-
-	err := cmd.Execute()
-	if err != nil {
-		assert.Fail(t, "cmd.Execute had unexpected error", err.Error())
-	}
-	require.Contains(t, clientsMock.GetStdoutOutput(), "You can now use")
-}
-*/

--- a/cmd/app/list_test.go
+++ b/cmd/app/list_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/slackapi/slack-cli/internal/hooks"
 	"github.com/slackapi/slack-cli/internal/shared"
 	"github.com/slackapi/slack-cli/internal/shared/types"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/test/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -39,6 +40,7 @@ func (m *ListPkgMock) List(ctx context.Context, clients *shared.ClientFactory) (
 
 func TestAppsListCommand(t *testing.T) {
 	// Create mocks
+	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
 
 	// Create clients that is mocked for testing
@@ -54,7 +56,7 @@ func TestAppsListCommand(t *testing.T) {
 	listFunc = listPkgMock.List
 
 	listPkgMock.On("List").Return(nil)
-	err := cmd.Execute()
+	err := cmd.ExecuteContext(ctx)
 	if err != nil {
 		assert.Fail(t, "cmd.Execute had unexpected error")
 	}

--- a/cmd/auth/auth_test.go
+++ b/cmd/auth/auth_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/slackapi/slack-cli/internal/logger"
 	"github.com/slackapi/slack-cli/internal/shared"
 	"github.com/slackapi/slack-cli/internal/shared/types"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/test/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -38,6 +39,7 @@ func (m *listMockObject) MockListFunction(ctx context.Context, clients *shared.C
 
 func TestAuthCommand(t *testing.T) {
 	// Create mocks
+	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
 	clientsMock.AddDefaultMocks()
 
@@ -53,7 +55,7 @@ func TestAuthCommand(t *testing.T) {
 	mock.On("MockListFunction").Return([]types.SlackAuth{}, nil)
 
 	// Execute test
-	err := cmd.Execute()
+	err := cmd.ExecuteContext(ctx)
 	if err != nil {
 		assert.Fail(t, "cmd.Execute had unexpected error")
 	}

--- a/cmd/auth/list_test.go
+++ b/cmd/auth/list_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/slackapi/slack-cli/internal/logger"
 	"github.com/slackapi/slack-cli/internal/shared"
 	"github.com/slackapi/slack-cli/internal/shared/types"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/test/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -38,6 +39,7 @@ func (m *ListPkgMock) List(ctx context.Context, clients *shared.ClientFactory, l
 
 func TestListCommand(t *testing.T) {
 	// Create mocks
+	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
 	clientsMock.AddDefaultMocks()
 
@@ -52,7 +54,7 @@ func TestListCommand(t *testing.T) {
 	listFunc = listPkgMock.List
 
 	listPkgMock.On("List").Return([]types.SlackAuth{}, nil)
-	err := cmd.Execute()
+	err := cmd.ExecuteContext(ctx)
 	if err != nil {
 		assert.Fail(t, "cmd.Execute had unexpected error")
 	}

--- a/cmd/collaborators/collaborators_test.go
+++ b/cmd/collaborators/collaborators_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/slackapi/slack-cli/internal/prompts"
 	"github.com/slackapi/slack-cli/internal/shared"
 	"github.com/slackapi/slack-cli/internal/shared/types"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/internal/slacktrace"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -99,6 +100,7 @@ func TestCollaboratorsCommand(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
+			ctx := slackcontext.MockContext(t.Context())
 			appSelectMock := prompts.NewAppSelectMock()
 			teamAppSelectPromptFunc = appSelectMock.TeamAppSelectPrompt
 			appSelectMock.On("TeamAppSelectPrompt").Return(prompts.SelectedApp{App: tt.app, Auth: types.SlackAuth{}}, nil)
@@ -110,7 +112,7 @@ func TestCollaboratorsCommand(t *testing.T) {
 				clients.SDKConfig = hooks.NewSDKConfigMock()
 			})
 
-			err := NewCommand(clients).Execute()
+			err := NewCommand(clients).ExecuteContext(ctx)
 			require.NoError(t, err)
 			clientsMock.ApiInterface.AssertCalled(t, "ListCollaborators", mock.Anything, mock.Anything, tt.app.AppID)
 			clientsMock.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.CollaboratorListSuccess, mock.Anything)

--- a/cmd/collaborators/list_test.go
+++ b/cmd/collaborators/list_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/slackapi/slack-cli/internal/prompts"
 	"github.com/slackapi/slack-cli/internal/shared"
 	"github.com/slackapi/slack-cli/internal/shared/types"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/internal/slacktrace"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -99,6 +100,7 @@ func TestListCommand(t *testing.T) {
 
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
+			ctx := slackcontext.MockContext(t.Context())
 			appSelectMock := prompts.NewAppSelectMock()
 			teamAppSelectPromptFunc = appSelectMock.TeamAppSelectPrompt
 			appSelectMock.On("TeamAppSelectPrompt").Return(prompts.SelectedApp{App: tt.app, Auth: types.SlackAuth{}}, nil)
@@ -110,7 +112,7 @@ func TestListCommand(t *testing.T) {
 				clients.SDKConfig = hooks.NewSDKConfigMock()
 			})
 
-			err := NewListCommand(clients).Execute()
+			err := NewListCommand(clients).ExecuteContext(ctx)
 			require.NoError(t, err)
 			clientsMock.ApiInterface.AssertCalled(t, "ListCollaborators", mock.Anything, mock.Anything, tt.app.AppID)
 			clientsMock.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.CollaboratorListSuccess, mock.Anything)

--- a/cmd/datastore/bulk_delete_test.go
+++ b/cmd/datastore/bulk_delete_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/slackapi/slack-cli/internal/logger"
 	"github.com/slackapi/slack-cli/internal/shared"
 	"github.com/slackapi/slack-cli/internal/shared/types"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/internal/slackerror"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -174,6 +175,7 @@ func TestBulkDeleteCommand(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
+			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := setupDatastoreMocks()
 			if tt.Setup != nil {
 				tt.Setup(clientsMock)
@@ -194,7 +196,7 @@ func TestBulkDeleteCommand(t *testing.T) {
 			clients.IO.SetCmdIO(cmd)
 
 			// Create mocked command
-			err := cmd.Execute()
+			err := cmd.ExecuteContext(ctx)
 			if assert.NoError(t, err) {
 				bulkDeleteMock.AssertCalled(t, "BulkDelete", mock.Anything, mock.Anything, mock.Anything, tt.Query)
 			}

--- a/cmd/datastore/bulk_get_test.go
+++ b/cmd/datastore/bulk_get_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/slackapi/slack-cli/internal/logger"
 	"github.com/slackapi/slack-cli/internal/shared"
 	"github.com/slackapi/slack-cli/internal/shared/types"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/internal/slackerror"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -174,6 +175,7 @@ func TestBulkGetCommand(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
+			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := setupDatastoreMocks()
 			if tt.Setup != nil {
 				tt.Setup(clientsMock)
@@ -194,7 +196,7 @@ func TestBulkGetCommand(t *testing.T) {
 			clients.IO.SetCmdIO(cmd)
 
 			// Perform test
-			err := cmd.Execute()
+			err := cmd.ExecuteContext(ctx)
 			if assert.NoError(t, err) {
 				bulkGetMock.AssertCalled(t, "BulkGet", mock.Anything, mock.Anything, mock.Anything, tt.Query)
 			}

--- a/cmd/datastore/bulk_put_test.go
+++ b/cmd/datastore/bulk_put_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/slackapi/slack-cli/internal/logger"
 	"github.com/slackapi/slack-cli/internal/shared"
 	"github.com/slackapi/slack-cli/internal/shared/types"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/internal/slackerror"
 	"github.com/slackapi/slack-cli/test/testutil"
 	"github.com/spf13/afero"
@@ -191,6 +192,7 @@ func TestBulkPutCommand(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
+			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := setupDatastoreMocks()
 			if tt.Setup != nil {
 				tt.Setup(clientsMock)
@@ -211,7 +213,7 @@ func TestBulkPutCommand(t *testing.T) {
 			clients.IO.SetCmdIO(cmd)
 
 			// Perform test
-			err := cmd.Execute()
+			err := cmd.ExecuteContext(ctx)
 			if assert.NoError(t, err) {
 				bulkPutMock.AssertCalled(t, "BulkPut", mock.Anything, mock.Anything, mock.Anything, tt.Query)
 			}

--- a/cmd/datastore/delete_test.go
+++ b/cmd/datastore/delete_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/slackapi/slack-cli/internal/logger"
 	"github.com/slackapi/slack-cli/internal/shared"
 	"github.com/slackapi/slack-cli/internal/shared/types"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/internal/slackerror"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -202,6 +203,7 @@ func TestDeleteCommand(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
+			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := setupDatastoreMocks()
 			if tt.Setup != nil {
 				tt.Setup(clientsMock)
@@ -225,7 +227,7 @@ func TestDeleteCommand(t *testing.T) {
 			clients.IO.SetCmdIO(cmd)
 
 			// Perform test
-			err := cmd.Execute()
+			err := cmd.ExecuteContext(ctx)
 			if assert.NoError(t, err) {
 				deleteMock.AssertCalled(t, "Delete", mock.Anything, mock.Anything, mock.Anything, tt.Query)
 			}

--- a/cmd/datastore/get_test.go
+++ b/cmd/datastore/get_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/slackapi/slack-cli/internal/logger"
 	"github.com/slackapi/slack-cli/internal/shared"
 	"github.com/slackapi/slack-cli/internal/shared/types"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/internal/slackerror"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -201,6 +202,7 @@ func TestGetCommand(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
+			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := setupDatastoreMocks()
 			if tt.Setup != nil {
 				tt.Setup(clientsMock)
@@ -224,7 +226,7 @@ func TestGetCommand(t *testing.T) {
 			clients.IO.SetCmdIO(cmd)
 
 			// Perform test
-			err := cmd.Execute()
+			err := cmd.ExecuteContext(ctx)
 			if assert.NoError(t, err) {
 				getMock.AssertCalled(t, "Get", mock.Anything, mock.Anything, mock.Anything, tt.Query)
 			}

--- a/cmd/datastore/put_test.go
+++ b/cmd/datastore/put_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/slackapi/slack-cli/internal/logger"
 	"github.com/slackapi/slack-cli/internal/shared"
 	"github.com/slackapi/slack-cli/internal/shared/types"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/internal/slackerror"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -220,6 +221,7 @@ func TestPutCommand(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
+			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := setupDatastoreMocks()
 			if tt.Setup != nil {
 				tt.Setup(clientsMock)
@@ -243,7 +245,7 @@ func TestPutCommand(t *testing.T) {
 			clients.IO.SetCmdIO(cmd)
 
 			// Perform test
-			err := cmd.Execute()
+			err := cmd.ExecuteContext(ctx)
 			if assert.NoError(t, err) {
 				putMock.AssertCalled(t, "Put", mock.Anything, mock.Anything, mock.Anything, tt.Query)
 			}

--- a/cmd/datastore/query_test.go
+++ b/cmd/datastore/query_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/slackapi/slack-cli/internal/logger"
 	"github.com/slackapi/slack-cli/internal/shared"
 	"github.com/slackapi/slack-cli/internal/shared/types"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/internal/slackerror"
 	"github.com/slackapi/slack-cli/test/testutil"
 	"github.com/spf13/cobra"
@@ -317,6 +318,7 @@ func TestQueryCommand(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
+			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := setupDatastoreMocks()
 			if tt.Setup != nil {
 				tt.Setup(clientsMock)
@@ -341,7 +343,7 @@ func TestQueryCommand(t *testing.T) {
 			clients.IO.SetCmdIO(cmd)
 
 			// Perform test
-			err := cmd.Execute()
+			err := cmd.ExecuteContext(ctx)
 			if assert.NoError(t, err) {
 				queryMock.AssertCalled(t, "Query", mock.Anything, mock.Anything, mock.Anything, tt.Query)
 			}

--- a/cmd/datastore/update_test.go
+++ b/cmd/datastore/update_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/slackapi/slack-cli/internal/logger"
 	"github.com/slackapi/slack-cli/internal/shared"
 	"github.com/slackapi/slack-cli/internal/shared/types"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/internal/slackerror"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -318,6 +319,7 @@ func TestUpdateCommand(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
+			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := setupDatastoreMocks()
 			if tt.Setup != nil {
 				tt.Setup(clientsMock)
@@ -341,7 +343,7 @@ func TestUpdateCommand(t *testing.T) {
 			clients.IO.SetCmdIO(cmd)
 
 			// Perform test
-			err := cmd.Execute()
+			err := cmd.ExecuteContext(ctx)
 			if assert.NoError(t, err) {
 				updateMock.AssertCalled(t, "Update", mock.Anything, mock.Anything, mock.Anything, tt.Query)
 			}

--- a/cmd/doctor/doctor_test.go
+++ b/cmd/doctor/doctor_test.go
@@ -88,7 +88,7 @@ func TestDoctorCommand(t *testing.T) {
 
 		cmd := NewDoctorCommand(clients)
 		testutil.MockCmdIO(clients.IO, cmd)
-		err := cmd.Execute()
+		err := cmd.ExecuteContext(ctx)
 		require.NoError(t, err)
 
 		report, err := performChecks(ctx, clients)
@@ -300,6 +300,7 @@ func TestDoctorCommand(t *testing.T) {
 	})
 
 	t.Run("errors on broken template", func(t *testing.T) {
+		ctx := slackcontext.MockContext(t.Context())
 		clientsMock := shared.NewClientsMock()
 		clientsMock.AddDefaultMocks()
 		clients := shared.NewClientFactory(clientsMock.MockClientFactory())
@@ -313,7 +314,7 @@ func TestDoctorCommand(t *testing.T) {
 			embedDocTmpl = embedDocTmplHolder
 		}()
 
-		err := cmd.Execute()
+		err := cmd.ExecuteContext(ctx)
 		if assert.Error(t, err) {
 			assert.Contains(t, err.Error(), "function \"BrokenTemplate\" not defined")
 		}

--- a/cmd/externalauth/externalauth_test.go
+++ b/cmd/externalauth/externalauth_test.go
@@ -18,12 +18,14 @@ import (
 	"testing"
 
 	"github.com/slackapi/slack-cli/internal/shared"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/test/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestExternalAuthCommand(t *testing.T) {
 	// Create mocks
+	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
 
 	// Create clients that is mocked for testing
@@ -34,7 +36,7 @@ func TestExternalAuthCommand(t *testing.T) {
 	cmd := NewCommand(clients)
 	testutil.MockCmdIO(clients.IO, cmd)
 
-	err := cmd.Execute()
+	err := cmd.ExecuteContext(ctx)
 	if err != nil {
 		assert.Fail(t, "cmd.Execute had unexpected error")
 	}

--- a/cmd/fingerprint/fingerprint_test.go
+++ b/cmd/fingerprint/fingerprint_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/slackapi/slack-cli/internal/shared"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/test/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -31,6 +32,7 @@ const fingerprintHash_test = "d41d8cd98f00b204e9800998ecf8427e"
 
 func TestFingerprintCommand(t *testing.T) {
 	// Create mocks
+	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
 
 	// Create clients that is mocked for testing
@@ -40,7 +42,7 @@ func TestFingerprintCommand(t *testing.T) {
 	cmd := NewCommand(clients)
 	testutil.MockCmdIO(clients.IO, cmd)
 
-	err := cmd.Execute()
+	err := cmd.ExecuteContext(ctx)
 
 	if err != nil {
 		assert.Fail(t, "cmd.Execute had unexpected error")

--- a/cmd/manifest/validate_test.go
+++ b/cmd/manifest/validate_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/slackapi/slack-cli/internal/prompts"
 	"github.com/slackapi/slack-cli/internal/shared"
 	"github.com/slackapi/slack-cli/internal/shared/types"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/internal/slackerror"
 	"github.com/slackapi/slack-cli/test/testutil"
 	"github.com/stretchr/testify/assert"
@@ -43,6 +44,7 @@ func (m *ManifestValidatePkgMock) ManifestValidate(ctx context.Context, clients 
 
 func TestManifestValidateCommand(t *testing.T) {
 	// Create mocks
+	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
 
 	// Create clients that is mocked for testing
@@ -62,7 +64,7 @@ func TestManifestValidateCommand(t *testing.T) {
 	manifestValidateFunc = manifestValidatePkgMock.ManifestValidate
 
 	manifestValidatePkgMock.On("ManifestValidate", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-	err := cmd.Execute()
+	err := cmd.ExecuteContext(ctx)
 	if err != nil {
 		assert.Fail(t, "cmd.Execute had unexpected error")
 	}
@@ -72,6 +74,7 @@ func TestManifestValidateCommand(t *testing.T) {
 
 func TestManifestValidateCommand_HandleMissingAppInstallError_ZeroUserAuth(t *testing.T) {
 	// Create mocks
+	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
 
 	// Create clients that is mocked for testing
@@ -94,12 +97,13 @@ func TestManifestValidateCommand_HandleMissingAppInstallError_ZeroUserAuth(t *te
 	clientsMock.AddDefaultMocks()
 
 	// A failed selection/prompt should raise an error
-	err := cmd.Execute()
+	err := cmd.ExecuteContext(ctx)
 	require.ErrorContains(t, err, slackerror.ErrNotAuthed)
 }
 
 func TestManifestValidateCommand_HandleMissingAppInstallError_OneUserAuth(t *testing.T) {
 	// Create mocks
+	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
 
 	// Mock one user auths
@@ -137,13 +141,14 @@ func TestManifestValidateCommand_HandleMissingAppInstallError_OneUserAuth(t *tes
 	manifestValidatePkgMock.On("ManifestValidate", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	// Should execute without error
-	err := cmd.Execute()
+	err := cmd.ExecuteContext(ctx)
 	require.NoError(t, err)
 	clientsMock.AuthInterface.AssertCalled(t, "SetSelectedAuth", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
 func TestManifestValidateCommand_HandleMissingAppInstallError_MoreThanOneUserAuth(t *testing.T) {
 	// Create mocks
+	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
 
 	// Create clients that is mocked for testing
@@ -198,13 +203,14 @@ func TestManifestValidateCommand_HandleMissingAppInstallError_MoreThanOneUserAut
 	manifestValidatePkgMock.On("ManifestValidate", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	// Should execute without error
-	err := cmd.Execute()
+	err := cmd.ExecuteContext(ctx)
 	require.NoError(t, err)
 	clientsMock.AuthInterface.AssertCalled(t, "SetSelectedAuth", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
 func TestManifestValidateCommand_HandleOtherErrors(t *testing.T) {
 	// Create mocks
+	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
 	clientsMock.AddDefaultMocks()
 
@@ -223,6 +229,6 @@ func TestManifestValidateCommand_HandleOtherErrors(t *testing.T) {
 	errMsg := "Unrelated error"
 	appSelectMock.On("AppSelectPrompt").Return(prompts.SelectedApp{}, slackerror.New(errMsg))
 
-	err := cmd.Execute()
+	err := cmd.ExecuteContext(ctx)
 	require.ErrorContains(t, err, errMsg)
 }

--- a/cmd/platform/activity_test.go
+++ b/cmd/platform/activity_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/slackapi/slack-cli/internal/prompts"
 	"github.com/slackapi/slack-cli/internal/shared"
 	"github.com/slackapi/slack-cli/internal/shared/types"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/test/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -46,6 +47,7 @@ func (m *ActivityPkgMock) Activity(
 
 func TestActivity_Command(t *testing.T) {
 	// Create mocks
+	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
 
 	// Create clients that is mocked for testing
@@ -65,7 +67,7 @@ func TestActivity_Command(t *testing.T) {
 	appSelectPromptFunc = appSelectMock.AppSelectPrompt
 	appSelectMock.On("AppSelectPrompt").Return(prompts.SelectedApp{}, nil)
 
-	err := cmd.Execute()
+	err := cmd.ExecuteContext(ctx)
 	if err != nil {
 		assert.Fail(t, "cmd.Execute had unexpected error")
 	}

--- a/cmd/platform/deploy_test.go
+++ b/cmd/platform/deploy_test.go
@@ -62,6 +62,7 @@ func (m *AppCmdMock) RunAddCommand(ctx context.Context, clients *shared.ClientFa
 // TODO: improve this test, it only tests the mock that we install ourselves on the function doing all the deploy work is called. Add actual tests here.
 func TestDeployCommand(t *testing.T) {
 	// Create mocks
+	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
 	clientsMock.AddDefaultMocks()
 	clients := shared.NewClientFactory(clientsMock.MockClientFactory(), func(clients *shared.ClientFactory) {
@@ -100,7 +101,7 @@ func TestDeployCommand(t *testing.T) {
 	runAddCommandFunc = appCmdMock.RunAddCommand
 	appCmdMock.On("RunAddCommand").Return()
 
-	err := cmd.Execute()
+	err := cmd.ExecuteContext(ctx)
 	if err != nil {
 		assert.Fail(t, "cmd.Execute had unexpected error", err.Error())
 	}
@@ -231,6 +232,7 @@ func TestDeployCommand_DeployHook(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
+			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := shared.NewClientsMock()
 			clientsMock.AddDefaultMocks()
 			sdkConfigMock := hooks.NewSDKConfigMock()
@@ -259,7 +261,7 @@ func TestDeployCommand_DeployHook(t *testing.T) {
 			cmd.PreRunE = func(cmd *cobra.Command, args []string) error { return nil }
 			testutil.MockCmdIO(clients.IO, cmd)
 
-			err := cmd.Execute()
+			err := cmd.ExecuteContext(ctx)
 			assert.Contains(t, stdoutBuffer.String(), tt.command)
 			if tt.expectedError != nil {
 				require.Error(t, err)

--- a/cmd/platform/platform_test.go
+++ b/cmd/platform/platform_test.go
@@ -18,12 +18,14 @@ import (
 	"testing"
 
 	"github.com/slackapi/slack-cli/internal/shared"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/test/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestPlatformCommand(t *testing.T) {
 	// Create mocks
+	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
 
 	// Create clients that is mocked for testing
@@ -33,7 +35,7 @@ func TestPlatformCommand(t *testing.T) {
 	cmd := NewCommand(clients)
 	testutil.MockCmdIO(clients.IO, cmd)
 
-	err := cmd.Execute()
+	err := cmd.ExecuteContext(ctx)
 	if err != nil {
 		assert.Fail(t, "cmd.Execute had unexpected error")
 	}

--- a/cmd/platform/run_test.go
+++ b/cmd/platform/run_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/slackapi/slack-cli/internal/prompts"
 	"github.com/slackapi/slack-cli/internal/shared"
 	"github.com/slackapi/slack-cli/internal/shared/types"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/internal/slackerror"
 	"github.com/slackapi/slack-cli/internal/style"
 	"github.com/slackapi/slack-cli/test/testutil"
@@ -205,6 +206,7 @@ func TestRunCommand_Flags(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
+			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := shared.NewClientsMock()
 			clientsMock.IO.On("IsTTY").Return(true)
 			clientsMock.IO.AddDefaultMocks()
@@ -227,7 +229,7 @@ func TestRunCommand_Flags(t *testing.T) {
 			cmd.SetArgs(tt.cmdArgs)
 
 			// Execute
-			err := cmd.Execute()
+			err := cmd.ExecuteContext(ctx)
 
 			// Check args passed into the run function
 			if tt.expectedErr == nil {
@@ -243,6 +245,7 @@ func TestRunCommand_Flags(t *testing.T) {
 }
 
 func TestRunCommand_Help(t *testing.T) {
+	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
 	clientsMock.AddDefaultMocks()
 	clients := shared.NewClientFactory(clientsMock.MockClientFactory())
@@ -255,7 +258,7 @@ func TestRunCommand_Help(t *testing.T) {
 	runFunc = runPkgMock.Run
 	runPkgMock.On("Run", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
-	err := cmd.Execute()
+	err := cmd.ExecuteContext(ctx)
 	assert.NoError(t, err)
 	runPkgMock.AssertNotCalled(t, "Run")
 

--- a/cmd/project/create_test.go
+++ b/cmd/project/create_test.go
@@ -42,6 +42,7 @@ func (m *CreateClientMock) Create(ctx context.Context, clients *shared.ClientFac
 
 func TestCreateCommand(t *testing.T) {
 	// Create mocks
+	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
 	clientsMock.AddDefaultMocks()
 
@@ -66,7 +67,7 @@ func TestCreateCommand(t *testing.T) {
 
 	CreateFunc = createClientMock.Create
 
-	err := cmd.Execute()
+	err := cmd.ExecuteContext(ctx)
 	if err != nil {
 		assert.Fail(t, "cmd.Execute had unexpected error")
 	}
@@ -273,7 +274,7 @@ func Test_CreateCommand_BoltExperiment(t *testing.T) {
 
 	CreateFunc = createClientMock.Create
 
-	err := cmd.Execute()
+	err := cmd.ExecuteContext(ctx)
 	if err != nil {
 		assert.Fail(t, "cmd.Execute had unexpected error")
 	}

--- a/cmd/project/samples.go
+++ b/cmd/project/samples.go
@@ -80,5 +80,5 @@ func runSamplesCommand(clients *shared.ClientFactory, cmd *cobra.Command, args [
 	}
 
 	// Execute the `create` command with the set flag
-	return createCmd.Execute()
+	return createCmd.ExecuteContext(ctx)
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -95,7 +95,7 @@ func TestVersionFlags(t *testing.T) {
 
 	// Test --version
 	cmd.SetArgs([]string{"--version"})
-	err := cmd.Execute()
+	err := cmd.ExecuteContext(ctx)
 	if err != nil {
 		assert.Fail(t, "cmd.Execute had unexpected error", err.Error())
 	}
@@ -104,7 +104,7 @@ func TestVersionFlags(t *testing.T) {
 
 	// Test -v
 	cmd.SetArgs([]string{"-v"})
-	err2 := cmd.Execute()
+	err2 := cmd.ExecuteContext(ctx)
 	if err2 != nil {
 		assert.Fail(t, "cmd.Execute had unexpected error", err.Error())
 	}
@@ -129,7 +129,7 @@ func Test_NewSuggestion(t *testing.T) {
 
 	// Execute new command
 	cmd.SetArgs([]string{"new"})
-	err := cmd.Execute()
+	err := cmd.ExecuteContext(ctx)
 
 	require.Error(t, err, "should have error because command not found")
 	require.Regexp(t, `Did you mean this\?\s+create`, err.Error(), "should suggest the create command")
@@ -202,7 +202,7 @@ func testExecCmd(ctx context.Context, args []string) (error, string) {
 	testutil.MockCmdIO(clientsMock.IO, cmd)
 
 	cmd.SetArgs(args)
-	err := cmd.Execute()
+	err := cmd.ExecuteContext(ctx)
 	if err != nil {
 		return err, ""
 	}

--- a/cmd/triggers/triggers_test.go
+++ b/cmd/triggers/triggers_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/slackapi/slack-cli/internal/hooks"
 	"github.com/slackapi/slack-cli/internal/shared"
 	"github.com/slackapi/slack-cli/internal/shared/types"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/test/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -27,6 +28,7 @@ import (
 
 func TestTriggersCommand(t *testing.T) {
 	// Create mocks
+	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
 
 	// Create clients that is mocked for testing
@@ -44,7 +46,7 @@ func TestTriggersCommand(t *testing.T) {
 
 	clientsMock.ApiInterface.On("WorkflowsTriggersList", mock.Anything, mock.Anything, mock.Anything).Return([]types.DeployedTrigger{}, "", nil)
 
-	err := cmd.Execute()
+	err := cmd.ExecuteContext(ctx)
 	if err != nil {
 		assert.Fail(t, "cmd.Execute had unexpected error")
 	}

--- a/cmd/upgrade/upgrade_test.go
+++ b/cmd/upgrade/upgrade_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/slackapi/slack-cli/internal/shared"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/test/testutil"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
@@ -35,6 +36,7 @@ func (m *UpdatePkgMock) CheckForUpdates(clients *shared.ClientFactory, cmd *cobr
 
 func TestUpgradeCommand(t *testing.T) {
 	// Create mocks
+	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
 
 	// Create clients that is mocked for testing
@@ -48,7 +50,7 @@ func TestUpgradeCommand(t *testing.T) {
 	checkForUpdatesFunc = updatePkgMock.CheckForUpdates
 
 	updatePkgMock.On("CheckForUpdates", mock.Anything, mock.Anything).Return(nil)
-	err := cmd.Execute()
+	err := cmd.ExecuteContext(ctx)
 	if err != nil {
 		assert.Fail(t, "cmd.Upgrade had unexpected error")
 	}

--- a/cmd/version/version_test.go
+++ b/cmd/version/version_test.go
@@ -18,12 +18,14 @@ import (
 	"testing"
 
 	"github.com/slackapi/slack-cli/internal/shared"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/test/testutil"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestVersionCommand(t *testing.T) {
 	// Create mocks
+	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
 
 	// Create clients that is mocked for testing
@@ -33,7 +35,7 @@ func TestVersionCommand(t *testing.T) {
 	cmd := NewCommand(clients)
 	testutil.MockCmdIO(clients.IO, cmd)
 
-	err := cmd.Execute()
+	err := cmd.ExecuteContext(ctx)
 	if err != nil {
 		assert.Fail(t, "cmd.Execute had unexpected error")
 	}

--- a/internal/update/sdk_test.go
+++ b/internal/update/sdk_test.go
@@ -322,6 +322,7 @@ func Test_SDK_InstallUpdate(t *testing.T) {
 func Test_SDK_PrintUpdateNotification(t *testing.T) {
 	for i, s := range updateScenarios {
 		// Create mocks
+		ctx := slackcontext.MockContext(t.Context())
 		clientsMock := shared.NewClientsMock()
 
 		// Create clients that is mocked for testing
@@ -346,7 +347,7 @@ func Test_SDK_PrintUpdateNotification(t *testing.T) {
 				assert.Fail(t, "PrintUpdateNotification had unexpected error")
 			}
 
-			err = cmd.Execute()
+			err = cmd.ExecuteContext(ctx)
 			if err != nil {
 				assert.Fail(t, "cmd.Execute had unexpected error")
 			}


### PR DESCRIPTION
### Summary

This pull request updates all `CobraCommand.Execute` references to use `CobraCommand.ExecuteContext`.

While minor, it will help prevent future code from using the `.Execute` syntax and encourage the use of `.ExecuteContext`. As we begin to rely on the context values, this will help ensure consistent and reliable tests.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).