### PR TITLE
build: remove paths to outdated artifacts in makefile clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,6 @@ clean:
 # Initialize project
 .PHONY: init
 init:
-	# Get the latest tags to build correctly
 	git fetch origin --tags
 
 # Run all unit tests
@@ -50,7 +49,6 @@ lint:
 .PHONY: build
 build: lint clean
 	mkdir bin/
-	# set version using the latest tag plus short revision
 	go build -ldflags="$(LDFLAGS)" -o bin/slack
 	SLACK_DISABLE_TELEMETRY="true" ./bin/slack version --skip-update
 
@@ -58,7 +56,6 @@ build: lint clean
 .PHONY: build-ci
 build-ci: clean
 	mkdir bin/
-	# set version using the latest tag plus short revision
 	go build -ldflags="-s -w $(LDFLAGS)" -o bin/slack
 	SLACK_DISABLE_TELEMETRY="true" ./bin/slack version --skip-update
 

--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,6 @@ testname ?= ./...
 # Remove files
 .PHONY: clean
 clean:
-	rm -f ./slack
-	rm -f ./slack-cli
-	rm -f ./hermes
 	rm -rf ./bin/
 	rm -rf ./dist/
 


### PR DESCRIPTION
### Summary

This PR removes references to outdated build artifacts and confusing comments from outputs of `make` commands.

### Preview

```diff
  $ make build
  golangci-lint run
  0 issues.
- rm -f ./slack
- rm -f ./slack-cli
- rm -f ./hermes
  rm -rf ./bin/
  rm -rf ./dist/
  mkdir bin/
- # set version using the latest tag plus short revision
  go build -ldflags="-X 'github.com/slackapi/slack-cli/internal/pkg/version.Version=`git describe --tags --match 'v*.*.*'`'" -o bin/slack
  SLACK_DISABLE_TELEMETRY="true" ./bin/slack version --skip-update
  Using slack v3.0.5-6-g7656d42
```

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).