### PR TITLE
fix: edge-case where cancelled context causes process to hang

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -329,9 +329,9 @@ func InitConfig(ctx context.Context, clients *shared.ClientFactory, rootCmd *cob
 func ExecuteContext(ctx context.Context, rootCmd *cobra.Command, clients *shared.ClientFactory) {
 	// Derive a cancel context that is cancelled when the main execution is interrupted or cleaned up.
 	// Sub-commands can register for the cleanup wait group with clients.CleanupWaitGroup.Add(1)
-	// and listen for <-ctx.Done() to be notified when the main execution is terminated and have
-	// a chance to cleanup. This is useful for long running processes and background goroutines,
-	// the activity and upgrade commands.
+	// and listen for <-ctx.Done() to be notified when the main execution is interrupted, in order
+	// to have a chance to cleanup. This is useful for long running processes and background goroutines,
+	// such as the activity and upgrade commands.
 	ctx, cancel := context.WithCancel(ctx)
 
 	completedChan := make(chan bool, 1)      // completed is used for signalling an end to command

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -327,6 +327,11 @@ func InitConfig(ctx context.Context, clients *shared.ClientFactory, rootCmd *cob
 // It listens for process interrupts and sends to IOStreams' GetInterruptChannel() for use in
 // in communicating process interrupts elsewhere in the code.
 func ExecuteContext(ctx context.Context, rootCmd *cobra.Command, clients *shared.ClientFactory) {
+	// Derive a cancel context that is cancelled when the main execution is interrupted or cleaned up.
+	// Sub-commands can register for the cleanup wait group with clients.CleanupWaitGroup.Add(1)
+	// and listen for <-ctx.Done() to be notified when the main execution is terminated and have
+	// a chance to cleanup. This is useful for long running processes and background goroutines,
+	// the activity and upgrade commands.
 	ctx, cancel := context.WithCancel(ctx)
 
 	completedChan := make(chan bool, 1)      // completed is used for signalling an end to command
@@ -358,19 +363,17 @@ func ExecuteContext(ctx context.Context, rootCmd *cobra.Command, clients *shared
 				clients.IO.PrintDebug(ctx, "Exiting with cancel exit code.")
 				os.Exit(int(iostreams.ExitCancel))
 			}()
-		// Received cancelled context, so send an interrupt signal
-		case <-ctx.Done():
-			clients.IO.PrintDebug(ctx, "Got a cancelled context, sending interrupt signal")
-			interruptChan <- os.Interrupt
 		// Received completed execution, so exit the process successfully
 		case <-completedChan:
 			exitChan <- true
 		}
+
 		// If we get a second interrupt, no matter what exit the process
 		<-interruptChan
 		clients.IO.PrintDebug(ctx, "Got second process interrupt signal, exiting the process")
 		os.Exit(int(iostreams.ExitCancel))
 	}()
+
 	// The cleanup() method in the root command will invoke via `defer` from within Execute.
 	if err := rootCmd.ExecuteContext(ctx); err != nil {
 		errMsg := err.Error()
@@ -393,6 +396,7 @@ func ExecuteContext(ctx context.Context, rootCmd *cobra.Command, clients *shared
 	} else {
 		completedChan <- true
 	}
+
 	<-exitChan
 	_ = clients.EventTracker.FlushToLogstash(ctx, clients.Config, clients.IO, clients.IO.GetExitCode())
 }


### PR DESCRIPTION
### Summary

This pull request fixes a bug in our root command's execution (`.ExecuteContext(...)`) that could cause the Slack CLI to hang indefinitely. However, AFAIK, it's very unlikely for the Slack CLI to hit the edge case to cause the indefinite hang.

The core problem is that `<-ctx.Done()` was not handled, so any cancelled context would cause the Slack CLI to hang waiting for a channel completion or interrupt signal event.

### CHANGELOG

> Fixes a rare edge-case that causes the Slack CLI to hang without exiting the process. Now, the Slack CLI will exit with the correct error code and allow sub-processes to cleanup.

### Reviewers

We don't have tests for this area of the code. I started to add tests, but it requires more refactoring that led to a messy PR. So, I'll save that work for a follow-up PR.

If you want to manually test, then you will need to make a code change that cancels the context causing the Slack CLI to handle the context cancelled channel event.

**cmd/root.go:L373-L374:**
```diff
	clients.IO.PrintDebug(ctx, "Got second process interrupt signal, exiting the process")
	os.Exit(int(iostreams.ExitCancel))
}()
+ cancel()
// The cleanup() method in the root command will invoke via `defer` from within Execute.
if err := rootCmd.ExecuteContext(ctx); err != nil {
```

**Steps for the Reviewer:**
```bash
# Apply the code changes above
$ vim cmd/root.go

# Build the CLI
$ make build
# → It will FAIL because the Slack CLI exits with a non-zero error code from the version command

$ lack version --verbose
[2025-04-22 20:53:02] Got a cancelled context, sending interrupt signal
[2025-04-22 20:53:02] Got second process interrupt signal, exiting the process
# → Confirm the above verbose output
```

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).