### PR TITLE
test: add success and error tests to cmd.ExecuteContext

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -356,7 +356,7 @@ func ExecuteContext(ctx context.Context, rootCmd *cobra.Command, clients *shared
 				clients.IO.PrintDebug(ctx, "... root cleanup waitgroup done.")
 				cleanup(ctx, clients)
 				clients.IO.PrintDebug(ctx, "Exiting with cancel exit code.")
-				os.Exit(int(iostreams.ExitCancel))
+				clients.Os.Exit(int(iostreams.ExitCancel))
 			}()
 		// Received cancelled context, so send an interrupt signal
 		case <-ctx.Done():
@@ -369,7 +369,7 @@ func ExecuteContext(ctx context.Context, rootCmd *cobra.Command, clients *shared
 		// If we get a second interrupt, no matter what exit the process
 		<-interruptChan
 		clients.IO.PrintDebug(ctx, "Got second process interrupt signal, exiting the process")
-		os.Exit(int(iostreams.ExitCancel))
+		clients.Os.Exit(int(iostreams.ExitCancel))
 	}()
 	// The cleanup() method in the root command will invoke via `defer` from within Execute.
 	if err := rootCmd.ExecuteContext(ctx); err != nil {
@@ -388,7 +388,7 @@ func ExecuteContext(ctx context.Context, rootCmd *cobra.Command, clients *shared
 			}
 			clients.IO.PrintError(ctx, errMsg)
 		}
-		defer os.Exit(int(clients.IO.GetExitCode()))
+		defer clients.Os.Exit(int(clients.IO.GetExitCode()))
 		completedChan <- true
 	} else {
 		completedChan <- true

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -118,6 +118,7 @@ func TestExecuteContext(t *testing.T) {
 			output := clientsMock.GetCombinedOutput()
 
 			// Assertions
+			// TODO: Assert that the event tracker was called with the correct exit code
 			require.Equal(t, tt.expectedExitCode, clients.IO.GetExitCode())
 
 			for _, expectedOutput := range tt.expectedOutputs {


### PR DESCRIPTION
### Summary

This pull request adds 2 test-cases to `cmd.ExecuteContext`:

* Command successfully executes
* Command returns an error

We do not test the following test-cases yet because they're a little tricky:

* Interrupt Signal (CTRL+C)
* Cancelled context

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).