### PR TITLE
docs: add comment block to package slackcontext

### DIFF
--- a/internal/slackcontext/slackcontext.go
+++ b/internal/slackcontext/slackcontext.go
@@ -12,6 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package slackcontext defines getters and setters for request-scoped values
+// that are propagated through context.Context during the execution of a Slack
+// command. These values may include identifiers, metadata, host information,
+// and other execution data.
+//
+// All values should be set in the context before a Slack command begins execution.
+// The values can then be accessed throughout the command's execution lifecycle
+// using the provided getter methods.
+//
+// Each value is stored with an unexported key type to prevent collisions with
+// other packages using context values. The package provides type-safe accessors
+// for retrieving these values.
 package slackcontext
 
 import (

--- a/internal/slackcontext/slackcontext.go
+++ b/internal/slackcontext/slackcontext.go
@@ -14,8 +14,8 @@
 
 // Package slackcontext defines getters and setters for request-scoped values
 // that are propagated through context.Context during the execution of a Slack
-// command. These values may include identifiers, metadata, host information,
-// and other execution data.
+// command. These values may include unique identifiers, session metadata, host
+// information, version details, and other execution data.
 //
 // All values should be set in the context before a Slack command begins execution.
 // The values can then be accessed throughout the command's execution lifecycle

--- a/internal/slackcontext/slackcontext.go
+++ b/internal/slackcontext/slackcontext.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package slackcontext defines getters and setters for request-scoped values
+// Package slackcontext defines getters and setters for execution-scoped values
 // that are propagated through context.Context during the execution of a Slack
 // command. These values may include unique identifiers, session metadata, host
 // information, version details, and other execution data.


### PR DESCRIPTION
### Summary

This pull request adds a comment block above `package slackcontext` inspired by Golang's `package context` to describe the purpose and usage of `slackcontext`. Most importantly, I wanted to mention that all values should be set before the execution of a command - we may change this opinion in the future, but for now it's how we're approaching the usage of `ctx`.

### Reviewers

❓ Should be this be labelled as "docs" or "code health"? It's an internal docs, not too different from something like `MAINTAINERS_GUIDE.md`.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).