### PR TITLE
test: assert cmd.ExecuteContext flushes exit code to logstash

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -104,6 +104,7 @@ func TestExecuteContext(t *testing.T) {
 			// Mock clients
 			clientsMock := shared.NewClientsMock()
 			clientsMock.AddDefaultMocks()
+			clientsMock.EventTracker.On("FlushToLogstash", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			clients := shared.NewClientFactory(clientsMock.MockClientFactory())
 
 			// Mock command

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/slackapi/slack-cli/test/testutil"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -118,8 +119,8 @@ func TestExecuteContext(t *testing.T) {
 			output := clientsMock.GetCombinedOutput()
 
 			// Assertions
-			// TODO: Assert that the event tracker was called with the correct exit code
 			require.Equal(t, tt.expectedExitCode, clients.IO.GetExitCode())
+			clientsMock.EventTracker.AssertCalled(t, "FlushToLogstash", mock.Anything, mock.Anything, mock.Anything, tt.expectedExitCode)
 
 			for _, expectedOutput := range tt.expectedOutputs {
 				require.Contains(t, output, expectedOutput)

--- a/internal/iostreams/iostreams_mock.go
+++ b/internal/iostreams/iostreams_mock.go
@@ -118,5 +118,3 @@ func (m *IOStreamsMock) InitLogFile(ctx context.Context) error {
 func (m *IOStreamsMock) FinishLogFile(ctx context.Context) {}
 
 func (m *IOStreamsMock) FlushToLogFile(ctx context.Context, prefix, errStr string) error { return nil }
-
-func (m *IOStreamsMock) FlushToLogstash(ctx context.Context) error { return nil }

--- a/internal/shared/clients_mock.go
+++ b/internal/shared/clients_mock.go
@@ -75,6 +75,7 @@ func (m *ClientsMock) AddDefaultMocks() {
 	m.AuthInterface.AddDefaultMocks()
 	m.Browser.AddDefaultMocks()
 	m.Cobra.AddDefaultMocks()
+	m.EventTracker.AddDefaultMocks()
 	m.IO.AddDefaultMocks()
 	m.Os.AddDefaultMocks()
 }
@@ -86,6 +87,7 @@ func (m *ClientsMock) MockClientFactory() func(c *ClientFactory) {
 		clients.Browser = func() slackdeps.Browser { return m.Browser }
 		clients.Cobra.GenMarkdownTree = m.Cobra.GenMarkdownTree
 		clients.Config = m.Config
+		clients.EventTracker = m.EventTracker
 		clients.Os = m.Os
 		clients.IO = m.IO
 		clients.Fs = m.Fs

--- a/internal/tracking/tracking_mock.go
+++ b/internal/tracking/tracking_mock.go
@@ -28,11 +28,30 @@ type EventTrackerMock struct {
 
 func (m *EventTrackerMock) AddDefaultMocks() {
 	m.On("FlushToLogstash", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	m.On("SetAppEnterpriseID", mock.Anything)
+	m.On("SetAppTeamID", mock.Anything)
+	m.On("SetAppTemplate", mock.Anything)
+	m.On("SetAppUserID", mock.Anything)
+	m.On("SetAuthEnterpriseID", mock.Anything)
+	m.On("SetAuthTeamID", mock.Anything)
+	m.On("SetAuthUserID", mock.Anything)
+	m.On("SetErrorCode", mock.Anything)
+	m.On("SetErrorMessage", mock.Anything)
 }
 
-func (m *EventTrackerMock) FlushToLogstash(ctx context.Context, cfg config.Config, io iostreams.IOStreamer, exitCode iostreams.ExitCode) error {
-	args := m.Called(ctx)
+func (m *EventTrackerMock) FlushToLogstash(ctx context.Context, cfg *config.Config, io iostreams.IOStreamer, exitCode iostreams.ExitCode) error {
+	args := m.Called(ctx, cfg, io, exitCode)
 	return args.Error(0)
+}
+
+func (m *EventTrackerMock) getSessionData() EventData {
+	args := m.Called()
+	return args.Get(0).(EventData)
+}
+
+func (m *EventTrackerMock) cleanSessionData(data EventData) EventData {
+	args := m.Called(data)
+	return args.Get(0).(EventData)
 }
 
 func (m *EventTrackerMock) SetErrorCode(code string) {

--- a/internal/tracking/tracking_mock.go
+++ b/internal/tracking/tracking_mock.go
@@ -27,7 +27,6 @@ type EventTrackerMock struct {
 }
 
 func (m *EventTrackerMock) AddDefaultMocks() {
-	m.On("FlushToLogstash", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	m.On("SetAppEnterpriseID", mock.Anything)
 	m.On("SetAppTeamID", mock.Anything)
 	m.On("SetAppTemplate", mock.Anything)


### PR DESCRIPTION
### Summary

This pull request is a follow-up for https://github.com/slackapi/slack-cli/pull/61#discussion_r2059054925 that asserts `cmd.ExecuteContext` flushes the correct exit code to Logstash.

In order for this to work, we needed to fix the implementation of the `EventTrackerMock` by adding a few missing functions, writing it up to `ClientsMock`, and adding default mocks to allow our existing tests to pass.

I think we're at the point where we can test Logstash flushes throughout the code! 🎉 

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).