### PR TITLE
feat: update 'feedback' command to include feedback about the Slack CLI

### DIFF
--- a/cmd/feedback/feedback.go
+++ b/cmd/feedback/feedback.go
@@ -90,7 +90,7 @@ var SurveyStore = map[string]SlackSurvey{
 			clients.IO.PrintInfo(ctx, false, fmt.Sprintf(
 				"%s\n%s\n",
 				style.Secondary("You can send us a message at "+style.Highlight(email)),
-				style.Secondary("Or, survey your experiences at "+style.Highlight("https://docs.slack.dev/developer-support")),
+				style.Secondary("Or, share your experiences at "+style.Highlight("https://docs.slack.dev/developer-support")),
 			))
 		},
 		Trace: slacktrace.FeedbackMessage,
@@ -206,7 +206,8 @@ func NewFeedbackCommand(clients *shared.ClientFactory) *cobra.Command {
 		Short:   "Share feedback about your experience or project",
 		Long:    "Help us make the Slack Platform better with your feedback",
 		Example: style.ExampleCommandsf([]style.ExampleCommand{
-			{Command: "feedback", Meaning: "Open a feedback survey in your browser"},
+			{Command: "feedback", Meaning: "Choose to give feedback on part of the Slack Platform"},
+			{Command: "feedback --name slack-cli-feedback", Meaning: "Give feedback on the Slack CLI"},
 		}),
 		PreRun: func(cmd *cobra.Command, args []string) {
 			clients.Config.SetFlags(cmd)
@@ -225,7 +226,7 @@ func NewFeedbackCommand(clients *shared.ClientFactory) *cobra.Command {
 	}
 	sort.Strings(surveyNames)
 	nameFlagDescription := style.Sectionf(style.TextSection{
-		Text:      "name of the survey:",
+		Text:      "name of the feedback:",
 		Secondary: surveyNames,
 	})
 	cmd.Flags().StringVar(&surveyNameFlag, "name", "", nameFlagDescription)
@@ -238,7 +239,7 @@ func NewFeedbackCommand(clients *shared.ClientFactory) *cobra.Command {
 // runFeedbackCommand will open the user's browser to the feedback survey webpage.
 func runFeedbackCommand(ctx context.Context, clients *shared.ClientFactory, cmd *cobra.Command) error {
 	if len(SurveyStore) == 0 {
-		clients.IO.PrintInfo(ctx, false, "No surveys currently available; please try again later")
+		clients.IO.PrintInfo(ctx, false, "No feedback options currently available; please try again later")
 		return nil
 	}
 
@@ -246,14 +247,14 @@ func runFeedbackCommand(ctx context.Context, clients *shared.ClientFactory, cmd 
 
 	if _, ok := SurveyStore[surveyNameFlag]; !ok && surveyNameFlag != "" {
 		return slackerror.New("invalid_survey_name").
-			WithMessage("Invalid survey name provided: %s", surveyNameFlag).
-			WithRemediation("View survey options with %s", style.Commandf("feedback --help", false))
+			WithMessage("Invalid feedback name provided: %s", surveyNameFlag).
+			WithRemediation("View the feedback options with %s", style.Commandf("feedback --help", false))
 	}
 
 	if surveyNameFlag == "" && noPromptFlag {
 		return slackerror.New("survey_name_required").
-			WithMessage("Please provide a survey name or remove the --no-prompt flag").
-			WithRemediation("View survey options with %s", style.Commandf("feedback --help", false))
+			WithMessage("Please provide a feedback name or remove the --no-prompt flag").
+			WithRemediation("View feedback options with %s", style.Commandf("feedback --help", false))
 	}
 
 	clients.IO.PrintInfo(ctx, false, style.Sectionf(style.TextSection{
@@ -339,7 +340,7 @@ func executeSurvey(ctx context.Context, clients *shared.ClientFactory, s SlackSu
 	var err error
 	var ok bool
 	if !noPromptFlag {
-		ok, err = clients.IO.ConfirmPrompt(ctx, "Open survey in browser?", true)
+		ok, err = clients.IO.ConfirmPrompt(ctx, "Open in browser?", true)
 		if err != nil {
 			return err
 		}
@@ -353,7 +354,7 @@ func executeSurvey(ctx context.Context, clients *shared.ClientFactory, s SlackSu
 	if ok { // Open survey in browser
 		clients.Browser().OpenURL(u)
 	} else { // Print survey URL
-		clients.IO.PrintInfo(ctx, false, fmt.Sprint("Survey URL: \n", style.Secondary(u)))
+		clients.IO.PrintInfo(ctx, false, fmt.Sprint("Feedback URL: \n", style.Secondary(u)))
 	}
 
 	// Record completion

--- a/cmd/feedback/feedback.go
+++ b/cmd/feedback/feedback.go
@@ -104,7 +104,7 @@ var SurveyStore = map[string]SlackSurvey{
 				Emoji: "love_letter",
 				Text:  "We would love to know how things are going",
 				Secondary: []string{
-					"Share your experience with " + style.Commandf("feedback --name slack-cli-feedback", false),
+					"Share your experience with " + style.Commandf(fmt.Sprintf("feedback --name %s", SlackCLIFeedback), false),
 				},
 			}))
 			return false, nil
@@ -210,7 +210,7 @@ func NewFeedbackCommand(clients *shared.ClientFactory) *cobra.Command {
 		Long:    "Help us make the Slack Platform better with your feedback",
 		Example: style.ExampleCommandsf([]style.ExampleCommand{
 			{Command: "feedback", Meaning: "Choose to give feedback on part of the Slack Platform"},
-			{Command: "feedback --name slack-cli-feedback", Meaning: "Give feedback on the Slack CLI"},
+			{Command: fmt.Sprintf("feedback --name %s", SlackCLIFeedback), Meaning: "Give feedback on the Slack CLI"},
 		}),
 		PreRun: func(cmd *cobra.Command, args []string) {
 			clients.Config.SetFlags(cmd)

--- a/cmd/feedback/feedback.go
+++ b/cmd/feedback/feedback.go
@@ -40,7 +40,7 @@ type SlackSurvey struct {
 	PromptDisplayText string
 	// PromptDescription is displayed beneath the `feedback` command prompt option
 	PromptDescription string
-	// SkipQueryParams is a flag to skip adding query params to the survey URL
+	// SkipQueryParams is a flag to skip adding query params to the survey URL (optional, default false)
 	SkipQueryParams bool
 	// URL is the survey URL
 	URL url.URL

--- a/cmd/feedback/feedback.go
+++ b/cmd/feedback/feedback.go
@@ -68,8 +68,8 @@ const (
 
 // Supported survey names
 const (
-	PlatformSurvey   = "platform-improvements"
-	SlackCLIFeedback = "slack-cli-feedback"
+	SlackCLIFeedback      = "slack-cli-feedback"
+	SlackPlatformFeedback = "platform-improvements"
 )
 
 type SurveyConfigInterface interface {
@@ -80,35 +80,6 @@ type SurveyConfigInterface interface {
 // SurveyStore stores all available surveys.
 // New surveys should be added here.
 var SurveyStore = map[string]SlackSurvey{
-	// PlatformSurvey asks for general developer experience feedback
-	PlatformSurvey: {
-		Name:              PlatformSurvey,
-		PromptDisplayText: "Help make the Slack platform better",
-		PromptDescription: "Tell us about your experience as a Slack developer",
-		URL:               url.URL{RawPath: "https://docs.slack.dev/developer-support"},
-		Info: func(ctx context.Context, clients *shared.ClientFactory) {
-			clients.IO.PrintInfo(ctx, false, fmt.Sprintf(
-				"%s\n%s\n",
-				style.Secondary("You can send us a message at "+style.Highlight(email)),
-				style.Secondary("Or, share your experiences at "+style.Highlight("https://docs.slack.dev/developer-support")),
-			))
-		},
-		Trace: slacktrace.FeedbackMessage,
-		Ask: func(ctx context.Context, clients *shared.ClientFactory) (bool, error) {
-			clients.IO.PrintInfo(ctx, false, style.Sectionf(style.TextSection{
-				Emoji: "love_letter",
-				Text:  "We would love to know how things are going",
-				Secondary: []string{
-					"Share your development experience with " + style.Commandf("feedback", false),
-				},
-			}))
-			return false, nil
-		},
-		Frequency: Always,
-		Config: func(clients *shared.ClientFactory) SurveyConfigInterface {
-			return clients.Config.SystemConfig
-		},
-	},
 	// SlackCLIFeedback asks for Slack CLI feedback using GitHub Issues
 	SlackCLIFeedback: {
 		Name:              SlackCLIFeedback,
@@ -136,6 +107,35 @@ var SurveyStore = map[string]SlackSurvey{
 			return false, nil
 		},
 		Frequency: Never,
+		Config: func(clients *shared.ClientFactory) SurveyConfigInterface {
+			return clients.Config.SystemConfig
+		},
+	},
+	// SlackPlatformFeedback asks for general developer experience feedback
+	SlackPlatformFeedback: {
+		Name:              SlackPlatformFeedback,
+		PromptDisplayText: "Slack Platform",
+		PromptDescription: "Developer support for the Slack Platform, Slack API, Block Kit, and more",
+		URL:               url.URL{RawPath: "https://docs.slack.dev/developer-support"},
+		Info: func(ctx context.Context, clients *shared.ClientFactory) {
+			clients.IO.PrintInfo(ctx, false, fmt.Sprintf(
+				"%s\n%s\n",
+				style.Secondary("You can send us a message at "+style.Highlight(email)),
+				style.Secondary("Or, share your experiences at "+style.Highlight("https://docs.slack.dev/developer-support")),
+			))
+		},
+		Trace: slacktrace.FeedbackMessage,
+		Ask: func(ctx context.Context, clients *shared.ClientFactory) (bool, error) {
+			clients.IO.PrintInfo(ctx, false, style.Sectionf(style.TextSection{
+				Emoji: "love_letter",
+				Text:  "We would love to know how things are going",
+				Secondary: []string{
+					"Share your development experience with " + style.Commandf("feedback", false),
+				},
+			}))
+			return false, nil
+		},
+		Frequency: Always,
 		Config: func(clients *shared.ClientFactory) SurveyConfigInterface {
 			return clients.Config.SystemConfig
 		},

--- a/cmd/feedback/feedback.go
+++ b/cmd/feedback/feedback.go
@@ -70,7 +70,7 @@ const (
 
 // Supported survey names
 const (
-	SlackCLIFeedback      = "slack-cli-feedback"
+	SlackCLIFeedback      = "slack-cli"
 	SlackPlatformFeedback = "platform-improvements"
 )
 

--- a/cmd/feedback/feedback.go
+++ b/cmd/feedback/feedback.go
@@ -338,7 +338,7 @@ func executeSurvey(ctx context.Context, clients *shared.ClientFactory, s SlackSu
 	if s.Info != nil {
 		s.Info(ctx, clients)
 	}
-	clients.IO.PrintTrace(ctx, s.Trace)
+	clients.IO.PrintTrace(ctx, s.Trace, s.Name)
 
 	var err error
 	var ok bool

--- a/cmd/feedback/feedback_test.go
+++ b/cmd/feedback/feedback_test.go
@@ -36,8 +36,8 @@ func TestFeedbackCommand(t *testing.T) {
 	t.Run("when there is only one survey option", func(t *testing.T) {
 
 		surveys := map[string]SlackSurvey{
-			PlatformSurvey: {
-				Name:              PlatformSurvey,
+			SlackPlatformFeedback: {
+				Name:              SlackPlatformFeedback,
 				PromptDisplayText: "Please complete this survey",
 				URL:               url.URL{RawPath: "https://survey.com"},
 				Config: func(clients *shared.ClientFactory) SurveyConfigInterface {
@@ -53,11 +53,11 @@ func TestFeedbackCommand(t *testing.T) {
 
 		pcm := &config.ProjectConfigMock{}
 		pcm.On("GetProjectID", mock.Anything).Return("projectID", nil)
-		pcm.On("GetSurveyConfig", mock.Anything, PlatformSurvey).Return(config.SurveyConfig{}, nil)
+		pcm.On("GetSurveyConfig", mock.Anything, SlackPlatformFeedback).Return(config.SurveyConfig{}, nil)
 		clientsMock.Config.ProjectConfig = pcm
 
 		scm := &config.SystemConfigMock{}
-		scm.On("GetSurveyConfig", mock.Anything, PlatformSurvey).Return(config.SurveyConfig{}, nil)
+		scm.On("GetSurveyConfig", mock.Anything, SlackPlatformFeedback).Return(config.SurveyConfig{}, nil)
 		scm.On("GetSystemID", mock.Anything).Return("systemID", nil)
 		scm.On("SetSurveyConfig", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		clientsMock.Config.SystemConfig = scm
@@ -87,8 +87,8 @@ func TestFeedbackCommand(t *testing.T) {
 					return clients.Config.SystemConfig
 				},
 			},
-			PlatformSurvey: {
-				Name:              PlatformSurvey,
+			SlackPlatformFeedback: {
+				Name:              SlackPlatformFeedback,
 				PromptDisplayText: "PlatformSurvey survey",
 				URL:               url.URL{RawPath: "https://survey.com"},
 				Config: func(clients *shared.ClientFactory) SurveyConfigInterface {

--- a/cmd/feedback/feedback_test.go
+++ b/cmd/feedback/feedback_test.go
@@ -62,7 +62,7 @@ func TestFeedbackCommand(t *testing.T) {
 		scm.On("SetSurveyConfig", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		clientsMock.Config.SystemConfig = scm
 
-		clientsMock.IO.On("ConfirmPrompt", mock.Anything, "Open survey in browser?", mock.Anything).Return(true)
+		clientsMock.IO.On("ConfirmPrompt", mock.Anything, "Open in browser?", mock.Anything).Return(true)
 		clientsMock.Browser.On("OpenURL", "https://survey.com?project_id=projectID&system_id=systemID&utm_medium=cli&utm_source=cli").Return(nil)
 
 		clients := shared.NewClientFactory(clientsMock.MockClientFactory())
@@ -128,7 +128,7 @@ func TestFeedbackCommand(t *testing.T) {
 			Index:  2,
 		}, nil)
 
-		clientsMock.IO.On("ConfirmPrompt", mock.Anything, "Open survey in browser?", mock.Anything).Return(true)
+		clientsMock.IO.On("ConfirmPrompt", mock.Anything, "Open in browser?", mock.Anything).Return(true)
 		clientsMock.Browser.On("OpenURL", "https://survey.com?project_id=projectID&system_id=systemID&utm_medium=cli&utm_source=cli").Return(nil)
 
 		clients := shared.NewClientFactory(clientsMock.MockClientFactory())
@@ -217,7 +217,7 @@ func TestShowSurveyMessages(t *testing.T) {
 		clientsMock.IO.On("ConfirmPrompt", mock.Anything, "Would you like to take a minute to tell us about B?", mock.Anything).Return(true)
 		scm.On("GetSystemID", mock.Anything).Return("systemID", nil).Once()
 		pcm.On("GetProjectID", mock.Anything).Return("projectID", nil).Once()
-		clientsMock.IO.On("ConfirmPrompt", mock.Anything, "Open survey in browser?", mock.Anything).Return(true).Once()
+		clientsMock.IO.On("ConfirmPrompt", mock.Anything, "Open in browser?", mock.Anything).Return(true).Once()
 		clientsMock.Browser.On("OpenURL", "https://B.com?project_id=projectID&system_id=systemID&utm_medium=cli&utm_source=cli").Return(nil).Once()
 		pcm.On("SetSurveyConfig", mock.Anything, "B", mock.Anything).Return(nil).Once()
 
@@ -226,7 +226,7 @@ func TestShowSurveyMessages(t *testing.T) {
 		clientsMock.IO.On("ConfirmPrompt", mock.Anything, "Would you like to take a minute to tell us about C?", mock.Anything).Return(true)
 		scm.On("GetSystemID", mock.Anything).Return("systemID", nil).Once()
 		pcm.On("GetProjectID", mock.Anything).Return("projectID", nil).Once()
-		clientsMock.IO.On("ConfirmPrompt", mock.Anything, "Open survey in browser?", mock.Anything).Return(true).Once()
+		clientsMock.IO.On("ConfirmPrompt", mock.Anything, "Open in browser?", mock.Anything).Return(true).Once()
 		clientsMock.Browser.On("OpenURL", "https://C.com?project_id=projectID&system_id=systemID&utm_medium=cli&utm_source=cli").Return(nil).Once()
 		scm.On("SetSurveyConfig", mock.Anything, "C", mock.Anything).Return(nil).Once()
 


### PR DESCRIPTION
### CHANGELOG

> Updated `feedback` command to display a prompt for Slack CLI feedback. Now developers can ask questions, submit issues, or suggest features for the Slack CLI through GitHub Issues.

### Summary

This pull request updates the `feedback` command to display a prompt with 2 choices:

1. Slack CLI
2. Slack Platform

While expanding `feedback` to display multiple options, there are a lot of improvements that we can make. However, I've tried to scope this PR to only adding the 2nd option and tweaking things to look & feel alright. 

**The main changes are:**

* **Added option for "Slack CLI Feedback"**
* **Renamed the original option to "Slack Platform Feedback"**
    * Previously, it was "Help make the Slack platform better"
* **Added a `Never` frequency**
    * So that the Slack CLI Feedback is never, randomly asked
    * The Slack Platform Feedback continues to be randomly asked after some commands
* **Added a `SkipQueryParams` field (optional)**
    * So that the the `system_id`, `project_id`, and other query string params are not included in the https://github.com/slackapi/slack-cli/issues URL
    * Default is `false`, so the Slack Platform Feedback URL continues to have the query string params
* **Updated `slacktrace.FeedbackMessage` to include the feedback option chosen**
    * e.g. `SLACK_TRACE_FEEDBACK_MESSAGE=slack-cli-feedback`
* **Generalized "survey" wording to be "feedback" or "options"**
    * This isn't perfect, but it's a step in the right direction
    * It just felt weird to see things like "Open survey in browser?" when a user was opening GitHub Issues

### Preview

https://github.com/user-attachments/assets/8f707c8f-8e2c-4bd2-b98c-afad45afc450

### Reviewers

```bash
# Feedback Prompt
$ lack feedback
# → Select Slack CLI
# → Confirm opening in browser without qs params

$ lack feedback
# → Confirm completed timestamp on Slack CLI
# CTRL+C

# Feedback Flag
$ lack feedback --name slack-cli-feedback
# → Confirm skips prompt and asks to open browser
# CTRL+C

# Feedback Trace
$ SLACK_TEST_TRACE=1 lack feedback --verbose
# → Select something
# → Confirm Trace with selection
# CTRL+C

# Post-Command Feedback Prompt
$ lack doctor
# → Confirm feedback message after command completes
```

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).