### PR TITLE
Fix example command references in enterprise docs

### DIFF
--- a/docs/guides/using-slack-cli-on-an-enterprise-grid-organization.md
+++ b/docs/guides/using-slack-cli-on-an-enterprise-grid-organization.md
@@ -93,13 +93,13 @@ You can also skip the prompt and proactively grant the desired access by appendi
 For running on a local development server:
 
 ```
-slack run -org-workspace-grant <team_id>
+slack run --org-workspace-grant <team_id>
 ```
 
 For deploying to production:
 
 ```
-slack deploy -org-workspace-grant <team_id>
+slack deploy --org-workspace-grant <team_id>
 ```
 
 ## Adjusting access to specific workspaces {#adjusting-access}


### PR DESCRIPTION
### Summary

Small update to fix example command references which were not using double hyphen for org workspace grant flag.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).