### PR TITLE
test: fix failing version tests if compilation flags are not provided

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -130,7 +130,6 @@ func TestExecuteContext(t *testing.T) {
 	}
 }
 
-// FYI: do not try to run this test in vscode using the run/debug test inline test helper; as the assertions in this test will fail in that context
 func TestVersionFlags(t *testing.T) {
 	ctx := slackcontext.MockContext(t.Context())
 

--- a/internal/pkg/version/version.go
+++ b/internal/pkg/version/version.go
@@ -24,7 +24,7 @@ import (
 const EnvTestVersion = "SLACK_TEST_VERSION"
 
 // Version is set with `git describe` at build time in the Makefile
-var Version = "dev"
+var Version = "v0.0.0-dev"
 
 // init attempts to update Version from an env var for testing purposes
 func init() {


### PR DESCRIPTION
### Summary

This pull request fixes tests that require a valid semver from failing when using VSCode/Cursor.

Previously, tests in the following packages would fail:

* `cmd/root_test.go`
* `cmd/doctor/doctor_test.go`
* `cmd/version/version_test.go`

If we want to take this work a step further, we could update our `.circleci` pipeline to validate that the `BUILD_VERSION` does not contain `v0.0.0`. However, locally, I think we want the build to remain loose, so that developers can build the CLI even when their local repo doesn't contain git tags.

### Reviewers

Testing:
* All unit tests should continue to pass when using `make test`
* Running file/package tests in one of the above files in VSCode should now pass

### Preview

![image](https://github.com/user-attachments/assets/358ce106-1886-49ba-a9ae-ad227070749c)

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).