### PR TITLE
refactor: enables linter rule ST1003 'poorly chosen identifier'

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,7 +33,6 @@ linters:
     staticcheck:
       checks:
         - all
-        - '-ST1003' # disable rule 'Poorly chosen identifier'
         - '-ST1005' # disable rule 'Incorrectly formatted error string'
         - '-ST1006' # disable rule 'Poorly chosen receiver name'
         - '-ST1008' # disable rule 'Function’s error value should be its last return value'

--- a/cmd/app/add.go
+++ b/cmd/app/add.go
@@ -89,7 +89,7 @@ func preRunAddCommand(ctx context.Context, clients *shared.ClientFactory) error 
 	if err != nil {
 		return err
 	}
-	if manifestSource.Equals(config.MANIFEST_SOURCE_REMOTE) {
+	if manifestSource.Equals(config.ManifestSourceRemote) {
 		return slackerror.New(slackerror.ErrAppInstall).
 			WithMessage("Apps cannot be installed due to project configurations").
 			WithRemediation(

--- a/cmd/app/add_test.go
+++ b/cmd/app/add_test.go
@@ -178,7 +178,7 @@ func TestAppAddCommand(t *testing.T) {
 							User     string "json:\"user,omitempty\""
 						}{},
 					},
-					types.SUCCESS,
+					types.InstallSuccess,
 					nil,
 				)
 
@@ -260,7 +260,7 @@ func TestAppAddCommand(t *testing.T) {
 							User     string "json:\"user,omitempty\""
 						}{},
 					},
-					types.SUCCESS,
+					types.InstallSuccess,
 					nil,
 				)
 
@@ -327,7 +327,7 @@ func TestAppAddCommand(t *testing.T) {
 					api.DeveloperAppInstallResult{
 						AppID: mockOrgApp.AppID,
 					},
-					types.SUCCESS,
+					types.InstallSuccess,
 					nil,
 				)
 
@@ -387,7 +387,7 @@ func TestAppAddCommand(t *testing.T) {
 					api.DeveloperAppInstallResult{
 						AppID: mockOrgApp.AppID,
 					},
-					types.REQUEST_PENDING,
+					types.InstallRequestPending,
 					nil,
 				)
 				// Mock existing and updated cache
@@ -443,7 +443,7 @@ func TestAppAddCommand(t *testing.T) {
 					api.DeveloperAppInstallResult{
 						AppID: mockOrgApp.AppID,
 					},
-					types.REQUEST_CANCELLED,
+					types.InstallRequestCancelled,
 					nil,
 				)
 				// Mock existing and updated cache

--- a/cmd/app/add_test.go
+++ b/cmd/app/add_test.go
@@ -106,7 +106,7 @@ func TestAppAddCommandPreRun(t *testing.T) {
 				cm.Config.ExperimentsFlag = append(cm.Config.ExperimentsFlag, experiment.BoltFrameworks)
 				cm.Config.LoadExperiments(ctx, cm.IO.PrintDebug)
 				mockProjectConfig := config.NewProjectConfigMock()
-				mockProjectConfig.On("GetManifestSource", mock.Anything).Return(config.MANIFEST_SOURCE_REMOTE, nil)
+				mockProjectConfig.On("GetManifestSource", mock.Anything).Return(config.ManifestSourceRemote, nil)
 				cm.Config.ProjectConfig = mockProjectConfig
 			},
 		},
@@ -118,7 +118,7 @@ func TestAppAddCommandPreRun(t *testing.T) {
 				cm.Config.ExperimentsFlag = append(cm.Config.ExperimentsFlag, experiment.BoltFrameworks)
 				cm.Config.LoadExperiments(ctx, cm.IO.PrintDebug)
 				mockProjectConfig := config.NewProjectConfigMock()
-				mockProjectConfig.On("GetManifestSource", mock.Anything).Return(config.MANIFEST_SOURCE_LOCAL, nil)
+				mockProjectConfig.On("GetManifestSource", mock.Anything).Return(config.ManifestSourceLocal, nil)
 				cm.Config.ProjectConfig = mockProjectConfig
 			},
 		},
@@ -144,24 +144,24 @@ func TestAppAddCommand(t *testing.T) {
 				appSelectMock.On("TeamAppSelectPrompt").Return(prompts.SelectedApp{Auth: mockAuthTeam1}, nil)
 
 				// Mock valid session for team1
-				cm.ApiInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{
+				cm.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{
 					UserID:   &mockAuthTeam1.UserID,
 					TeamID:   &mockAuthTeam1.TeamID,
 					TeamName: &mockAuthTeam1.TeamDomain,
 				}, nil)
 
 				// Mock a clean ValidateAppManifest result
-				cm.ApiInterface.On("ValidateAppManifest", mock.Anything, mockAuthTeam1.Token, mock.Anything, mock.Anything).Return(
+				cm.APIInterface.On("ValidateAppManifest", mock.Anything, mockAuthTeam1.Token, mock.Anything, mock.Anything).Return(
 					api.ValidateAppManifestResult{
 						Warnings: slackerror.Warnings{},
 					}, nil,
 				)
 
 				// Mock Host
-				cm.ApiInterface.On("Host").Return("")
+				cm.APIInterface.On("Host").Return("")
 
 				// Mock a successful CreateApp call and return our mocked AppID
-				cm.ApiInterface.On("CreateApp", mock.Anything, mockAuthTeam1.Token, mock.Anything, mock.Anything).Return(
+				cm.APIInterface.On("CreateApp", mock.Anything, mockAuthTeam1.Token, mock.Anything, mock.Anything).Return(
 					api.CreateAppResult{
 						AppID: mockAppTeam1.AppID,
 					},
@@ -169,7 +169,7 @@ func TestAppAddCommand(t *testing.T) {
 				)
 
 				// Mock a successful DeveloperAppInstall
-				cm.ApiInterface.On("DeveloperAppInstall", mock.Anything, mock.Anything, mockAuthTeam1.Token, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+				cm.APIInterface.On("DeveloperAppInstall", mock.Anything, mock.Anything, mockAuthTeam1.Token, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 					api.DeveloperAppInstallResult{
 						AppID: mockAppTeam1.AppID,
 						APIAccessTokens: struct {
@@ -183,7 +183,7 @@ func TestAppAddCommand(t *testing.T) {
 				)
 
 				// Mock existing and updated cache
-				cm.ApiInterface.On(
+				cm.APIInterface.On(
 					"ExportAppManifest",
 					mock.Anything,
 					mock.Anything,
@@ -216,21 +216,21 @@ func TestAppAddCommand(t *testing.T) {
 				appSelectMock.On("TeamAppSelectPrompt").Return(prompts.SelectedApp{App: mockAppTeam1, Auth: mockAuthTeam1}, nil)
 
 				// Mock valid session for team1
-				cm.ApiInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{
+				cm.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{
 					UserID:   &mockAuthTeam1.UserID,
 					TeamID:   &mockAuthTeam1.TeamID,
 					TeamName: &mockAuthTeam1.TeamDomain,
 				}, nil)
 
 				// Mock a clean ValidateAppManifest result
-				cm.ApiInterface.On("ValidateAppManifest", mock.Anything, mockAuthTeam1.Token, mock.Anything, mock.Anything).Return(
+				cm.APIInterface.On("ValidateAppManifest", mock.Anything, mockAuthTeam1.Token, mock.Anything, mock.Anything).Return(
 					api.ValidateAppManifestResult{
 						Warnings: slackerror.Warnings{},
 					}, nil,
 				)
 
 				// Mock Host
-				cm.ApiInterface.On("Host").Return("")
+				cm.APIInterface.On("Host").Return("")
 
 				// Mock to ensure that an existing deployed app is found
 				appClientMock := &app.AppClientMock{}
@@ -241,7 +241,7 @@ func TestAppAddCommand(t *testing.T) {
 				cf.AppClient().AppClientInterface = appClientMock
 
 				// Mock to ensure that the existing deployed app is updated successfully
-				cm.ApiInterface.On("UpdateApp", mock.Anything, mockAuthTeam1.Token, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+				cm.APIInterface.On("UpdateApp", mock.Anything, mockAuthTeam1.Token, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 					api.UpdateAppResult{
 						AppID:             mockAppTeam1.AppID,
 						Credentials:       api.Credentials{},
@@ -251,7 +251,7 @@ func TestAppAddCommand(t *testing.T) {
 				)
 
 				// Mock a successful DeveloperAppInstall
-				cm.ApiInterface.On("DeveloperAppInstall", mock.Anything, mock.Anything, mockAuthTeam1.Token, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+				cm.APIInterface.On("DeveloperAppInstall", mock.Anything, mock.Anything, mockAuthTeam1.Token, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 					api.DeveloperAppInstallResult{
 						AppID: mockAppTeam1.AppID,
 						APIAccessTokens: struct {
@@ -265,7 +265,7 @@ func TestAppAddCommand(t *testing.T) {
 				)
 
 				// Mock existing and updated cache
-				cm.ApiInterface.On(
+				cm.APIInterface.On(
 					"ExportAppManifest",
 					mock.Anything,
 					mock.Anything,
@@ -306,24 +306,24 @@ func TestAppAddCommand(t *testing.T) {
 				teamAppSelectPromptFunc = appSelectMock.TeamAppSelectPrompt
 				appSelectMock.On("TeamAppSelectPrompt").Return(prompts.SelectedApp{App: types.NewApp(), Auth: mockOrgAuth}, nil)
 				// Mock calls
-				cm.ApiInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{
+				cm.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{
 					UserID:   &mockOrgAuth.UserID,
 					TeamID:   &mockOrgAuth.TeamID,
 					TeamName: &mockOrgAuth.TeamDomain,
 				}, nil)
-				cm.ApiInterface.On("ValidateAppManifest", mock.Anything, mockOrgAuth.Token, mock.Anything, mock.Anything).Return(
+				cm.APIInterface.On("ValidateAppManifest", mock.Anything, mockOrgAuth.Token, mock.Anything, mock.Anything).Return(
 					api.ValidateAppManifestResult{}, nil,
 				)
-				cm.ApiInterface.On("Host").Return("")
+				cm.APIInterface.On("Host").Return("")
 				// Return mocked AppID
-				cm.ApiInterface.On("CreateApp", mock.Anything, mockOrgAuth.Token, mock.Anything, mock.Anything).Return(
+				cm.APIInterface.On("CreateApp", mock.Anything, mockOrgAuth.Token, mock.Anything, mock.Anything).Return(
 					api.CreateAppResult{
 						AppID: mockOrgApp.AppID,
 					},
 					nil,
 				)
 				// Mock call to apps.developerInstall
-				cm.ApiInterface.On("DeveloperAppInstall", mock.Anything, mock.Anything, mockOrgAuth.Token, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+				cm.APIInterface.On("DeveloperAppInstall", mock.Anything, mock.Anything, mockOrgAuth.Token, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 					api.DeveloperAppInstallResult{
 						AppID: mockOrgApp.AppID,
 					},
@@ -332,7 +332,7 @@ func TestAppAddCommand(t *testing.T) {
 				)
 
 				// Mock existing and updated cache
-				cm.ApiInterface.On(
+				cm.APIInterface.On(
 					"ExportAppManifest",
 					mock.Anything,
 					mock.Anything,
@@ -353,7 +353,7 @@ func TestAppAddCommand(t *testing.T) {
 				cm.Config.ProjectConfig = mockProjectConfig
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
-				cm.ApiInterface.AssertCalled(t, "DeveloperAppInstall", mock.Anything, mock.Anything, mockOrgAuth.Token, mock.Anything, mock.Anything, mock.Anything, "T123", mock.Anything)
+				cm.APIInterface.AssertCalled(t, "DeveloperAppInstall", mock.Anything, mock.Anything, mockOrgAuth.Token, mock.Anything, mock.Anything, mock.Anything, "T123", mock.Anything)
 			},
 		},
 		"When admin approval request is pending, outputs instructions": {
@@ -366,24 +366,24 @@ func TestAppAddCommand(t *testing.T) {
 				teamAppSelectPromptFunc = appSelectMock.TeamAppSelectPrompt
 				appSelectMock.On("TeamAppSelectPrompt").Return(prompts.SelectedApp{App: types.NewApp(), Auth: mockOrgAuth}, nil)
 				// Mock calls
-				cm.ApiInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{
+				cm.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{
 					UserID:   &mockOrgAuth.UserID,
 					TeamID:   &mockOrgAuth.TeamID,
 					TeamName: &mockOrgAuth.TeamDomain,
 				}, nil)
-				cm.ApiInterface.On("ValidateAppManifest", mock.Anything, mockOrgAuth.Token, mock.Anything, mock.Anything).Return(
+				cm.APIInterface.On("ValidateAppManifest", mock.Anything, mockOrgAuth.Token, mock.Anything, mock.Anything).Return(
 					api.ValidateAppManifestResult{}, nil,
 				)
-				cm.ApiInterface.On("Host").Return("")
+				cm.APIInterface.On("Host").Return("")
 				// Return mocked AppID
-				cm.ApiInterface.On("CreateApp", mock.Anything, mockOrgAuth.Token, mock.Anything, mock.Anything).Return(
+				cm.APIInterface.On("CreateApp", mock.Anything, mockOrgAuth.Token, mock.Anything, mock.Anything).Return(
 					api.CreateAppResult{
 						AppID: mockOrgApp.AppID,
 					},
 					nil,
 				)
 				// Mock call to apps.developerInstall
-				cm.ApiInterface.On("DeveloperAppInstall", mock.Anything, mock.Anything, mockOrgAuth.Token, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+				cm.APIInterface.On("DeveloperAppInstall", mock.Anything, mock.Anything, mockOrgAuth.Token, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 					api.DeveloperAppInstallResult{
 						AppID: mockOrgApp.AppID,
 					},
@@ -391,7 +391,7 @@ func TestAppAddCommand(t *testing.T) {
 					nil,
 				)
 				// Mock existing and updated cache
-				cm.ApiInterface.On(
+				cm.APIInterface.On(
 					"ExportAppManifest",
 					mock.Anything,
 					mock.Anything,
@@ -422,24 +422,24 @@ func TestAppAddCommand(t *testing.T) {
 				teamAppSelectPromptFunc = appSelectMock.TeamAppSelectPrompt
 				appSelectMock.On("TeamAppSelectPrompt").Return(prompts.SelectedApp{App: types.NewApp(), Auth: mockOrgAuth}, nil)
 				// Mock calls
-				cm.ApiInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{
+				cm.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{
 					UserID:   &mockOrgAuth.UserID,
 					TeamID:   &mockOrgAuth.TeamID,
 					TeamName: &mockOrgAuth.TeamDomain,
 				}, nil)
-				cm.ApiInterface.On("ValidateAppManifest", mock.Anything, mockOrgAuth.Token, mock.Anything, mock.Anything).Return(
+				cm.APIInterface.On("ValidateAppManifest", mock.Anything, mockOrgAuth.Token, mock.Anything, mock.Anything).Return(
 					api.ValidateAppManifestResult{}, nil,
 				)
-				cm.ApiInterface.On("Host").Return("")
+				cm.APIInterface.On("Host").Return("")
 				// Return mocked AppID
-				cm.ApiInterface.On("CreateApp", mock.Anything, mockOrgAuth.Token, mock.Anything, mock.Anything).Return(
+				cm.APIInterface.On("CreateApp", mock.Anything, mockOrgAuth.Token, mock.Anything, mock.Anything).Return(
 					api.CreateAppResult{
 						AppID: mockOrgApp.AppID,
 					},
 					nil,
 				)
 				// Mock call to apps.developerInstall
-				cm.ApiInterface.On("DeveloperAppInstall", mock.Anything, mock.Anything, mockOrgAuth.Token, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+				cm.APIInterface.On("DeveloperAppInstall", mock.Anything, mock.Anything, mockOrgAuth.Token, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 					api.DeveloperAppInstallResult{
 						AppID: mockOrgApp.AppID,
 					},
@@ -447,7 +447,7 @@ func TestAppAddCommand(t *testing.T) {
 					nil,
 				)
 				// Mock existing and updated cache
-				cm.ApiInterface.On(
+				cm.APIInterface.On(
 					"ExportAppManifest",
 					mock.Anything,
 					mock.Anything,
@@ -478,7 +478,7 @@ func TestAppAddCommand(t *testing.T) {
 func prepareAddMocks(t *testing.T, clients *shared.ClientFactory, clientsMock *shared.ClientsMock) {
 	clientsMock.AddDefaultMocks()
 
-	clientsMock.AuthInterface.On("ResolveApiHost", mock.Anything, mock.Anything, mock.Anything).
+	clientsMock.AuthInterface.On("ResolveAPIHost", mock.Anything, mock.Anything, mock.Anything).
 		Return("api host")
 	clientsMock.AuthInterface.On("ResolveLogstashHost", mock.Anything, mock.Anything, mock.Anything).
 		Return("logstash host")
@@ -489,7 +489,7 @@ func prepareAddMocks(t *testing.T, clients *shared.ClientFactory, clientsMock *s
 			DisplayInformation: types.DisplayInformation{
 				Name: team1TeamDomain,
 			},
-			Workflows: map[string]types.Workflow{"test_workflow": {Title: "test workflow", InputParameters: types.ToRawJson(`{}`)}},
+			Workflows: map[string]types.Workflow{"test_workflow": {Title: "test workflow", InputParameters: types.ToRawJSON(`{}`)}},
 		},
 	}, nil)
 	clients.AppClient().Manifest = manifestMock

--- a/cmd/app/delete_test.go
+++ b/cmd/app/delete_test.go
@@ -61,12 +61,12 @@ func TestAppsDeleteCommand(t *testing.T) {
 				}, nil)
 				// Mock delete confirmation prompt
 				cm.IO.On("ConfirmPrompt", mock.Anything, "Are you sure you want to delete the app?", mock.Anything).Return(true, nil)
-				cm.ApiInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{
+				cm.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{
 					TeamName: &fakeDeployedApp.TeamDomain,
 					TeamID:   &fakeDeployedApp.TeamID,
 				}, nil)
 				// Mock delete API call
-				cm.ApiInterface.On("DeleteApp", mock.Anything, mock.Anything, fakeDeployedApp.AppID).Return(nil)
+				cm.APIInterface.On("DeleteApp", mock.Anything, mock.Anything, fakeDeployedApp.AppID).Return(nil)
 				// Mock AppClient calls
 				appClientMock := &app.AppClientMock{}
 				appClientMock.On("GetDeployed", mock.Anything, mock.Anything).Return(fakeDeployedApp, nil)
@@ -75,7 +75,7 @@ func TestAppsDeleteCommand(t *testing.T) {
 				cf.AppClient().AppClientInterface = appClientMock
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
-				cm.ApiInterface.AssertCalled(t, "DeleteApp", mock.Anything, mock.Anything, fakeDeployedApp.AppID)
+				cm.APIInterface.AssertCalled(t, "DeleteApp", mock.Anything, mock.Anything, fakeDeployedApp.AppID)
 			},
 			ExpectedStdoutOutputs: []string{
 				fmt.Sprintf(`Uninstalled the app "%s" from "%s"`, fakeDeployedApp.AppID, fakeDeployedApp.TeamDomain),
@@ -95,12 +95,12 @@ func TestAppsDeleteCommand(t *testing.T) {
 				}, nil)
 				// Mock delete confirmation prompt
 				cm.IO.On("ConfirmPrompt", mock.Anything, "Are you sure you want to delete the app?", mock.Anything).Return(true, nil)
-				cm.ApiInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{
+				cm.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{
 					TeamName: &fakeLocalApp.TeamDomain,
 					TeamID:   &fakeLocalApp.TeamID,
 				}, nil)
 				// Mock delete API call
-				cm.ApiInterface.On("DeleteApp", mock.Anything, mock.Anything, fakeLocalApp.AppID).Return(nil)
+				cm.APIInterface.On("DeleteApp", mock.Anything, mock.Anything, fakeLocalApp.AppID).Return(nil)
 				// Mock AppClient calls
 				appClientMock := &app.AppClientMock{}
 				appClientMock.On("GetLocal", mock.Anything, mock.Anything).Return(fakeLocalApp, nil)
@@ -108,7 +108,7 @@ func TestAppsDeleteCommand(t *testing.T) {
 				cf.AppClient().AppClientInterface = appClientMock
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
-				cm.ApiInterface.AssertCalled(t, "DeleteApp", mock.Anything, mock.Anything, fakeLocalApp.AppID)
+				cm.APIInterface.AssertCalled(t, "DeleteApp", mock.Anything, mock.Anything, fakeLocalApp.AppID)
 			},
 			ExpectedStdoutOutputs: []string{
 				fmt.Sprintf(`Uninstalled the app "%s" from "%s"`, fakeLocalApp.AppID, fakeLocalApp.TeamDomain),
@@ -128,12 +128,12 @@ func TestAppsDeleteCommand(t *testing.T) {
 				}, nil)
 				// Mock delete confirmation prompt
 				cm.IO.On("ConfirmPrompt", mock.Anything, "Are you sure you want to delete the app?", mock.Anything).Return(true, nil)
-				cm.ApiInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{
+				cm.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{
 					TeamName: &fakeDeployedApp.TeamDomain,
 					TeamID:   &fakeDeployedApp.TeamID,
 				}, nil)
 				// Mock delete API call
-				cm.ApiInterface.On("DeleteApp", mock.Anything, mock.Anything, fakeDeployedApp.AppID).Return(fmt.Errorf("something went terribly wrong"))
+				cm.APIInterface.On("DeleteApp", mock.Anything, mock.Anything, fakeDeployedApp.AppID).Return(fmt.Errorf("something went terribly wrong"))
 				// Mock AppClient calls
 				appClientMock := &app.AppClientMock{}
 				appClientMock.On("GetDeployed", mock.Anything, mock.Anything).Return(fakeDeployedApp, nil)
@@ -146,7 +146,7 @@ func TestAppsDeleteCommand(t *testing.T) {
 			ExpectedError: slackerror.New(slackerror.ErrCredentialsNotFound),
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
 				prepareCommonDeleteMocks(t, cf, cm)
-				cm.ApiInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
+				cm.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
 				appSelectMock := prompts.NewAppSelectMock()
 				deleteAppSelectPromptFunc = appSelectMock.AppSelectPrompt
 				appSelectMock.On("AppSelectPrompt").Return(prompts.SelectedApp{App: fakeDeployedApp}, nil)
@@ -162,7 +162,7 @@ func TestAppsDeleteCommand(t *testing.T) {
 func prepareCommonDeleteMocks(t *testing.T, cf *shared.ClientFactory, cm *shared.ClientsMock) {
 	cm.AddDefaultMocks()
 
-	cm.AuthInterface.On("ResolveApiHost", mock.Anything, mock.Anything, mock.Anything).
+	cm.AuthInterface.On("ResolveAPIHost", mock.Anything, mock.Anything, mock.Anything).
 		Return("api host")
 	cm.AuthInterface.On("ResolveLogstashHost", mock.Anything, mock.Anything, mock.Anything).
 		Return("logstash host")

--- a/cmd/app/link.go
+++ b/cmd/app/link.go
@@ -160,13 +160,13 @@ func LinkExistingApp(ctx context.Context, clients *shared.ClientFactory, app *ty
 	// - Update the manifest source to remote when its a GBP project with a local manifest.
 	// - Do not update manifest source for ROSI projects, because they can only be local manifests.
 	manifestSource, err := clients.Config.ProjectConfig.GetManifestSource(ctx)
-	isManifestSourceRemote := manifestSource.Equals(config.MANIFEST_SOURCE_REMOTE)
+	isManifestSourceRemote := manifestSource.Equals(config.ManifestSourceRemote)
 	isSlackHostedProject := cmdutil.IsSlackHostedProject(ctx, clients) == nil
 
 	if err != nil || (!isManifestSourceRemote && !isSlackHostedProject) {
-		// When undefined, the default is config.MANIFEST_SOURCE_LOCAL
+		// When undefined, the default is config.ManifestSourceLocal
 		if !manifestSource.Exists() {
-			manifestSource = config.MANIFEST_SOURCE_LOCAL
+			manifestSource = config.ManifestSourceLocal
 		}
 
 		clients.IO.PrintInfo(ctx, false, "%s", style.Sectionf(style.TextSection{
@@ -174,24 +174,24 @@ func LinkExistingApp(ctx context.Context, clients *shared.ClientFactory, app *ty
 			Text:  "Warning",
 			Secondary: []string{
 				"Existing apps have manifests configured by app settings",
-				"Linking existing apps requires the manifest source to be " + config.MANIFEST_SOURCE_REMOTE.String(),
-				fmt.Sprintf(`Manifest source can be "%s" or "%s"`, config.MANIFEST_SOURCE_LOCAL.String(), config.MANIFEST_SOURCE_REMOTE.String()),
+				"Linking existing apps requires the manifest source to be " + config.ManifestSourceRemote.String(),
+				fmt.Sprintf(`Manifest source can be "%s" or "%s"`, config.ManifestSourceLocal.String(), config.ManifestSourceRemote.String()),
 				" ",
 				fmt.Sprintf(style.Highlight(`Your manifest source is "%s"`), manifestSource.String()),
-				fmt.Sprintf("- %s: uses manifest from your project's source code for all apps", config.MANIFEST_SOURCE_LOCAL.String()),
-				fmt.Sprintf("- %s: uses manifest from app settings for each app", config.MANIFEST_SOURCE_REMOTE.String()),
+				fmt.Sprintf("- %s: uses manifest from your project's source code for all apps", config.ManifestSourceLocal.String()),
+				fmt.Sprintf("- %s: uses manifest from app settings for each app", config.ManifestSourceRemote.String()),
 				" ",
 				fmt.Sprintf("Current manifest source in %s:", style.Highlight(filepath.Join(config.ProjectConfigDirName, config.ProjectConfigJSONFilename))),
 				fmt.Sprintf(style.Highlight(`  %s: "%s"`), "manifest.source", manifestSource.String()),
 				" ",
 				fmt.Sprintf("Updating manifest source will be changed in %s:", style.Highlight(filepath.Join(config.ProjectConfigDirName, config.ProjectConfigJSONFilename))),
-				fmt.Sprintf(style.Highlight(`  %s: "%s"`), "manifest.source", config.MANIFEST_SOURCE_REMOTE),
+				fmt.Sprintf(style.Highlight(`  %s: "%s"`), "manifest.source", config.ManifestSourceRemote),
 			},
 		}))
 
 		proceed, err := clients.IO.ConfirmPrompt(ctx, LinkAppManifestSourceConfirmPromptText, false)
 		if err != nil {
-			clients.IO.PrintDebug(ctx, "Error prompting to update the manifest source to %s: %s", config.MANIFEST_SOURCE_REMOTE, err)
+			clients.IO.PrintDebug(ctx, "Error prompting to update the manifest source to %s: %s", config.ManifestSourceRemote, err)
 			return err
 		}
 
@@ -201,16 +201,16 @@ func LinkExistingApp(ctx context.Context, clients *shared.ClientFactory, app *ty
 			return nil
 		}
 
-		if err := clients.Config.ProjectConfig.SetManifestSource(ctx, config.MANIFEST_SOURCE_REMOTE); err != nil {
+		if err := clients.Config.ProjectConfig.SetManifestSource(ctx, config.ManifestSourceRemote); err != nil {
 			// Log the error to the verbose output
 			clients.IO.PrintDebug(ctx, "Error setting manifest source in project-level config: %s", err)
 			// Display a user-friendly error with a workaround
 			slackErr := slackerror.New(slackerror.ErrProjectConfigManifestSource).
-				WithMessage("Failed to update the manifest source to %s", config.MANIFEST_SOURCE_REMOTE).
+				WithMessage("Failed to update the manifest source to %s", config.ManifestSourceRemote).
 				WithRemediation(
 					"You can manually update the manifest source by setting the following\nproperty in %s:\n  %s",
 					filepath.Join(config.ProjectConfigDirName, config.ProjectConfigJSONFilename),
-					fmt.Sprintf(`manifest.source: "%s"`, config.MANIFEST_SOURCE_REMOTE),
+					fmt.Sprintf(`manifest.source: "%s"`, config.ManifestSourceRemote),
 				).
 				WithRootCause(err)
 			clients.IO.PrintError(ctx, slackErr.Error())
@@ -225,7 +225,7 @@ func LinkExistingApp(ctx context.Context, clients *shared.ClientFactory, app *ty
 	}
 
 	appIDs := []string{app.AppID}
-	_, err = clients.ApiInterface().GetAppStatus(ctx, auth.Token, appIDs, app.TeamID)
+	_, err = clients.APIInterface().GetAppStatus(ctx, auth.Token, appIDs, app.TeamID)
 	if err != nil {
 		return err
 	}

--- a/cmd/app/link_test.go
+++ b/cmd/app/link_test.go
@@ -88,7 +88,7 @@ func Test_Apps_Link(t *testing.T) {
 					Flag:   true,
 					Option: "deployed",
 				}, nil)
-				cm.ApiInterface.On(
+				cm.APIInterface.On(
 					"GetAppStatus",
 					mock.Anything,
 					mockLinkSlackAuth1.Token,
@@ -146,7 +146,7 @@ func Test_Apps_Link(t *testing.T) {
 					Prompt: true,
 					Option: "local",
 				}, nil)
-				cm.ApiInterface.On(
+				cm.APIInterface.On(
 					"GetAppStatus",
 					mock.Anything,
 					mockLinkSlackAuth2.Token,
@@ -213,7 +213,7 @@ func Test_Apps_Link(t *testing.T) {
 					Prompt: true,
 					Option: "deployed",
 				}, nil)
-				cm.ApiInterface.On(
+				cm.APIInterface.On(
 					"GetAppStatus",
 					mock.Anything,
 					mockLinkSlackAuth1.Token,
@@ -282,7 +282,7 @@ func Test_Apps_Link(t *testing.T) {
 					Prompt: true,
 					Option: "local",
 				}, nil)
-				cm.ApiInterface.On(
+				cm.APIInterface.On(
 					"GetAppStatus",
 					mock.Anything,
 					mockLinkSlackAuth1.Token,
@@ -358,7 +358,7 @@ func Test_Apps_Link(t *testing.T) {
 					Prompt: true,
 					Option: "local",
 				}, nil)
-				cm.ApiInterface.On(
+				cm.APIInterface.On(
 					"GetAppStatus",
 					mock.Anything,
 					mockLinkSlackAuth2.Token,
@@ -417,7 +417,7 @@ func Test_Apps_Link(t *testing.T) {
 					Prompt: true,
 					Option: "Deployed",
 				}, nil)
-				cm.ApiInterface.On(
+				cm.APIInterface.On(
 					"GetAppStatus",
 					mock.Anything,
 					mockLinkSlackAuth1.Token,
@@ -440,7 +440,7 @@ func Test_Apps_Link(t *testing.T) {
 				cm.AddDefaultMocks()
 				setupAppLinkCommandMocks(t, ctx, cm, cf)
 				// Set manifest source to project to trigger confirmation prompt
-				if err := cm.Config.ProjectConfig.SetManifestSource(ctx, config.MANIFEST_SOURCE_LOCAL); err != nil {
+				if err := cm.Config.ProjectConfig.SetManifestSource(ctx, config.ManifestSourceLocal); err != nil {
 					require.FailNow(t, fmt.Sprintf("Failed to set the manifest source in the memory-based file system: %s", err))
 				}
 				// Accept manifest source confirmation prompt
@@ -474,7 +474,7 @@ func Test_Apps_Link(t *testing.T) {
 					Flag:   true,
 					Option: "deployed",
 				}, nil)
-				cm.ApiInterface.On(
+				cm.APIInterface.On(
 					"GetAppStatus",
 					mock.Anything,
 					mockLinkSlackAuth1.Token,
@@ -509,7 +509,7 @@ func Test_Apps_Link(t *testing.T) {
 				cm.AddDefaultMocks()
 				setupAppLinkCommandMocks(t, ctx, cm, cf)
 				// Set manifest source to project to trigger confirmation prompt
-				if err := cm.Config.ProjectConfig.SetManifestSource(ctx, config.MANIFEST_SOURCE_LOCAL); err != nil {
+				if err := cm.Config.ProjectConfig.SetManifestSource(ctx, config.ManifestSourceLocal); err != nil {
 					require.FailNow(t, fmt.Sprintf("Failed to set the manifest source in the memory-based file system: %s", err))
 				}
 				// Decline manifest source confirmation prompt
@@ -547,7 +547,7 @@ func Test_Apps_Link(t *testing.T) {
 				cm.AddDefaultMocks()
 				setupAppLinkCommandMocks(t, ctx, cm, cf)
 				// Set manifest source to local
-				if err := cm.Config.ProjectConfig.SetManifestSource(ctx, config.MANIFEST_SOURCE_LOCAL); err != nil {
+				if err := cm.Config.ProjectConfig.SetManifestSource(ctx, config.ManifestSourceLocal); err != nil {
 					require.FailNow(t, fmt.Sprintf("Failed to set the manifest source in the memory-based file system: %s", err))
 				}
 				// Mock manifest for Run-on-Slack app
@@ -555,7 +555,7 @@ func Test_Apps_Link(t *testing.T) {
 				manifestMock.On("GetManifestLocal", mock.Anything, mock.Anything, mock.Anything).Return(types.SlackYaml{
 					AppManifest: types.AppManifest{
 						Settings: &types.AppSettings{
-							FunctionRuntime: types.SLACK_HOSTED,
+							FunctionRuntime: types.SlackHosted,
 						},
 					},
 				}, nil)
@@ -585,7 +585,7 @@ func Test_Apps_Link(t *testing.T) {
 					Flag:   true,
 					Option: "deployed",
 				}, nil)
-				cm.ApiInterface.On(
+				cm.APIInterface.On(
 					"GetAppStatus",
 					mock.Anything,
 					mockLinkSlackAuth1.Token,
@@ -624,7 +624,7 @@ func Test_Apps_Link(t *testing.T) {
 				cm.AddDefaultMocks()
 				setupAppLinkCommandMocks(t, ctx, cm, cf)
 				// Set manifest source to local
-				if err := cm.Config.ProjectConfig.SetManifestSource(ctx, config.MANIFEST_SOURCE_LOCAL); err != nil {
+				if err := cm.Config.ProjectConfig.SetManifestSource(ctx, config.ManifestSourceLocal); err != nil {
 					require.FailNow(t, fmt.Sprintf("Failed to set the manifest source in the memory-based file system: %s", err))
 				}
 				// Mock manifest for Run-on-Slack app
@@ -661,7 +661,7 @@ func Test_Apps_Link(t *testing.T) {
 					Flag:   true,
 					Option: "deployed",
 				}, nil)
-				cm.ApiInterface.On(
+				cm.APIInterface.On(
 					"GetAppStatus",
 					mock.Anything,
 					mockLinkSlackAuth1.Token,
@@ -760,7 +760,7 @@ func setupAppLinkCommandMocks(t *testing.T, ctx context.Context, cm *shared.Clie
 		require.FailNow(t, fmt.Sprintf("Failed to create the hooks file in the memory-based file system: %s", err))
 	}
 
-	if err := cm.Config.ProjectConfig.SetManifestSource(ctx, config.MANIFEST_SOURCE_REMOTE); err != nil {
+	if err := cm.Config.ProjectConfig.SetManifestSource(ctx, config.ManifestSourceRemote); err != nil {
 		require.FailNow(t, fmt.Sprintf("Failed to set the manifest source in the memory-based file system: %s", err))
 	}
 

--- a/cmd/app/uninstall_test.go
+++ b/cmd/app/uninstall_test.go
@@ -48,7 +48,7 @@ func TestAppsUninstall(t *testing.T) {
 		"Successfully uninstall": {
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				prepareCommonUninstallMocks(ctx, clients, clientsMock)
-				clientsMock.ApiInterface.On("UninstallApp", mock.Anything, mock.Anything, fakeAppID, fakeAppTeamID).
+				clientsMock.APIInterface.On("UninstallApp", mock.Anything, mock.Anything, fakeAppID, fakeAppTeamID).
 					Return(nil).Once()
 			},
 			ExpectedStdoutOutputs: []string{
@@ -58,7 +58,7 @@ func TestAppsUninstall(t *testing.T) {
 		"Successfully uninstall with a get-manifest hook error": {
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				prepareCommonUninstallMocks(ctx, clients, clientsMock)
-				clientsMock.ApiInterface.On("UninstallApp", mock.Anything, mock.Anything, fakeAppID, fakeAppTeamID).
+				clientsMock.APIInterface.On("UninstallApp", mock.Anything, mock.Anything, fakeAppID, fakeAppTeamID).
 					Return(nil).Once()
 				manifestMock := &app.ManifestMockObject{}
 				manifestMock.On("GetManifestLocal", mock.Anything, mock.Anything, mock.Anything).
@@ -73,7 +73,7 @@ func TestAppsUninstall(t *testing.T) {
 			ExpectedError: slackerror.New("something went wrong"),
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				prepareCommonUninstallMocks(ctx, clients, clientsMock)
-				clientsMock.ApiInterface.On("UninstallApp", mock.Anything, mock.Anything, fakeAppID, fakeAppTeamID).
+				clientsMock.APIInterface.On("UninstallApp", mock.Anything, mock.Anything, fakeAppID, fakeAppTeamID).
 					Return(slackerror.New("something went wrong")).Once()
 			},
 		},
@@ -102,12 +102,12 @@ func prepareCommonUninstallMocks(ctx context.Context, clients *shared.ClientFact
 	appSelectMock.On("AppSelectPrompt").Return(selectedProdApp, nil)
 
 	// Mock API calls
-	clientsMock.AuthInterface.On("ResolveApiHost", mock.Anything, mock.Anything, mock.Anything).
+	clientsMock.AuthInterface.On("ResolveAPIHost", mock.Anything, mock.Anything, mock.Anything).
 		Return("api host")
 	clientsMock.AuthInterface.On("ResolveLogstashHost", mock.Anything, mock.Anything, mock.Anything).
 		Return("logstash host")
 
-	clientsMock.ApiInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{
+	clientsMock.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{
 		TeamName: &fakeApp.TeamDomain,
 		TeamID:   &fakeApp.TeamID,
 	}, nil)

--- a/cmd/auth/list.go
+++ b/cmd/auth/list.go
@@ -105,10 +105,10 @@ func printAuthList(cmd *cobra.Command, IO iostreams.IOStreamer, userAuthList []t
 			style.Secondary("User ID: %s\n"),
 			authInfo.UserID,
 		)
-		if authInfo.ApiHost != nil {
+		if authInfo.APIHost != nil {
 			cmd.Printf(
 				style.Secondary("API Host: %s\n"),
-				*authInfo.ApiHost,
+				*authInfo.APIHost,
 			)
 		}
 		cmd.Printf(

--- a/cmd/auth/login_test.go
+++ b/cmd/auth/login_test.go
@@ -168,9 +168,9 @@ func TestLoginCommand(t *testing.T) {
 				cm.IO.On("InputPrompt", mock.Anything, "Enter challenge code", iostreams.InputPromptConfig{
 					Required: true,
 				}).Return(mockChallengeCode, nil)
-				cm.ApiInterface.On("ExchangeAuthTicket", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.ExchangeAuthTicketResult{}, slackerror.New(slackerror.ErrHttpResponseInvalid))
+				cm.ApiInterface.On("ExchangeAuthTicket", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.ExchangeAuthTicketResult{}, slackerror.New(slackerror.ErrHTTPResponseInvalid))
 			},
-			ExpectedError: slackerror.New(slackerror.ErrHttpResponseInvalid),
+			ExpectedError: slackerror.New(slackerror.ErrHTTPResponseInvalid),
 		},
 	}, func(cf *shared.ClientFactory) *cobra.Command {
 		return NewLoginCommand(cf)

--- a/cmd/auth/login_test.go
+++ b/cmd/auth/login_test.go
@@ -54,13 +54,13 @@ func TestLoginCommand(t *testing.T) {
 			CmdArgs:         []string{"--auth", "xoxp-example"},
 			ExpectedOutputs: []string{deprecatedUserTokenMessage},
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
-				cm.ApiInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{
+				cm.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{
 					UserID:   &mockOrgAuth.UserID,
 					TeamID:   &mockOrgAuth.TeamID,
 					TeamName: &mockOrgAuth.TeamDomain,
 					URL:      &mockOrgAuthURL,
 				}, nil)
-				cm.AuthInterface.On("IsApiHostSlackProd", mock.Anything).Return(true)
+				cm.AuthInterface.On("IsAPIHostSlackProd", mock.Anything).Return(true)
 				cm.AuthInterface.On(
 					"AuthWithTeamDomain",
 					mock.Anything,
@@ -81,7 +81,7 @@ func TestLoginCommand(t *testing.T) {
 			CmdArgs:               []string{"--ticket=example", "--challenge=tictactoe"},
 			ExpectedStdoutOutputs: []string{"Get started by creating a new app"},
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
-				cm.ApiInterface.On(
+				cm.APIInterface.On(
 					"ExchangeAuthTicket",
 					mock.Anything,
 					mock.Anything,
@@ -94,7 +94,7 @@ func TestLoginCommand(t *testing.T) {
 					},
 					nil,
 				)
-				cm.AuthInterface.On("IsApiHostSlackProd", mock.Anything).Return(true)
+				cm.AuthInterface.On("IsAPIHostSlackProd", mock.Anything).Return(true)
 				cm.AuthInterface.On(
 					"SetAuth",
 					mock.Anything,
@@ -111,7 +111,7 @@ func TestLoginCommand(t *testing.T) {
 			CmdArgs:               []string{"--ticket", "example", "--challenge", "tictactoe"},
 			ExpectedStdoutOutputs: []string{"Review existing installations of the app"},
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
-				cm.ApiInterface.On(
+				cm.APIInterface.On(
 					"ExchangeAuthTicket",
 					mock.Anything,
 					mock.Anything,
@@ -124,7 +124,7 @@ func TestLoginCommand(t *testing.T) {
 					},
 					nil,
 				)
-				cm.AuthInterface.On("IsApiHostSlackProd", mock.Anything).Return(true)
+				cm.AuthInterface.On("IsAPIHostSlackProd", mock.Anything).Return(true)
 				cm.AuthInterface.On(
 					"SetAuth",
 					mock.Anything,
@@ -141,12 +141,12 @@ func TestLoginCommand(t *testing.T) {
 		"happy path login with prompt flow should pass challenge code to ExchangeAuthTicket API": {
 			CmdArgs: []string{},
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
-				cm.ApiInterface.On("GenerateAuthTicket", mock.Anything, mock.Anything, mock.Anything).Return(api.GenerateAuthTicketResult{}, nil)
+				cm.APIInterface.On("GenerateAuthTicket", mock.Anything, mock.Anything, mock.Anything).Return(api.GenerateAuthTicketResult{}, nil)
 				cm.IO.On("InputPrompt", mock.Anything, "Enter challenge code", iostreams.InputPromptConfig{
 					Required: true,
 				}).Return(mockChallengeCode, nil)
-				cm.ApiInterface.On("ExchangeAuthTicket", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.ExchangeAuthTicketResult{}, nil)
-				cm.AuthInterface.On("IsApiHostSlackProd", mock.Anything).Return(true)
+				cm.APIInterface.On("ExchangeAuthTicket", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.ExchangeAuthTicketResult{}, nil)
+				cm.AuthInterface.On("IsAPIHostSlackProd", mock.Anything).Return(true)
 				cm.AuthInterface.On(
 					"SetAuth",
 					mock.Anything,
@@ -158,17 +158,17 @@ func TestLoginCommand(t *testing.T) {
 				)
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
-				cm.ApiInterface.AssertCalled(t, "ExchangeAuthTicket", mock.Anything, mock.Anything, mockChallengeCode, mock.Anything)
+				cm.APIInterface.AssertCalled(t, "ExchangeAuthTicket", mock.Anything, mock.Anything, mockChallengeCode, mock.Anything)
 			},
 		},
 		"should explode if ExchangeAuthTicket API fails": {
 			CmdArgs: []string{},
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
-				cm.ApiInterface.On("GenerateAuthTicket", mock.Anything, mock.Anything, mock.Anything).Return(api.GenerateAuthTicketResult{}, nil)
+				cm.APIInterface.On("GenerateAuthTicket", mock.Anything, mock.Anything, mock.Anything).Return(api.GenerateAuthTicketResult{}, nil)
 				cm.IO.On("InputPrompt", mock.Anything, "Enter challenge code", iostreams.InputPromptConfig{
 					Required: true,
 				}).Return(mockChallengeCode, nil)
-				cm.ApiInterface.On("ExchangeAuthTicket", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.ExchangeAuthTicketResult{}, slackerror.New(slackerror.ErrHTTPResponseInvalid))
+				cm.APIInterface.On("ExchangeAuthTicket", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.ExchangeAuthTicketResult{}, slackerror.New(slackerror.ErrHTTPResponseInvalid))
 			},
 			ExpectedError: slackerror.New(slackerror.ErrHTTPResponseInvalid),
 		},

--- a/cmd/auth/logout.go
+++ b/cmd/auth/logout.go
@@ -94,8 +94,8 @@ func handleAuthRemoval(ctx context.Context, clients *shared.ClientFactory, auth 
 	defer span.Finish()
 
 	// Update the API Host and Logstash Host to be the selected/default auth
-	clients.Config.ApiHostResolved = clients.AuthInterface().ResolveApiHost(ctx, clients.Config.ApiHostFlag, &auth)
-	clients.Config.LogstashHostResolved = clients.AuthInterface().ResolveLogstashHost(ctx, clients.Config.ApiHostResolved, clients.Config.Version)
+	clients.Config.APIHostResolved = clients.AuthInterface().ResolveAPIHost(ctx, clients.Config.APIHostFlag, &auth)
+	clients.Config.LogstashHostResolved = clients.AuthInterface().ResolveLogstashHost(ctx, clients.Config.APIHostResolved, clients.Config.Version)
 
 	// First, try to revoke the xoxe-xoxp (auth) token credential
 	var xoxpToken = auth.Token
@@ -117,8 +117,8 @@ func handleAuthRemoval(ctx context.Context, clients *shared.ClientFactory, auth 
 	}
 
 	// Update the API Host and Logstash Host to be the selected/default auth
-	clients.Config.ApiHostResolved = clients.AuthInterface().ResolveApiHost(ctx, clients.Config.ApiHostFlag, nil)
-	clients.Config.LogstashHostResolved = clients.AuthInterface().ResolveLogstashHost(ctx, clients.Config.ApiHostResolved, clients.Config.Version)
+	clients.Config.APIHostResolved = clients.AuthInterface().ResolveAPIHost(ctx, clients.Config.APIHostFlag, nil)
+	clients.Config.LogstashHostResolved = clients.AuthInterface().ResolveLogstashHost(ctx, clients.Config.APIHostResolved, clients.Config.Version)
 
 	return nil
 }

--- a/cmd/auth/logout_test.go
+++ b/cmd/auth/logout_test.go
@@ -36,7 +36,7 @@ func TestLogoutCommand(t *testing.T) {
 		"logout of all teams": {
 			CmdArgs: []string{"--all"},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.AuthInterface.On("ResolveApiHost", mock.Anything, mock.Anything, mock.Anything).Return("api.slack.com")
+				clientsMock.AuthInterface.On("ResolveAPIHost", mock.Anything, mock.Anything, mock.Anything).Return("api.slack.com")
 				clientsMock.AuthInterface.On("ResolveLogstashHost", mock.Anything, mock.Anything, mock.Anything).Return("logstash.slack.com")
 				clientsMock.AuthInterface.On("Auths", mock.Anything).Return(fakeAuthsByTeamSlice, nil)
 				clientsMock.AuthInterface.On("RevokeToken", mock.Anything, fakeAuthsByTeamSlice[0].Token).Return(nil)
@@ -60,7 +60,7 @@ func TestLogoutCommand(t *testing.T) {
 		"logout of single team by named domain via flag": {
 			CmdArgs: []string{"--team", "team1"},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.AuthInterface.On("ResolveApiHost", mock.Anything, mock.Anything, mock.Anything).Return("api.slack.com")
+				clientsMock.AuthInterface.On("ResolveAPIHost", mock.Anything, mock.Anything, mock.Anything).Return("api.slack.com")
 				clientsMock.AuthInterface.On("ResolveLogstashHost", mock.Anything, mock.Anything, mock.Anything).Return("logstash.slack.com")
 				clientsMock.AuthInterface.On("Auths", mock.Anything).Return(fakeAuthsByTeamSlice, nil)
 				clientsMock.IO.On("SelectPrompt", mock.Anything, "Select an authorization to revoke", mock.Anything, iostreams.MatchPromptConfig(iostreams.SelectPromptConfig{
@@ -84,7 +84,7 @@ func TestLogoutCommand(t *testing.T) {
 		"logout of single team by id via flag": {
 			CmdArgs: []string{"--team", "T2"},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.AuthInterface.On("ResolveApiHost", mock.Anything, mock.Anything, mock.Anything).Return("api.slack.com")
+				clientsMock.AuthInterface.On("ResolveAPIHost", mock.Anything, mock.Anything, mock.Anything).Return("api.slack.com")
 				clientsMock.AuthInterface.On("ResolveLogstashHost", mock.Anything, mock.Anything, mock.Anything).Return("logstash.slack.com")
 				clientsMock.IO.On("SelectPrompt", mock.Anything, "Select an authorization to revoke", mock.Anything, iostreams.MatchPromptConfig(iostreams.SelectPromptConfig{
 					Flag: clientsMock.Config.Flags.Lookup("team"),
@@ -133,7 +133,7 @@ func TestLogoutCommand(t *testing.T) {
 		"logout of a workspace by prompt": {
 			CmdArgs: []string{},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.AuthInterface.On("ResolveApiHost", mock.Anything, mock.Anything, mock.Anything).Return("api.slack.com")
+				clientsMock.AuthInterface.On("ResolveAPIHost", mock.Anything, mock.Anything, mock.Anything).Return("api.slack.com")
 				clientsMock.AuthInterface.On("ResolveLogstashHost", mock.Anything, mock.Anything, mock.Anything).Return("logstash.slack.com")
 				clientsMock.AuthInterface.On("Auths", mock.Anything).Return(fakeAuthsByTeamSlice, nil)
 				clientsMock.IO.On("SelectPrompt", mock.Anything, "Select an authorization to revoke", []string{
@@ -161,7 +161,7 @@ func TestLogoutCommand(t *testing.T) {
 		"automatically logout of the only available workspace available": {
 			CmdArgs: []string{},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.AuthInterface.On("ResolveApiHost", mock.Anything, mock.Anything, mock.Anything).Return("api.slack.com")
+				clientsMock.AuthInterface.On("ResolveAPIHost", mock.Anything, mock.Anything, mock.Anything).Return("api.slack.com")
 				clientsMock.AuthInterface.On("ResolveLogstashHost", mock.Anything, mock.Anything, mock.Anything).Return("logstash.slack.com")
 				clientsMock.AuthInterface.On("Auths", mock.Anything).Return([]types.SlackAuth{
 					fakeAuthsByTeamSlice[0],

--- a/cmd/auth/token_test.go
+++ b/cmd/auth/token_test.go
@@ -30,12 +30,12 @@ func TestTokenCommand(t *testing.T) {
 	ctx := slackcontext.MockContext(t.Context())
 
 	clientsMock := shared.NewClientsMock()
-	clientsMock.ApiInterface.On("ValidateSession", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.AuthSession{UserID: &mockOrgAuth.UserID,
+	clientsMock.APIInterface.On("ValidateSession", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.AuthSession{UserID: &mockOrgAuth.UserID,
 		TeamID:   &mockOrgAuth.TeamID,
 		TeamName: &mockOrgAuth.TeamDomain,
 		URL:      &mockOrgAuthURL}, nil)
 	clientsMock.AuthInterface.On("AuthWithTeamDomain", mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
-	clientsMock.AuthInterface.On("IsApiHostSlackProd", mock.Anything).Return(true)
+	clientsMock.AuthInterface.On("IsAPIHostSlackProd", mock.Anything).Return(true)
 	clientsMock.AddDefaultMocks()
 	clients := shared.NewClientFactory(clientsMock.MockClientFactory())
 

--- a/cmd/collaborators/add.go
+++ b/cmd/collaborators/add.go
@@ -85,7 +85,7 @@ func runAddCommandFunc(ctx context.Context, clients *shared.ClientFactory, cmd *
 	if err != nil {
 		return err
 	}
-	err = clients.ApiInterface().AddCollaborator(ctx, selection.Auth.Token, selection.App.AppID, slackUser)
+	err = clients.APIInterface().AddCollaborator(ctx, selection.Auth.Token, selection.App.AppID, slackUser)
 	if err != nil {
 		if clients.Config.WithExperimentOn(experiment.ReadOnlyAppCollaborators) && strings.Contains(err.Error(), "user_already_owner") {
 			cmd.Println()

--- a/cmd/collaborators/add_test.go
+++ b/cmd/collaborators/add_test.go
@@ -41,12 +41,12 @@ func TestAddCommand(t *testing.T) {
 				cm.Config.ExperimentsFlag = append(cm.Config.ExperimentsFlag, "read-only-collaborators")
 				cm.Config.LoadExperiments(ctx, cm.IO.PrintDebug)
 				// Mock API call
-				cm.ApiInterface.On("AddCollaborator", mock.Anything, mock.Anything,
+				cm.APIInterface.On("AddCollaborator", mock.Anything, mock.Anything,
 					"A123",
 					types.SlackUser{ID: "U123", PermissionType: types.READER}).Return(nil)
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
-				cm.ApiInterface.AssertCalled(t, "AddCollaborator", mock.Anything, mock.Anything,
+				cm.APIInterface.AssertCalled(t, "AddCollaborator", mock.Anything, mock.Anything,
 					"A123",
 					types.SlackUser{ID: "U123", PermissionType: types.READER})
 				cm.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.CollaboratorAddSuccess, mock.Anything)
@@ -65,13 +65,13 @@ func TestAddCommand(t *testing.T) {
 				cm.Config.ExperimentsFlag = append(cm.Config.ExperimentsFlag, "read-only-collaborators")
 				cm.Config.LoadExperiments(ctx, cm.IO.PrintDebug)
 				// Mock API call
-				cm.ApiInterface.On("AddCollaborator", mock.Anything, mock.Anything,
+				cm.APIInterface.On("AddCollaborator", mock.Anything, mock.Anything,
 					"A123",
 					types.SlackUser{Email: "joe.smith@company.com", PermissionType: types.OWNER}).Return(nil)
 				addFlags.permissionType = "owner"
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
-				cm.ApiInterface.AssertCalled(t, "AddCollaborator", mock.Anything, mock.Anything,
+				cm.APIInterface.AssertCalled(t, "AddCollaborator", mock.Anything, mock.Anything,
 					"A123",
 					types.SlackUser{Email: "joe.smith@company.com", PermissionType: types.OWNER})
 				cm.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.CollaboratorAddSuccess, mock.Anything)
@@ -87,11 +87,11 @@ func TestAddCommand(t *testing.T) {
 				teamAppSelectPromptFunc = appSelectMock.TeamAppSelectPrompt
 				appSelectMock.On("TeamAppSelectPrompt").Return(prompts.SelectedApp{App: types.App{AppID: "A123"}, Auth: types.SlackAuth{}}, nil)
 				// Mock API call
-				cm.ApiInterface.On("AddCollaborator", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+				cm.APIInterface.On("AddCollaborator", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(nil)
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
-				cm.ApiInterface.AssertCalled(t, "AddCollaborator", mock.Anything, mock.Anything,
+				cm.APIInterface.AssertCalled(t, "AddCollaborator", mock.Anything, mock.Anything,
 					"A123",
 					types.SlackUser{Email: "joe.smith@company.com", PermissionType: types.OWNER})
 				cm.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.CollaboratorAddSuccess, mock.Anything)

--- a/cmd/collaborators/collaborators_test.go
+++ b/cmd/collaborators/collaborators_test.go
@@ -106,7 +106,7 @@ func TestCollaboratorsCommand(t *testing.T) {
 			appSelectMock.On("TeamAppSelectPrompt").Return(prompts.SelectedApp{App: tt.app, Auth: types.SlackAuth{}}, nil)
 			clientsMock := shared.NewClientsMock()
 			clientsMock.AddDefaultMocks()
-			clientsMock.ApiInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).
+			clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).
 				Return(tt.collaborators, nil)
 			clients := shared.NewClientFactory(clientsMock.MockClientFactory(), func(clients *shared.ClientFactory) {
 				clients.SDKConfig = hooks.NewSDKConfigMock()
@@ -114,7 +114,7 @@ func TestCollaboratorsCommand(t *testing.T) {
 
 			err := NewCommand(clients).ExecuteContext(ctx)
 			require.NoError(t, err)
-			clientsMock.ApiInterface.AssertCalled(t, "ListCollaborators", mock.Anything, mock.Anything, tt.app.AppID)
+			clientsMock.APIInterface.AssertCalled(t, "ListCollaborators", mock.Anything, mock.Anything, tt.app.AppID)
 			clientsMock.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.CollaboratorListSuccess, mock.Anything)
 			clientsMock.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.CollaboratorListCount, []string{
 				fmt.Sprintf("%d", len(tt.collaborators)),

--- a/cmd/collaborators/list.go
+++ b/cmd/collaborators/list.go
@@ -66,7 +66,7 @@ func runListCommand(cmd *cobra.Command, clients *shared.ClientFactory) error {
 	if err = cmdutil.AppExists(app, selection.Auth); err != nil {
 		return err
 	}
-	collaborators, err := clients.ApiInterface().ListCollaborators(ctx, selection.Auth.Token, app.AppID)
+	collaborators, err := clients.APIInterface().ListCollaborators(ctx, selection.Auth.Token, app.AppID)
 	if err != nil {
 		return slackerror.Wrap(err, "Error listing collaborators")
 	}

--- a/cmd/collaborators/list_test.go
+++ b/cmd/collaborators/list_test.go
@@ -106,7 +106,7 @@ func TestListCommand(t *testing.T) {
 			appSelectMock.On("TeamAppSelectPrompt").Return(prompts.SelectedApp{App: tt.app, Auth: types.SlackAuth{}}, nil)
 			clientsMock := shared.NewClientsMock()
 			clientsMock.AddDefaultMocks()
-			clientsMock.ApiInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).
+			clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).
 				Return(tt.collaborators, nil)
 			clients := shared.NewClientFactory(clientsMock.MockClientFactory(), func(clients *shared.ClientFactory) {
 				clients.SDKConfig = hooks.NewSDKConfigMock()
@@ -114,7 +114,7 @@ func TestListCommand(t *testing.T) {
 
 			err := NewListCommand(clients).ExecuteContext(ctx)
 			require.NoError(t, err)
-			clientsMock.ApiInterface.AssertCalled(t, "ListCollaborators", mock.Anything, mock.Anything, tt.app.AppID)
+			clientsMock.APIInterface.AssertCalled(t, "ListCollaborators", mock.Anything, mock.Anything, tt.app.AppID)
 			clientsMock.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.CollaboratorListSuccess, mock.Anything)
 			clientsMock.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.CollaboratorListCount, []string{
 				fmt.Sprintf("%d", len(tt.collaborators)),

--- a/cmd/collaborators/remove.go
+++ b/cmd/collaborators/remove.go
@@ -70,7 +70,7 @@ func runRemoveCommandFunc(ctx context.Context, clients *shared.ClientFactory, cm
 	if err = cmdutil.AppExists(selection.App, selection.Auth); err != nil {
 		return err
 	}
-	warnings, err := clients.ApiInterface().RemoveCollaborator(ctx, selection.Auth.Token, selection.App.AppID, slackUser)
+	warnings, err := clients.APIInterface().RemoveCollaborator(ctx, selection.Auth.Token, selection.App.AppID, slackUser)
 	if err != nil {
 		return err
 	}
@@ -120,7 +120,7 @@ func promptCollaboratorsRemoveSlackUserPrompts(
 	slackUser types.SlackUser,
 	err error,
 ) {
-	collaborators, err := clients.ApiInterface().ListCollaborators(ctx, selection.Auth.Token, selection.App.AppID)
+	collaborators, err := clients.APIInterface().ListCollaborators(ctx, selection.Auth.Token, selection.App.AppID)
 	if err != nil {
 		return types.SlackUser{}, err
 	}

--- a/cmd/collaborators/remove_test.go
+++ b/cmd/collaborators/remove_test.go
@@ -56,14 +56,14 @@ func TestRemoveCommand(t *testing.T) {
 				teamAppSelectPromptFunc = appSelectMock.TeamAppSelectPrompt
 				appSelectMock.On("TeamAppSelectPrompt").
 					Return(mockSelection, nil)
-				cm.ApiInterface.On("RemoveCollaborator", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+				cm.APIInterface.On("RemoveCollaborator", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(nil)
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
 				collaborator := types.SlackUser{
 					ID: "USLACKBOT",
 				}
-				cm.ApiInterface.AssertCalled(t, "RemoveCollaborator", mock.Anything, mock.Anything, "A001", collaborator)
+				cm.APIInterface.AssertCalled(t, "RemoveCollaborator", mock.Anything, mock.Anything, "A001", collaborator)
 				cm.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.CollaboratorRemoveSuccess, mock.Anything)
 				cm.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.CollaboratorRemoveCollaborator, []string{"USLACKBOT"})
 			},
@@ -75,16 +75,16 @@ func TestRemoveCommand(t *testing.T) {
 				teamAppSelectPromptFunc = appSelectMock.TeamAppSelectPrompt
 				appSelectMock.On("TeamAppSelectPrompt").
 					Return(mockSelection, nil)
-				cm.ApiInterface.On("RemoveCollaborator", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+				cm.APIInterface.On("RemoveCollaborator", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(nil)
 				cm.IO.On("IsTTY").Return(true)
-				cm.ApiInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).
+				cm.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).
 					Return(mockCollaborators, nil)
 				cm.IO.On("SelectPrompt", mock.Anything, "Remove a collaborator", mock.Anything, mock.Anything).
 					Return(iostreams.SelectPromptResponse{Prompt: true, Index: 1}, nil)
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
-				cm.ApiInterface.AssertCalled(t, "RemoveCollaborator", mock.Anything, mock.Anything, "A001", mockCollaborators[1])
+				cm.APIInterface.AssertCalled(t, "RemoveCollaborator", mock.Anything, mock.Anything, "A001", mockCollaborators[1])
 				cm.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.CollaboratorRemoveSuccess, mock.Anything)
 				cm.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.CollaboratorRemoveCollaborator, []string{"reader@slack.com"})
 			},
@@ -96,10 +96,10 @@ func TestRemoveCommand(t *testing.T) {
 				teamAppSelectPromptFunc = appSelectMock.TeamAppSelectPrompt
 				appSelectMock.On("TeamAppSelectPrompt").
 					Return(mockSelection, nil)
-				cm.ApiInterface.On("RemoveCollaborator", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+				cm.APIInterface.On("RemoveCollaborator", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(nil)
 				cm.IO.On("IsTTY").Return(true)
-				cm.ApiInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).
+				cm.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).
 					Return(mockCollaborators, nil)
 				cm.IO.On("SelectPrompt", mock.Anything, "Remove a collaborator", mock.Anything, mock.Anything).
 					Return(iostreams.SelectPromptResponse{Prompt: true, Index: 0}, nil)
@@ -107,7 +107,7 @@ func TestRemoveCommand(t *testing.T) {
 					Return(false, nil)
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
-				cm.ApiInterface.AssertNotCalled(t, "RemoveCollaborator", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+				cm.APIInterface.AssertNotCalled(t, "RemoveCollaborator", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 			},
 			ExpectedError: slackerror.New(slackerror.ErrProcessInterrupted),
 		},

--- a/cmd/collaborators/update.go
+++ b/cmd/collaborators/update.go
@@ -108,7 +108,7 @@ func runUpdateCommand(cmd *cobra.Command, clients *shared.ClientFactory, args []
 		return err
 	}
 
-	err = clients.ApiInterface().UpdateCollaborator(ctx, selection.Auth.Token, app.AppID, slackUser)
+	err = clients.APIInterface().UpdateCollaborator(ctx, selection.Auth.Token, app.AppID, slackUser)
 	if err != nil {
 		return slackerror.Wrap(err, "Error updating collaborator")
 	}

--- a/cmd/collaborators/update_test.go
+++ b/cmd/collaborators/update_test.go
@@ -41,7 +41,7 @@ func TestUpdateCommand(t *testing.T) {
 				clientsMock.Config.ExperimentsFlag = append(clientsMock.Config.ExperimentsFlag, "read-only-collaborators")
 				clientsMock.Config.LoadExperiments(ctx, clientsMock.IO.PrintDebug)
 				// Mock APi call
-				clientsMock.ApiInterface.On("UpdateCollaborator", mock.Anything, mock.Anything,
+				clientsMock.APIInterface.On("UpdateCollaborator", mock.Anything, mock.Anything,
 					"A123",
 					types.SlackUser{ID: "U123", PermissionType: types.READER}).Return(nil)
 			},
@@ -59,7 +59,7 @@ func TestUpdateCommand(t *testing.T) {
 				clientsMock.Config.ExperimentsFlag = append(clientsMock.Config.ExperimentsFlag, "read-only-collaborators")
 				clientsMock.Config.LoadExperiments(ctx, clientsMock.IO.PrintDebug)
 				// Mock APi call
-				clientsMock.ApiInterface.On("UpdateCollaborator", mock.Anything, mock.Anything,
+				clientsMock.APIInterface.On("UpdateCollaborator", mock.Anything, mock.Anything,
 					"A123",
 					types.SlackUser{Email: "joe.smith@company.com", PermissionType: types.OWNER}).Return(nil)
 			},

--- a/cmd/datastore/bulk_delete.go
+++ b/cmd/datastore/bulk_delete.go
@@ -146,14 +146,14 @@ func printBulkDeleteResult(clients *shared.ClientFactory, cmd *cobra.Command, de
 		datastore,
 	)
 
-	var failed_items = deleteResult.FailedItems
-	if len(failed_items) > 0 {
+	var failedItems = deleteResult.FailedItems
+	if len(failedItems) > 0 {
 		cmd.Printf(
 			style.Bold("%s Some items failed to be deleted and should be retried: \n\n"),
 			style.Emoji("warning"),
 		)
 
-		b, err := goutils.JsonMarshalUnescapedIndent(failed_items)
+		b, err := goutils.JsonMarshalUnescapedIndent(failedItems)
 		if err != nil {
 			return slackerror.New("Error during output indentation").WithRootCause(err)
 		}

--- a/cmd/datastore/bulk_delete.go
+++ b/cmd/datastore/bulk_delete.go
@@ -153,7 +153,7 @@ func printBulkDeleteResult(clients *shared.ClientFactory, cmd *cobra.Command, de
 			style.Emoji("warning"),
 		)
 
-		b, err := goutils.JsonMarshalUnescapedIndent(failedItems)
+		b, err := goutils.JSONMarshalUnescapedIndent(failedItems)
 		if err != nil {
 			return slackerror.New("Error during output indentation").WithRootCause(err)
 		}

--- a/cmd/datastore/bulk_delete_test.go
+++ b/cmd/datastore/bulk_delete_test.go
@@ -56,12 +56,12 @@ func TestBulkDeleteCommandPreRun(t *testing.T) {
 			mockManifestResponse: types.SlackYaml{
 				AppManifest: types.AppManifest{
 					Settings: &types.AppSettings{
-						FunctionRuntime: types.SLACK_HOSTED,
+						FunctionRuntime: types.SlackHosted,
 					},
 				},
 			},
 			mockManifestError:    nil,
-			mockManifestSource:   config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:   config.ManifestSourceLocal,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        nil,
 		},
@@ -69,12 +69,12 @@ func TestBulkDeleteCommandPreRun(t *testing.T) {
 			mockManifestResponse: types.SlackYaml{
 				AppManifest: types.AppManifest{
 					Settings: &types.AppSettings{
-						FunctionRuntime: types.REMOTE,
+						FunctionRuntime: types.Remote,
 					},
 				},
 			},
 			mockManifestError:    nil,
-			mockManifestSource:   config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:   config.ManifestSourceLocal,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        slackerror.New(slackerror.ErrAppNotHosted),
 		},
@@ -86,7 +86,7 @@ func TestBulkDeleteCommandPreRun(t *testing.T) {
 		"errors if the project manifest cannot be retrieved": {
 			mockManifestResponse: types.SlackYaml{},
 			mockManifestError:    slackerror.New(slackerror.ErrSDKHookInvocationFailed),
-			mockManifestSource:   config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:   config.ManifestSourceLocal,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        slackerror.New(slackerror.ErrSDKHookInvocationFailed),
 		},
@@ -97,7 +97,7 @@ func TestBulkDeleteCommandPreRun(t *testing.T) {
 			expectedError:        slackerror.New(slackerror.ErrInvalidAppDirectory),
 		},
 		"errors if the manifest source is set to remote": {
-			mockManifestSource:   config.MANIFEST_SOURCE_REMOTE,
+			mockManifestSource:   config.ManifestSourceRemote,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        slackerror.New(slackerror.ErrAppNotHosted),
 		},

--- a/cmd/datastore/bulk_get.go
+++ b/cmd/datastore/bulk_get.go
@@ -146,9 +146,9 @@ func printBulkGetResult(clients *shared.ClientFactory, cmd *cobra.Command, reque
 	var datastore = getResult.Datastore
 	var items = getResult.Items
 
-	missing_ids_msg := ""
+	missingIDsMessage := ""
 	if len(request.IDs) != len(items)+len(getResult.FailedItems) {
-		missing_ids_msg = " Not all IDs were found"
+		missingIDsMessage = " Not all IDs were found"
 	}
 
 	if outputFlag == "text" {
@@ -156,7 +156,7 @@ func printBulkGetResult(clients *shared.ClientFactory, cmd *cobra.Command, reque
 			style.Bold("%s Get from Datastore: %s.%s\n\n"),
 			style.Emoji("tada"),
 			datastore,
-			missing_ids_msg,
+			missingIDsMessage,
 		)
 	}
 
@@ -170,14 +170,14 @@ func printBulkGetResult(clients *shared.ClientFactory, cmd *cobra.Command, reque
 		string(b),
 	)
 
-	var failed_items = getResult.FailedItems
-	if len(failed_items) > 0 {
+	var failedItems = getResult.FailedItems
+	if len(failedItems) > 0 {
 		cmd.Printf(
 			style.Bold("%s Some items failed to be retrieved and should be retried: \n\n"),
 			style.Emoji("warning"),
 		)
 
-		b, err := goutils.JsonMarshalUnescapedIndent(failed_items)
+		b, err := goutils.JSONMarshalUnescapedIndent(failedItems)
 		if err != nil {
 			return slackerror.New("Error during output indentation").WithRootCause(err)
 		}

--- a/cmd/datastore/bulk_get_test.go
+++ b/cmd/datastore/bulk_get_test.go
@@ -56,12 +56,12 @@ func TestBulkGetCommandPreRun(t *testing.T) {
 			mockManifestResponse: types.SlackYaml{
 				AppManifest: types.AppManifest{
 					Settings: &types.AppSettings{
-						FunctionRuntime: types.SLACK_HOSTED,
+						FunctionRuntime: types.SlackHosted,
 					},
 				},
 			},
 			mockManifestError:    nil,
-			mockManifestSource:   config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:   config.ManifestSourceLocal,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        nil,
 		},
@@ -69,12 +69,12 @@ func TestBulkGetCommandPreRun(t *testing.T) {
 			mockManifestResponse: types.SlackYaml{
 				AppManifest: types.AppManifest{
 					Settings: &types.AppSettings{
-						FunctionRuntime: types.REMOTE,
+						FunctionRuntime: types.Remote,
 					},
 				},
 			},
 			mockManifestError:    nil,
-			mockManifestSource:   config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:   config.ManifestSourceLocal,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        slackerror.New(slackerror.ErrAppNotHosted),
 		},
@@ -86,7 +86,7 @@ func TestBulkGetCommandPreRun(t *testing.T) {
 		"errors if the project manifest cannot be retrieved": {
 			mockManifestResponse: types.SlackYaml{},
 			mockManifestError:    slackerror.New(slackerror.ErrSDKHookInvocationFailed),
-			mockManifestSource:   config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:   config.ManifestSourceLocal,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        slackerror.New(slackerror.ErrSDKHookInvocationFailed),
 		},
@@ -97,7 +97,7 @@ func TestBulkGetCommandPreRun(t *testing.T) {
 			expectedError:        slackerror.New(slackerror.ErrInvalidAppDirectory),
 		},
 		"errors if the manifest source is set to remote": {
-			mockManifestSource:   config.MANIFEST_SOURCE_REMOTE,
+			mockManifestSource:   config.ManifestSourceRemote,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        slackerror.New(slackerror.ErrAppNotHosted),
 		},

--- a/cmd/datastore/bulk_put.go
+++ b/cmd/datastore/bulk_put.go
@@ -177,14 +177,14 @@ func printBulkPutResult(clients *shared.ClientFactory, cmd *cobra.Command, putRe
 		datastore,
 	)
 
-	var failed_items = putResult.FailedItems
-	if len(failed_items) > 0 {
+	var failedItems = putResult.FailedItems
+	if len(failedItems) > 0 {
 		cmd.Printf(
 			style.Bold("%s Some items failed to be inserted and should be retried: \n\n"),
 			style.Emoji("warning"),
 		)
 
-		b, err := goutils.JsonMarshalUnescapedIndent(failed_items)
+		b, err := goutils.JSONMarshalUnescapedIndent(failedItems)
 		if err != nil {
 			return slackerror.New("Error during output indentation").WithRootCause(err)
 		}
@@ -263,7 +263,7 @@ func startBulkPutImport(ctx context.Context, clients *shared.ClientFactory, cmd 
 				continue
 			}
 			var parsedNextItem map[string]interface{}
-			err = goutils.JsonUnmarshal([]byte(nextItem), &parsedNextItem)
+			err = goutils.JSONUnmarshal([]byte(nextItem), &parsedNextItem)
 			if err != nil {
 				err = logBulkPutImportError(errorLogFile, nextItem, "item couldn't be parsed as JSON")
 				if err != nil {
@@ -302,7 +302,7 @@ func startBulkPutImport(ctx context.Context, clients *shared.ClientFactory, cmd 
 		}
 
 		query.Items = currentBatch
-		bulkPutResult, err := clients.ApiInterface().AppsDatastoreBulkPut(ctx, token, query)
+		bulkPutResult, err := clients.APIInterface().AppsDatastoreBulkPut(ctx, token, query)
 		if err != nil {
 			if len(err.(*slackerror.Error).Details) == 0 {
 				return err

--- a/cmd/datastore/bulk_put.go
+++ b/cmd/datastore/bulk_put.go
@@ -314,7 +314,7 @@ func startBulkPutImport(ctx context.Context, clients *shared.ClientFactory, cmd 
 				}
 				currentBatch = slices.Delete(currentBatch, idx, idx+1)
 
-				stringItem, err := goutils.JsonMarshalUnescaped(errorDetail.Item)
+				stringItem, err := goutils.JSONMarshalUnescaped(errorDetail.Item)
 				if err != nil {
 					return err
 				}
@@ -359,7 +359,7 @@ func logBulkPutImportError(file afero.File, item string, reason string) error {
 		Item:   item,
 		Reason: reason,
 	}
-	stringFailedItem, err := goutils.JsonMarshalUnescaped(failedItem)
+	stringFailedItem, err := goutils.JSONMarshalUnescaped(failedItem)
 	if err != nil {
 		return err
 	}

--- a/cmd/datastore/bulk_put_test.go
+++ b/cmd/datastore/bulk_put_test.go
@@ -388,7 +388,7 @@ func prepareImportMockData(file afero.File, numberOfValidRows int, numberOfInval
 		} else {
 			data = append(data, item)
 		}
-		stringItem, err := goutils.JsonMarshalUnescaped(item)
+		stringItem, err := goutils.JSONMarshalUnescaped(item)
 		if err != nil {
 			return []map[string]interface{}{}, err
 		}

--- a/cmd/datastore/bulk_put_test.go
+++ b/cmd/datastore/bulk_put_test.go
@@ -61,12 +61,12 @@ func TestBulkPutCommandPreRun(t *testing.T) {
 			mockManifestResponse: types.SlackYaml{
 				AppManifest: types.AppManifest{
 					Settings: &types.AppSettings{
-						FunctionRuntime: types.SLACK_HOSTED,
+						FunctionRuntime: types.SlackHosted,
 					},
 				},
 			},
 			mockManifestError:    nil,
-			mockManifestSource:   config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:   config.ManifestSourceLocal,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        nil,
 		},
@@ -74,12 +74,12 @@ func TestBulkPutCommandPreRun(t *testing.T) {
 			mockManifestResponse: types.SlackYaml{
 				AppManifest: types.AppManifest{
 					Settings: &types.AppSettings{
-						FunctionRuntime: types.REMOTE,
+						FunctionRuntime: types.Remote,
 					},
 				},
 			},
 			mockManifestError:    nil,
-			mockManifestSource:   config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:   config.ManifestSourceLocal,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        slackerror.New(slackerror.ErrAppNotHosted),
 		},
@@ -91,7 +91,7 @@ func TestBulkPutCommandPreRun(t *testing.T) {
 		"errors if the project manifest cannot be retrieved": {
 			mockManifestResponse: types.SlackYaml{},
 			mockManifestError:    slackerror.New(slackerror.ErrSDKHookInvocationFailed),
-			mockManifestSource:   config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:   config.ManifestSourceLocal,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        slackerror.New(slackerror.ErrSDKHookInvocationFailed),
 		},
@@ -102,7 +102,7 @@ func TestBulkPutCommandPreRun(t *testing.T) {
 			expectedError:        slackerror.New(slackerror.ErrInvalidAppDirectory),
 		},
 		"errors if the manifest source is set to remote": {
-			mockManifestSource:   config.MANIFEST_SOURCE_REMOTE,
+			mockManifestSource:   config.ManifestSourceRemote,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        slackerror.New(slackerror.ErrAppNotHosted),
 		},
@@ -235,7 +235,7 @@ func TestBulkPutCommandImport(t *testing.T) {
 			},
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
 				*cm = *setupDatastoreMocks()
-				cm.ApiInterface.On("AppsDatastoreBulkPut", mock.Anything, mock.Anything, mock.Anything).
+				cm.APIInterface.On("AppsDatastoreBulkPut", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.AppDatastoreBulkPutResult{}, nil)
 
 				itemsFile, err := cm.Fs.Create("my-file")
@@ -265,7 +265,7 @@ func TestBulkPutCommandImport(t *testing.T) {
 			ExpectedOutputs: []string{"Some items failed to be imported"},
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
 				*cm = *setupDatastoreMocks()
-				cm.ApiInterface.On("AppsDatastoreBulkPut", mock.Anything, mock.Anything, mock.Anything).
+				cm.APIInterface.On("AppsDatastoreBulkPut", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.AppDatastoreBulkPutResult{}, nil)
 
 				itemsFile, err := cm.Fs.Create("my-file")
@@ -308,7 +308,7 @@ func TestBulkPutCommandImport(t *testing.T) {
 			ExpectedOutputs: []string{"Import will be limited to the first 5000 items in the file"},
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
 				*cm = *setupDatastoreMocks()
-				cm.ApiInterface.On("AppsDatastoreBulkPut", mock.Anything, mock.Anything, mock.Anything).
+				cm.APIInterface.On("AppsDatastoreBulkPut", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.AppDatastoreBulkPutResult{}, nil)
 
 				itemsFile, err := cm.Fs.Create("my-file")
@@ -338,10 +338,10 @@ func TestBulkPutCommandImport(t *testing.T) {
 				items, err := prepareImportMockData(itemsFile, 2, 0)
 				assert.NoError(t, err)
 
-				cm.ApiInterface.On("AppsDatastoreBulkPut", mock.Anything, mock.Anything, mock.Anything).
+				cm.APIInterface.On("AppsDatastoreBulkPut", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.AppDatastoreBulkPutResult{FailedItems: items[:1]}, nil).Once()
 
-				cm.ApiInterface.On("AppsDatastoreBulkPut", mock.Anything, mock.Anything, mock.Anything).
+				cm.APIInterface.On("AppsDatastoreBulkPut", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.AppDatastoreBulkPutResult{}, nil).Once()
 
 				*cf = *shared.NewClientFactory(cm.MockClientFactory())
@@ -350,8 +350,8 @@ func TestBulkPutCommandImport(t *testing.T) {
 				status, _ := importProgressSpinner.Status()
 				assert.Contains(t, status, "Successfully imported (2) items! (0) items failed to be imported. Total processed items is (2)")
 
-				cm.ApiInterface.AssertNumberOfCalls(t, "AppsDatastoreBulkPut", 2)
-				cm.ApiInterface.AssertCalled(t, "AppsDatastoreBulkPut", mock.Anything, mock.Anything, types.AppDatastoreBulkPut{
+				cm.APIInterface.AssertNumberOfCalls(t, "AppsDatastoreBulkPut", 2)
+				cm.APIInterface.AssertCalled(t, "AppsDatastoreBulkPut", mock.Anything, mock.Anything, types.AppDatastoreBulkPut{
 					Datastore: "Todos",
 					App:       "A0123456",
 					Items: []map[string]interface{}{
@@ -359,7 +359,7 @@ func TestBulkPutCommandImport(t *testing.T) {
 						{"task_id": "0002", "task": "counting", "status": "ongoing"},
 					},
 				})
-				cm.ApiInterface.AssertCalled(t, "AppsDatastoreBulkPut", mock.Anything, mock.Anything, types.AppDatastoreBulkPut{
+				cm.APIInterface.AssertCalled(t, "AppsDatastoreBulkPut", mock.Anything, mock.Anything, types.AppDatastoreBulkPut{
 					Datastore: "Todos",
 					App:       "A0123456",
 					Items: []map[string]interface{}{

--- a/cmd/datastore/count.go
+++ b/cmd/datastore/count.go
@@ -135,7 +135,7 @@ func runCountCommandFunc(
 	}
 
 	// Perform the count
-	countResult, err := clients.ApiInterface().AppsDatastoreCount(ctx, selection.Auth.Token, count)
+	countResult, err := clients.APIInterface().AppsDatastoreCount(ctx, selection.Auth.Token, count)
 	if err != nil {
 		return err
 	}

--- a/cmd/datastore/count_test.go
+++ b/cmd/datastore/count_test.go
@@ -45,7 +45,7 @@ func TestCountCommandPreRun(t *testing.T) {
 			mockManifestResponse: types.SlackYaml{
 				AppManifest: types.AppManifest{
 					Settings: &types.AppSettings{
-						FunctionRuntime: types.SLACK_HOSTED,
+						FunctionRuntime: types.SlackHosted,
 					},
 				},
 			},
@@ -57,12 +57,12 @@ func TestCountCommandPreRun(t *testing.T) {
 			mockManifestResponse: types.SlackYaml{
 				AppManifest: types.AppManifest{
 					Settings: &types.AppSettings{
-						FunctionRuntime: types.REMOTE,
+						FunctionRuntime: types.Remote,
 					},
 				},
 			},
 			mockManifestError:    nil,
-			mockManifestSource:   config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:   config.ManifestSourceLocal,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        slackerror.New(slackerror.ErrAppNotHosted),
 		},
@@ -74,7 +74,7 @@ func TestCountCommandPreRun(t *testing.T) {
 		"errors if the project manifest cannot be retrieved": {
 			mockManifestResponse: types.SlackYaml{},
 			mockManifestError:    slackerror.New(slackerror.ErrSDKHookInvocationFailed),
-			mockManifestSource:   config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:   config.ManifestSourceLocal,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        slackerror.New(slackerror.ErrSDKHookInvocationFailed),
 		},
@@ -85,7 +85,7 @@ func TestCountCommandPreRun(t *testing.T) {
 			expectedError:        slackerror.New(slackerror.ErrInvalidAppDirectory),
 		},
 		"errors if the manifest source is set to remote": {
-			mockManifestSource:   config.MANIFEST_SOURCE_REMOTE,
+			mockManifestSource:   config.ManifestSourceRemote,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        slackerror.New(slackerror.ErrAppNotHosted),
 		},
@@ -133,14 +133,14 @@ func TestCountCommand(t *testing.T) {
 		"default to the empty expression when no expression is passed": {
 			CmdArgs: []string{"--datastore", "tasks"},
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
-				cm.ApiInterface.On("AppsDatastoreCount", mock.Anything, mock.Anything, mock.Anything).
+				cm.APIInterface.On("AppsDatastoreCount", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.AppDatastoreCountResult{Datastore: "tasks", Count: 12}, nil)
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
 				cm.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.DatastoreCountSuccess, mock.Anything)
 				cm.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.DatastoreCountTotal, []string{"12"})
 				cm.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.DatastoreCountDatastore, []string{"tasks"})
-				cm.ApiInterface.AssertCalled(
+				cm.APIInterface.AssertCalled(
 					t,
 					"AppsDatastoreCount",
 					mock.Anything,
@@ -152,14 +152,14 @@ func TestCountCommand(t *testing.T) {
 		"pass an empty expression through arguments": {
 			CmdArgs: []string{`{"datastore":"tasks"}`},
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
-				cm.ApiInterface.On("AppsDatastoreCount", mock.Anything, mock.Anything, mock.Anything).
+				cm.APIInterface.On("AppsDatastoreCount", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.AppDatastoreCountResult{Datastore: "tasks", Count: 12}, nil)
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
 				cm.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.DatastoreCountSuccess, mock.Anything)
 				cm.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.DatastoreCountTotal, []string{"12"})
 				cm.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.DatastoreCountDatastore, []string{"tasks"})
-				cm.ApiInterface.AssertCalled(
+				cm.APIInterface.AssertCalled(
 					t,
 					"AppsDatastoreCount",
 					mock.Anything,
@@ -173,14 +173,14 @@ func TestCountCommand(t *testing.T) {
 				`{"datastore":"tasks","expression":"#task_id < :num","expression_attributes":{"#task_id":"task_id"},"expression_values":{":num":"3"}}`,
 			},
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
-				cm.ApiInterface.On("AppsDatastoreCount", mock.Anything, mock.Anything, mock.Anything).
+				cm.APIInterface.On("AppsDatastoreCount", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.AppDatastoreCountResult{Datastore: "tasks", Count: 12}, nil)
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
 				cm.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.DatastoreCountSuccess, mock.Anything)
 				cm.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.DatastoreCountTotal, []string{"12"})
 				cm.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.DatastoreCountDatastore, []string{"tasks"})
-				cm.ApiInterface.AssertCalled(
+				cm.APIInterface.AssertCalled(
 					t,
 					"AppsDatastoreCount",
 					mock.Anything,
@@ -204,14 +204,14 @@ func TestCountCommand(t *testing.T) {
 				`{"datastore":"Todos","app":"A001","expression":"#task_id < :num AND #status = :progress","expression_attributes":{"#task_id":"task_id","#status":"status"},"expression_values":{":num":"3",":progress":"wip"}}`,
 			},
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
-				cm.ApiInterface.On("AppsDatastoreCount", mock.Anything, mock.Anything, mock.Anything).
+				cm.APIInterface.On("AppsDatastoreCount", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.AppDatastoreCountResult{Datastore: "tasks", Count: 12}, nil)
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
 				cm.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.DatastoreCountSuccess, mock.Anything)
 				cm.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.DatastoreCountTotal, []string{"12"})
 				cm.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.DatastoreCountDatastore, []string{"tasks"})
-				cm.ApiInterface.AssertCalled(
+				cm.APIInterface.AssertCalled(
 					t,
 					"AppsDatastoreCount",
 					mock.Anything,
@@ -252,14 +252,14 @@ func TestCountCommand(t *testing.T) {
 				cm.IO.On("InputPrompt", mock.Anything, "Enter an expression", iostreams.InputPromptConfig{
 					Required: false,
 				}).Return("")
-				cm.ApiInterface.On("AppsDatastoreCount", mock.Anything, mock.Anything, mock.Anything).
+				cm.APIInterface.On("AppsDatastoreCount", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.AppDatastoreCountResult{Datastore: "numbers", Count: 12}, nil)
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
 				cm.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.DatastoreCountSuccess, mock.Anything)
 				cm.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.DatastoreCountTotal, []string{"12"})
 				cm.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.DatastoreCountDatastore, []string{"numbers"})
-				cm.ApiInterface.AssertCalled(
+				cm.APIInterface.AssertCalled(
 					t,
 					"AppsDatastoreCount",
 					mock.Anything,
@@ -308,14 +308,14 @@ func TestCountCommand(t *testing.T) {
 				cm.IO.On("InputPrompt", mock.Anything, "Enter a value for ':bool'", iostreams.InputPromptConfig{
 					Required: true,
 				}).Return("true")
-				cm.ApiInterface.On("AppsDatastoreCount", mock.Anything, mock.Anything, mock.Anything).
+				cm.APIInterface.On("AppsDatastoreCount", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.AppDatastoreCountResult{Datastore: "numbers", Count: 6}, nil)
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
 				cm.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.DatastoreCountSuccess, mock.Anything)
 				cm.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.DatastoreCountTotal, []string{"6"})
 				cm.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.DatastoreCountDatastore, []string{"numbers"})
-				cm.ApiInterface.AssertCalled(
+				cm.APIInterface.AssertCalled(
 					t,
 					"AppsDatastoreCount",
 					mock.Anything,

--- a/cmd/datastore/datastore.go
+++ b/cmd/datastore/datastore.go
@@ -157,7 +157,7 @@ func datastoreExpressionRemediation(command string, isEmpty bool) string {
 
 // printDatastoreExpressionMarshal displays a message with the query encoded as JSON
 func printDatastoreExpressionMarshal(ctx context.Context, clients *shared.ClientFactory, query interface{}) error {
-	expression, err := goutils.JsonMarshalUnescaped(query)
+	expression, err := goutils.JSONMarshalUnescaped(query)
 	if err != nil {
 		return err
 	}

--- a/cmd/datastore/datastore.go
+++ b/cmd/datastore/datastore.go
@@ -112,7 +112,7 @@ func NewCommand(clients *shared.ClientFactory) *cobra.Command {
 
 // setQueryExpression validates the provided expression and sets query values
 func setQueryExpression(clients *shared.ClientFactory, query types.Datastorer, expression string, method string) error {
-	err := goutils.JsonUnmarshal([]byte(expression), query)
+	err := goutils.JSONUnmarshal([]byte(expression), query)
 	if err != nil {
 		return slackerror.New(slackerror.ErrInvalidDatastoreExpression).
 			WithRootCause(err).

--- a/cmd/datastore/delete_test.go
+++ b/cmd/datastore/delete_test.go
@@ -57,12 +57,12 @@ func TestDeleteCommandPreRun(t *testing.T) {
 			mockManifestResponse: types.SlackYaml{
 				AppManifest: types.AppManifest{
 					Settings: &types.AppSettings{
-						FunctionRuntime: types.SLACK_HOSTED,
+						FunctionRuntime: types.SlackHosted,
 					},
 				},
 			},
 			mockManifestError:    nil,
-			mockManifestSource:   config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:   config.ManifestSourceLocal,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        nil,
 		},
@@ -70,12 +70,12 @@ func TestDeleteCommandPreRun(t *testing.T) {
 			mockManifestResponse: types.SlackYaml{
 				AppManifest: types.AppManifest{
 					Settings: &types.AppSettings{
-						FunctionRuntime: types.REMOTE,
+						FunctionRuntime: types.Remote,
 					},
 				},
 			},
 			mockManifestError:    nil,
-			mockManifestSource:   config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:   config.ManifestSourceLocal,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        slackerror.New(slackerror.ErrAppNotHosted),
 		},
@@ -87,19 +87,19 @@ func TestDeleteCommandPreRun(t *testing.T) {
 		"errors if the project manifest cannot be retrieved": {
 			mockManifestResponse: types.SlackYaml{},
 			mockManifestError:    slackerror.New(slackerror.ErrSDKHookInvocationFailed),
-			mockManifestSource:   config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:   config.ManifestSourceLocal,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        slackerror.New(slackerror.ErrSDKHookInvocationFailed),
 		},
 		"errors if the command is not run in a project": {
 			mockManifestResponse: types.SlackYaml{},
 			mockManifestError:    slackerror.New(slackerror.ErrSDKHookNotFound),
-			mockManifestSource:   config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:   config.ManifestSourceLocal,
 			mockWorkingDirectory: "",
 			expectedError:        slackerror.New(slackerror.ErrInvalidAppDirectory),
 		},
 		"errors if the manifest source is set to remote": {
-			mockManifestSource:   config.MANIFEST_SOURCE_REMOTE,
+			mockManifestSource:   config.ManifestSourceRemote,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        slackerror.New(slackerror.ErrAppNotHosted),
 		},

--- a/cmd/datastore/get_test.go
+++ b/cmd/datastore/get_test.go
@@ -57,12 +57,12 @@ func TestGetCommandPreRun(t *testing.T) {
 			mockManifestResponse: types.SlackYaml{
 				AppManifest: types.AppManifest{
 					Settings: &types.AppSettings{
-						FunctionRuntime: types.SLACK_HOSTED,
+						FunctionRuntime: types.SlackHosted,
 					},
 				},
 			},
 			mockManifestError:    nil,
-			mockManifestSource:   config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:   config.ManifestSourceLocal,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        nil,
 		},
@@ -70,12 +70,12 @@ func TestGetCommandPreRun(t *testing.T) {
 			mockManifestResponse: types.SlackYaml{
 				AppManifest: types.AppManifest{
 					Settings: &types.AppSettings{
-						FunctionRuntime: types.REMOTE,
+						FunctionRuntime: types.Remote,
 					},
 				},
 			},
 			mockManifestError:    nil,
-			mockManifestSource:   config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:   config.ManifestSourceLocal,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        slackerror.New(slackerror.ErrAppNotHosted),
 		},
@@ -87,7 +87,7 @@ func TestGetCommandPreRun(t *testing.T) {
 		"errors if the project manifest cannot be retrieved": {
 			mockManifestResponse: types.SlackYaml{},
 			mockManifestError:    slackerror.New(slackerror.ErrSDKHookInvocationFailed),
-			mockManifestSource:   config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:   config.ManifestSourceLocal,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        slackerror.New(slackerror.ErrSDKHookInvocationFailed),
 		},
@@ -98,7 +98,7 @@ func TestGetCommandPreRun(t *testing.T) {
 			expectedError:        slackerror.New(slackerror.ErrInvalidAppDirectory),
 		},
 		"errors if the manifest source is set to remote": {
-			mockManifestSource:   config.MANIFEST_SOURCE_REMOTE,
+			mockManifestSource:   config.ManifestSourceRemote,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        slackerror.New(slackerror.ErrAppNotHosted),
 		},

--- a/cmd/datastore/put.go
+++ b/cmd/datastore/put.go
@@ -158,7 +158,7 @@ func printPutResult(clients *shared.ClientFactory, cmd *cobra.Command, putResult
 		style.Emoji("tada"),
 		datastore,
 	)
-	b, err := goutils.JsonMarshalUnescapedIndent(item)
+	b, err := goutils.JSONMarshalUnescapedIndent(item)
 	if err != nil {
 		return slackerror.New("Error during output indentation").WithRootCause(err)
 	}
@@ -228,13 +228,13 @@ func promptDatastorePutRequest(
 	// Prompt for the primary key first
 	primaryKey := yaml.Datastores[query.Datastore].PrimaryKey
 	primaryKeyPrompt := fmt.Sprintf("Enter a value for '%s':", primaryKey)
-	recordId, err := clients.IO.InputPrompt(ctx, primaryKeyPrompt, iostreams.InputPromptConfig{
+	recordID, err := clients.IO.InputPrompt(ctx, primaryKeyPrompt, iostreams.InputPromptConfig{
 		Required: true,
 	})
 	if err != nil {
 		return types.AppDatastorePut{}, err
 	}
-	query.Item[primaryKey] = recordId
+	query.Item[primaryKey] = recordID
 	delete(fields, primaryKey)
 
 	for field := range fields {

--- a/cmd/datastore/put_test.go
+++ b/cmd/datastore/put_test.go
@@ -57,12 +57,12 @@ func TestPutCommandPreRun(t *testing.T) {
 			mockManifestResponse: types.SlackYaml{
 				AppManifest: types.AppManifest{
 					Settings: &types.AppSettings{
-						FunctionRuntime: types.SLACK_HOSTED,
+						FunctionRuntime: types.SlackHosted,
 					},
 				},
 			},
 			mockManifestError:    nil,
-			mockManifestSource:   config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:   config.ManifestSourceLocal,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        nil,
 		},
@@ -70,12 +70,12 @@ func TestPutCommandPreRun(t *testing.T) {
 			mockManifestResponse: types.SlackYaml{
 				AppManifest: types.AppManifest{
 					Settings: &types.AppSettings{
-						FunctionRuntime: types.REMOTE,
+						FunctionRuntime: types.Remote,
 					},
 				},
 			},
 			mockManifestError:    nil,
-			mockManifestSource:   config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:   config.ManifestSourceLocal,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        slackerror.New(slackerror.ErrAppNotHosted),
 		},
@@ -87,19 +87,19 @@ func TestPutCommandPreRun(t *testing.T) {
 		"errors if the project manifest cannot be retrieved": {
 			mockManifestResponse: types.SlackYaml{},
 			mockManifestError:    slackerror.New(slackerror.ErrSDKHookInvocationFailed),
-			mockManifestSource:   config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:   config.ManifestSourceLocal,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        slackerror.New(slackerror.ErrSDKHookInvocationFailed),
 		},
 		"errors if the command is not run in a project": {
 			mockManifestResponse: types.SlackYaml{},
 			mockManifestError:    slackerror.New(slackerror.ErrSDKHookNotFound),
-			mockManifestSource:   config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:   config.ManifestSourceLocal,
 			mockWorkingDirectory: "",
 			expectedError:        slackerror.New(slackerror.ErrInvalidAppDirectory),
 		},
 		"errors if the manifest source is set to remote": {
-			mockManifestSource:   config.MANIFEST_SOURCE_REMOTE,
+			mockManifestSource:   config.ManifestSourceRemote,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        slackerror.New(slackerror.ErrAppNotHosted),
 		},

--- a/cmd/datastore/query.go
+++ b/cmd/datastore/query.go
@@ -415,7 +415,7 @@ func startQueryExport(ctx context.Context, clients *shared.ClientFactory, cmd *c
 		}
 
 		for _, element := range queryResult.Items {
-			stringItem, err := goutils.JsonMarshalUnescaped(element)
+			stringItem, err := goutils.JSONMarshalUnescaped(element)
 			if err != nil {
 				return err
 			}

--- a/cmd/datastore/query.go
+++ b/cmd/datastore/query.go
@@ -201,7 +201,7 @@ func printQueryResult(clients *shared.ClientFactory, cmd *cobra.Command, queryRe
 			datastore,
 		)
 		for _, item := range items {
-			b, err := goutils.JsonMarshalUnescapedIndent(item)
+			b, err := goutils.JSONMarshalUnescapedIndent(item)
 			if err != nil {
 				return slackerror.New("Error during output indentation").WithRootCause(err)
 			}
@@ -211,7 +211,7 @@ func printQueryResult(clients *shared.ClientFactory, cmd *cobra.Command, queryRe
 			)
 		}
 	case "json":
-		b, err := goutils.JsonMarshalUnescapedIndent(queryResult)
+		b, err := goutils.JSONMarshalUnescapedIndent(queryResult)
 		if err != nil {
 			return slackerror.New("Error during output indentation").WithRootCause(err)
 		}
@@ -409,7 +409,7 @@ func startQueryExport(ctx context.Context, clients *shared.ClientFactory, cmd *c
 		}
 
 		query.Limit = maxItemsToRead
-		queryResult, err := clients.ApiInterface().AppsDatastoreQuery(ctx, token, query)
+		queryResult, err := clients.APIInterface().AppsDatastoreQuery(ctx, token, query)
 		if err != nil {
 			return err
 		}

--- a/cmd/datastore/query_test.go
+++ b/cmd/datastore/query_test.go
@@ -61,12 +61,12 @@ func TestQueryCommandPreRun(t *testing.T) {
 			mockManifestResponse: types.SlackYaml{
 				AppManifest: types.AppManifest{
 					Settings: &types.AppSettings{
-						FunctionRuntime: types.SLACK_HOSTED,
+						FunctionRuntime: types.SlackHosted,
 					},
 				},
 			},
 			mockManifestError:    nil,
-			mockManifestSource:   config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:   config.ManifestSourceLocal,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        nil,
 		},
@@ -74,12 +74,12 @@ func TestQueryCommandPreRun(t *testing.T) {
 			mockManifestResponse: types.SlackYaml{
 				AppManifest: types.AppManifest{
 					Settings: &types.AppSettings{
-						FunctionRuntime: types.REMOTE,
+						FunctionRuntime: types.Remote,
 					},
 				},
 			},
 			mockManifestError:    nil,
-			mockManifestSource:   config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:   config.ManifestSourceLocal,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        slackerror.New(slackerror.ErrAppNotHosted),
 		},
@@ -91,7 +91,7 @@ func TestQueryCommandPreRun(t *testing.T) {
 		"errors if the project manifest cannot be retrieved": {
 			mockManifestResponse: types.SlackYaml{},
 			mockManifestError:    slackerror.New(slackerror.ErrSDKHookInvocationFailed),
-			mockManifestSource:   config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:   config.ManifestSourceLocal,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        slackerror.New(slackerror.ErrSDKHookInvocationFailed),
 		},
@@ -99,7 +99,7 @@ func TestQueryCommandPreRun(t *testing.T) {
 			mockManifestResponse: types.SlackYaml{},
 			mockManifestError:    slackerror.New(slackerror.ErrSDKHookNotFound),
 			mockWorkingDirectory: "",
-			mockManifestSource:   config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:   config.ManifestSourceLocal,
 			expectedError:        slackerror.New(slackerror.ErrInvalidAppDirectory),
 		},
 		"errors if both the output file and type flag are specified": {
@@ -458,7 +458,7 @@ func prepareExportMockData(cm *shared.ClientsMock, numberOfItems int, maxItemsTo
 				nextCursor = fmt.Sprintf("%d", i)
 
 			}
-			cm.ApiInterface.On("AppsDatastoreQuery", mock.Anything, mock.Anything, mock.Anything).
+			cm.APIInterface.On("AppsDatastoreQuery", mock.Anything, mock.Anything, mock.Anything).
 				Return(types.AppDatastoreQueryResult{
 					Items:      append([]map[string]interface{}{}, data...),
 					NextCursor: nextCursor,

--- a/cmd/datastore/update.go
+++ b/cmd/datastore/update.go
@@ -224,13 +224,13 @@ func promptDatastoreUpdateRequest(
 	// Prompt for the primary key first
 	primaryKey := yaml.Datastores[query.Datastore].PrimaryKey
 	primaryKeyPrompt := fmt.Sprintf("Enter a value for '%s':", yaml.Datastores[query.Datastore].PrimaryKey)
-	recordId, err := clients.IO.InputPrompt(ctx, primaryKeyPrompt, iostreams.InputPromptConfig{
+	recordID, err := clients.IO.InputPrompt(ctx, primaryKeyPrompt, iostreams.InputPromptConfig{
 		Required: true,
 	})
 	if err != nil {
 		return types.AppDatastoreUpdate{}, err
 	}
-	query.Item[primaryKey] = recordId
+	query.Item[primaryKey] = recordID
 	delete(fields, primaryKey)
 
 	// Choose fields to update, then update

--- a/cmd/datastore/update_test.go
+++ b/cmd/datastore/update_test.go
@@ -57,12 +57,12 @@ func TestUpdateCommandPreRun(t *testing.T) {
 			mockManifestResponse: types.SlackYaml{
 				AppManifest: types.AppManifest{
 					Settings: &types.AppSettings{
-						FunctionRuntime: types.SLACK_HOSTED,
+						FunctionRuntime: types.SlackHosted,
 					},
 				},
 			},
 			mockManifestError:    nil,
-			mockManifestSource:   config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:   config.ManifestSourceLocal,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        nil,
 		},
@@ -70,12 +70,12 @@ func TestUpdateCommandPreRun(t *testing.T) {
 			mockManifestResponse: types.SlackYaml{
 				AppManifest: types.AppManifest{
 					Settings: &types.AppSettings{
-						FunctionRuntime: types.REMOTE,
+						FunctionRuntime: types.Remote,
 					},
 				},
 			},
 			mockManifestError:    nil,
-			mockManifestSource:   config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:   config.ManifestSourceLocal,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        slackerror.New(slackerror.ErrAppNotHosted),
 		},
@@ -87,19 +87,19 @@ func TestUpdateCommandPreRun(t *testing.T) {
 		"errors if the project manifest cannot be retrieved": {
 			mockManifestResponse: types.SlackYaml{},
 			mockManifestError:    slackerror.New(slackerror.ErrSDKHookInvocationFailed),
-			mockManifestSource:   config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:   config.ManifestSourceLocal,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        slackerror.New(slackerror.ErrSDKHookInvocationFailed),
 		},
 		"errors if the command is not run in a project": {
 			mockManifestResponse: types.SlackYaml{},
 			mockManifestError:    slackerror.New(slackerror.ErrSDKHookNotFound),
-			mockManifestSource:   config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:   config.ManifestSourceLocal,
 			mockWorkingDirectory: "",
 			expectedError:        slackerror.New(slackerror.ErrInvalidAppDirectory),
 		},
 		"errors if the manifest source is set to remote": {
-			mockManifestSource:   config.MANIFEST_SOURCE_REMOTE,
+			mockManifestSource:   config.ManifestSourceRemote,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        slackerror.New(slackerror.ErrAppNotHosted),
 		},

--- a/cmd/doctor/check.go
+++ b/cmd/doctor/check.go
@@ -273,7 +273,7 @@ func checkCLICreds(ctx context.Context, clients *shared.ClientFactory) (Section,
 	// Teams
 	if len(authList) > 0 {
 		authSections := []Section{}
-		currentApiHost := clients.Config.ApiHostResolved
+		currentAPIHost := clients.Config.APIHostResolved
 		caser := cases.Title(language.English)
 		for _, authInfo := range authList {
 			checkDetails := []Section{
@@ -289,19 +289,19 @@ func checkCLICreds(ctx context.Context, clients *shared.ClientFactory) (Section,
 				{"Authorization level", caser.String(authInfo.AuthLevel()), []Section{}, []slackerror.Error{}},
 			}
 
-			if authInfo.ApiHost != nil {
-				hostSection := Section{"API Host", *authInfo.ApiHost, []Section{}, []slackerror.Error{}}
+			if authInfo.APIHost != nil {
+				hostSection := Section{"API Host", *authInfo.APIHost, []Section{}, []slackerror.Error{}}
 				checkDetails = append(checkDetails, hostSection)
 			}
 
 			// Validate session token
 			validitySection := Section{"Token status", "Valid", []Section{}, []slackerror.Error{}}
 
-			// TODO :: .ValidateSession() utilizes the host (ApiHost) assigned to the client making
+			// TODO :: .ValidateSession() utilizes the host (APIHost) assigned to the client making
 			// the call. This results in incorrectly deeming tokens invalid if using multiple workspaces
 			// with different API hosts. (cc: @mbrooks)
-			clients.Config.ApiHostResolved = clients.AuthInterface().ResolveApiHost(ctx, clients.Config.ApiHostFlag, &authInfo)
-			_, err := clients.ApiInterface().ValidateSession(ctx, authInfo.Token)
+			clients.Config.APIHostResolved = clients.AuthInterface().ResolveAPIHost(ctx, clients.Config.APIHostFlag, &authInfo)
+			_, err := clients.APIInterface().ValidateSession(ctx, authInfo.Token)
 			if err != nil {
 				validitySection.Value = "Invalid"
 			}
@@ -311,7 +311,7 @@ func checkCLICreds(ctx context.Context, clients *shared.ClientFactory) (Section,
 			authSections = append(authSections, authSection)
 		}
 
-		clients.Config.ApiHostResolved = currentApiHost
+		clients.Config.APIHostResolved = currentAPIHost
 
 		section.Subsections = authSections
 	}

--- a/cmd/doctor/check_test.go
+++ b/cmd/doctor/check_test.go
@@ -94,7 +94,7 @@ func TestDoctorCheckProjectConfig(t *testing.T) {
 			projectConfig: config.ProjectConfig{
 				ProjectID: "project-abcdef",
 				Manifest: &config.ManifestConfig{
-					Source: config.MANIFEST_SOURCE_LOCAL.String(),
+					Source: config.ManifestSourceLocal.String(),
 				},
 			},
 			expectedProjectSection: &Section{

--- a/cmd/doctor/doctor.go
+++ b/cmd/doctor/doctor.go
@@ -173,7 +173,7 @@ func doctorHook(ctx context.Context, clients *shared.ClientFactory) (DoctorHookJ
 	}
 	err = json.Unmarshal([]byte(getDoctorHookJSON), &doctorHookJSON)
 	if err != nil {
-		return DoctorHookJSON{}, slackerror.New(slackerror.ErrUnableToParseJson).
+		return DoctorHookJSON{}, slackerror.New(slackerror.ErrUnableToParseJSON).
 			WithMessage("Failed to parse response from doctor hook").
 			WithRootCause(err)
 	}

--- a/cmd/doctor/doctor_test.go
+++ b/cmd/doctor/doctor_test.go
@@ -54,14 +54,14 @@ func TestDoctorCommand(t *testing.T) {
 		ctx := slackcontext.MockContext(t.Context())
 		clientsMock := shared.NewClientsMock()
 		clientsMock.AuthInterface.On("Auths", mock.Anything).Return([]types.SlackAuth{expectedCredentials}, nil)
-		clientsMock.AuthInterface.On("ResolveApiHost", mock.Anything, mock.Anything, mock.Anything).Return("api.slack.com")
-		clientsMock.ApiInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
+		clientsMock.AuthInterface.On("ResolveAPIHost", mock.Anything, mock.Anything, mock.Anything).Return("api.slack.com")
+		clientsMock.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
 		clientsMock.AddDefaultMocks()
 		pcm := &config.ProjectConfigMock{}
 		pcm.On("ReadProjectConfigFile", mock.Anything).Return(config.ProjectConfig{
 			ProjectID: expectedProjectID,
 			Manifest: &config.ManifestConfig{
-				Source: config.MANIFEST_SOURCE_LOCAL.String(),
+				Source: config.ManifestSourceLocal.String(),
 			},
 		}, nil)
 		clientsMock.Config.ProjectConfig = pcm

--- a/cmd/env/add.go
+++ b/cmd/env/add.go
@@ -127,7 +127,7 @@ func runEnvAddCommandFunc(clients *shared.ClientFactory, cmd *cobra.Command, arg
 		variableValue = args[1]
 	}
 
-	err = clients.ApiInterface().AddVariable(
+	err = clients.APIInterface().AddVariable(
 		ctx,
 		selection.Auth.Token,
 		selection.App.AppID,

--- a/cmd/env/add_test.go
+++ b/cmd/env/add_test.go
@@ -57,12 +57,12 @@ func Test_Env_AddCommandPreRun(t *testing.T) {
 			mockManifestResponse: types.SlackYaml{
 				AppManifest: types.AppManifest{
 					Settings: &types.AppSettings{
-						FunctionRuntime: types.SLACK_HOSTED,
+						FunctionRuntime: types.SlackHosted,
 					},
 				},
 			},
 			mockManifestError:    nil,
-			mockManifestSource:   config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:   config.ManifestSourceLocal,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        nil,
 		},
@@ -70,12 +70,12 @@ func Test_Env_AddCommandPreRun(t *testing.T) {
 			mockManifestResponse: types.SlackYaml{
 				AppManifest: types.AppManifest{
 					Settings: &types.AppSettings{
-						FunctionRuntime: types.REMOTE,
+						FunctionRuntime: types.Remote,
 					},
 				},
 			},
 			mockManifestError:    nil,
-			mockManifestSource:   config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:   config.ManifestSourceLocal,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        slackerror.New(slackerror.ErrAppNotHosted),
 		},
@@ -87,7 +87,7 @@ func Test_Env_AddCommandPreRun(t *testing.T) {
 		"errors if the project manifest cannot be retrieved": {
 			mockManifestResponse: types.SlackYaml{},
 			mockManifestError:    slackerror.New(slackerror.ErrSDKHookInvocationFailed),
-			mockManifestSource:   config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:   config.ManifestSourceLocal,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        slackerror.New(slackerror.ErrSDKHookInvocationFailed),
 		},
@@ -98,7 +98,7 @@ func Test_Env_AddCommandPreRun(t *testing.T) {
 			expectedError:        slackerror.New(slackerror.ErrInvalidAppDirectory),
 		},
 		"errors if the manifest source is set to remote": {
-			mockManifestSource:   config.MANIFEST_SOURCE_REMOTE,
+			mockManifestSource:   config.ManifestSourceRemote,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        slackerror.New(slackerror.ErrAppNotHosted),
 		},
@@ -149,7 +149,7 @@ func Test_Env_AddCommand(t *testing.T) {
 				setupEnvAddCommandMocks(ctx, cm, cf)
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
-				cm.ApiInterface.AssertCalled(
+				cm.APIInterface.AssertCalled(
 					t,
 					"AddVariable",
 					mock.Anything,
@@ -187,7 +187,7 @@ func Test_Env_AddCommand(t *testing.T) {
 				)
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
-				cm.ApiInterface.AssertCalled(
+				cm.APIInterface.AssertCalled(
 					t,
 					"AddVariable",
 					mock.Anything,
@@ -218,7 +218,7 @@ func Test_Env_AddCommand(t *testing.T) {
 				)
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
-				cm.ApiInterface.AssertCalled(
+				cm.APIInterface.AssertCalled(
 					t,
 					"AddVariable",
 					mock.Anything,
@@ -258,7 +258,7 @@ func Test_Env_AddCommand(t *testing.T) {
 				)
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
-				cm.ApiInterface.AssertCalled(
+				cm.APIInterface.AssertCalled(
 					t,
 					"AddVariable",
 					mock.Anything,
@@ -288,5 +288,5 @@ func setupEnvAddCommandMocks(ctx context.Context, cm *shared.ClientsMock, cf *sh
 
 	cm.Config.Flags.String("value", "", "mock value flag")
 
-	cm.ApiInterface.On("AddVariable", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	cm.APIInterface.On("AddVariable", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 }

--- a/cmd/env/list.go
+++ b/cmd/env/list.go
@@ -88,7 +88,7 @@ func runEnvListCommandFunc(
 		return err
 	}
 
-	variableNames, err := clients.ApiInterface().ListVariables(
+	variableNames, err := clients.APIInterface().ListVariables(
 		ctx,
 		selection.Auth.Token,
 		selection.App.AppID,

--- a/cmd/env/list_test.go
+++ b/cmd/env/list_test.go
@@ -44,12 +44,12 @@ func Test_Env_ListCommandPreRun(t *testing.T) {
 			mockManifestResponse: types.SlackYaml{
 				AppManifest: types.AppManifest{
 					Settings: &types.AppSettings{
-						FunctionRuntime: types.SLACK_HOSTED,
+						FunctionRuntime: types.SlackHosted,
 					},
 				},
 			},
 			mockManifestError:    nil,
-			mockManifestSource:   config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:   config.ManifestSourceLocal,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        nil,
 		},
@@ -57,12 +57,12 @@ func Test_Env_ListCommandPreRun(t *testing.T) {
 			mockManifestResponse: types.SlackYaml{
 				AppManifest: types.AppManifest{
 					Settings: &types.AppSettings{
-						FunctionRuntime: types.REMOTE,
+						FunctionRuntime: types.Remote,
 					},
 				},
 			},
 			mockManifestError:    nil,
-			mockManifestSource:   config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:   config.ManifestSourceLocal,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        slackerror.New(slackerror.ErrAppNotHosted),
 		},
@@ -74,7 +74,7 @@ func Test_Env_ListCommandPreRun(t *testing.T) {
 		"errors if the project manifest cannot be retrieved": {
 			mockManifestResponse: types.SlackYaml{},
 			mockManifestError:    slackerror.New(slackerror.ErrSDKHookInvocationFailed),
-			mockManifestSource:   config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:   config.ManifestSourceLocal,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        slackerror.New(slackerror.ErrSDKHookInvocationFailed),
 		},
@@ -85,7 +85,7 @@ func Test_Env_ListCommandPreRun(t *testing.T) {
 			expectedError:        slackerror.New(slackerror.ErrInvalidAppDirectory),
 		},
 		"errors if the manifest source is set to remote": {
-			mockManifestSource:   config.MANIFEST_SOURCE_REMOTE,
+			mockManifestSource:   config.ManifestSourceRemote,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        slackerror.New(slackerror.ErrAppNotHosted),
 		},
@@ -132,7 +132,7 @@ func Test_Env_ListCommand(t *testing.T) {
 	testutil.TableTestCommand(t, testutil.CommandTests{
 		"list variables using arguments": {
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
-				cm.ApiInterface.On(
+				cm.APIInterface.On(
 					"ListVariables",
 					mock.Anything,
 					mock.Anything,
@@ -150,7 +150,7 @@ func Test_Env_ListCommand(t *testing.T) {
 				appSelectMock.On("TeamAppSelectPrompt").Return(prompts.SelectedApp{}, nil)
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
-				cm.ApiInterface.AssertCalled(
+				cm.APIInterface.AssertCalled(
 					t,
 					"ListVariables",
 					mock.Anything,

--- a/cmd/env/remove.go
+++ b/cmd/env/remove.go
@@ -95,7 +95,7 @@ func runEnvRemoveCommandFunc(clients *shared.ClientFactory, cmd *cobra.Command, 
 	if len(args) > 0 {
 		variableName = args[0]
 	} else {
-		variables, err := clients.ApiInterface().ListVariables(
+		variables, err := clients.APIInterface().ListVariables(
 			ctx,
 			selection.Auth.Token,
 			selection.App.AppID,
@@ -130,7 +130,7 @@ func runEnvRemoveCommandFunc(clients *shared.ClientFactory, cmd *cobra.Command, 
 		}
 	}
 
-	err = clients.ApiInterface().RemoveVariable(
+	err = clients.APIInterface().RemoveVariable(
 		ctx,
 		selection.Auth.Token,
 		selection.App.AppID,

--- a/cmd/env/remove_test.go
+++ b/cmd/env/remove_test.go
@@ -45,12 +45,12 @@ func Test_Env_RemoveCommandPreRun(t *testing.T) {
 			mockManifestResponse: types.SlackYaml{
 				AppManifest: types.AppManifest{
 					Settings: &types.AppSettings{
-						FunctionRuntime: types.SLACK_HOSTED,
+						FunctionRuntime: types.SlackHosted,
 					},
 				},
 			},
 			mockManifestError:    nil,
-			mockManifestSource:   config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:   config.ManifestSourceLocal,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        nil,
 		},
@@ -58,12 +58,12 @@ func Test_Env_RemoveCommandPreRun(t *testing.T) {
 			mockManifestResponse: types.SlackYaml{
 				AppManifest: types.AppManifest{
 					Settings: &types.AppSettings{
-						FunctionRuntime: types.REMOTE,
+						FunctionRuntime: types.Remote,
 					},
 				},
 			},
 			mockManifestError:    nil,
-			mockManifestSource:   config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:   config.ManifestSourceLocal,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        slackerror.New(slackerror.ErrAppNotHosted),
 		},
@@ -75,7 +75,7 @@ func Test_Env_RemoveCommandPreRun(t *testing.T) {
 		"errors if the project manifest cannot be retrieved": {
 			mockManifestResponse: types.SlackYaml{},
 			mockManifestError:    slackerror.New(slackerror.ErrSDKHookInvocationFailed),
-			mockManifestSource:   config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:   config.ManifestSourceLocal,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        slackerror.New(slackerror.ErrSDKHookInvocationFailed),
 		},
@@ -86,7 +86,7 @@ func Test_Env_RemoveCommandPreRun(t *testing.T) {
 			expectedError:        slackerror.New(slackerror.ErrInvalidAppDirectory),
 		},
 		"errors if the manifest source is set to remote": {
-			mockManifestSource:   config.MANIFEST_SOURCE_REMOTE,
+			mockManifestSource:   config.ManifestSourceRemote,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        slackerror.New(slackerror.ErrAppNotHosted),
 		},
@@ -134,7 +134,7 @@ func Test_Env_RemoveCommand(t *testing.T) {
 		"remove a variable using arguments": {
 			CmdArgs: []string{"ENV_NAME"},
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
-				cm.ApiInterface.On(
+				cm.APIInterface.On(
 					"ListVariables",
 					mock.Anything,
 					mock.Anything,
@@ -143,7 +143,7 @@ func Test_Env_RemoveCommand(t *testing.T) {
 					[]string{"example"},
 					nil,
 				)
-				cm.ApiInterface.On(
+				cm.APIInterface.On(
 					"RemoveVariable",
 					mock.Anything,
 					mock.Anything,
@@ -157,7 +157,7 @@ func Test_Env_RemoveCommand(t *testing.T) {
 				appSelectMock.On("TeamAppSelectPrompt").Return(prompts.SelectedApp{}, nil)
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
-				cm.ApiInterface.AssertCalled(
+				cm.APIInterface.AssertCalled(
 					t,
 					"RemoveVariable",
 					mock.Anything,
@@ -177,7 +177,7 @@ func Test_Env_RemoveCommand(t *testing.T) {
 		"remove a variable using prompt": {
 			CmdArgs: []string{},
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
-				cm.ApiInterface.On(
+				cm.APIInterface.On(
 					"ListVariables",
 					mock.Anything,
 					mock.Anything,
@@ -186,7 +186,7 @@ func Test_Env_RemoveCommand(t *testing.T) {
 					[]string{"example"},
 					nil,
 				)
-				cm.ApiInterface.On(
+				cm.APIInterface.On(
 					"RemoveVariable",
 					mock.Anything,
 					mock.Anything,
@@ -216,14 +216,14 @@ func Test_Env_RemoveCommand(t *testing.T) {
 				appSelectMock.On("TeamAppSelectPrompt").Return(prompts.SelectedApp{}, nil)
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
-				cm.ApiInterface.AssertCalled(
+				cm.APIInterface.AssertCalled(
 					t,
 					"ListVariables",
 					mock.Anything,
 					mock.Anything,
 					mock.Anything,
 				)
-				cm.ApiInterface.AssertCalled(
+				cm.APIInterface.AssertCalled(
 					t,
 					"RemoveVariable",
 					mock.Anything,
@@ -236,7 +236,7 @@ func Test_Env_RemoveCommand(t *testing.T) {
 		"exit without errors when prompting zero environment variables": {
 			CmdArgs: []string{},
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
-				cm.ApiInterface.On(
+				cm.APIInterface.On(
 					"ListVariables",
 					mock.Anything,
 					mock.Anything,
@@ -250,7 +250,7 @@ func Test_Env_RemoveCommand(t *testing.T) {
 				appSelectMock.On("TeamAppSelectPrompt").Return(prompts.SelectedApp{}, nil)
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
-				cm.ApiInterface.AssertCalled(
+				cm.APIInterface.AssertCalled(
 					t,
 					"ListVariables",
 					mock.Anything,

--- a/cmd/externalauth/add.go
+++ b/cmd/externalauth/add.go
@@ -89,7 +89,7 @@ func runAddCommand(clients *shared.ClientFactory, cmd *cobra.Command) error {
 	}
 
 	// Get the oauth2 provider keys
-	providerAuths, err := clients.ApiInterface().AppsAuthExternalList(
+	providerAuths, err := clients.APIInterface().AppsAuthExternalList(
 		ctx,
 		selection.Auth.Token,
 		selection.App.AppID,
@@ -132,7 +132,7 @@ func runAddCommand(clients *shared.ClientFactory, cmd *cobra.Command) error {
 		return slackerror.New(fmt.Sprintf("Error: No client secret exists. Add one with %s", command))
 	}
 
-	authorizationUrl, err := clients.ApiInterface().AppsAuthExternalStart(
+	authorizationURL, err := clients.APIInterface().AppsAuthExternalStart(
 		ctx,
 		selection.Auth.Token,
 		selection.App.AppID,
@@ -143,7 +143,7 @@ func runAddCommand(clients *shared.ClientFactory, cmd *cobra.Command) error {
 	}
 
 	clients.IO.PrintInfo(ctx, false, "Redirecting to browser...")
-	clients.Browser().OpenURL(authorizationUrl)
+	clients.Browser().OpenURL(authorizationURL)
 
 	return err
 }

--- a/cmd/externalauth/add_secret.go
+++ b/cmd/externalauth/add_secret.go
@@ -92,7 +92,7 @@ func runAddClientSecretCommand(clients *shared.ClientFactory, cmd *cobra.Command
 	}
 
 	// Get the oauth2 provider keys
-	providerAuths, err := clients.ApiInterface().AppsAuthExternalList(
+	providerAuths, err := clients.APIInterface().AppsAuthExternalList(
 		ctx,
 		selection.Auth.Token,
 		selection.App.AppID,
@@ -121,7 +121,7 @@ func runAddClientSecretCommand(clients *shared.ClientFactory, cmd *cobra.Command
 		clientSecret = response.Value
 	}
 
-	err = clients.ApiInterface().AppsAuthExternalClientSecretAdd(
+	err = clients.APIInterface().AppsAuthExternalClientSecretAdd(
 		ctx,
 		selection.Auth.Token,
 		selection.App.AppID,

--- a/cmd/externalauth/add_secret_test.go
+++ b/cmd/externalauth/add_secret_test.go
@@ -45,7 +45,7 @@ func TestExternalAuthAddClientSecretCommandPreRun(t *testing.T) {
 			mockManifestResponse: types.SlackYaml{
 				AppManifest: types.AppManifest{
 					Settings: &types.AppSettings{
-						FunctionRuntime: types.SLACK_HOSTED,
+						FunctionRuntime: types.SlackHosted,
 					},
 				},
 			},
@@ -57,12 +57,12 @@ func TestExternalAuthAddClientSecretCommandPreRun(t *testing.T) {
 			mockManifestResponse: types.SlackYaml{
 				AppManifest: types.AppManifest{
 					Settings: &types.AppSettings{
-						FunctionRuntime: types.REMOTE,
+						FunctionRuntime: types.Remote,
 					},
 				},
 			},
 			mockManifestError:    nil,
-			mockManifestSource:   config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:   config.ManifestSourceLocal,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        slackerror.New(slackerror.ErrAppNotHosted),
 		},
@@ -74,19 +74,19 @@ func TestExternalAuthAddClientSecretCommandPreRun(t *testing.T) {
 		"errors if the project manifest cannot be retrieved": {
 			mockManifestResponse: types.SlackYaml{},
 			mockManifestError:    slackerror.New(slackerror.ErrSDKHookInvocationFailed),
-			mockManifestSource:   config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:   config.ManifestSourceLocal,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        slackerror.New(slackerror.ErrSDKHookInvocationFailed),
 		},
 		"errors if the command is not run in a project": {
 			mockManifestResponse: types.SlackYaml{},
 			mockManifestError:    slackerror.New(slackerror.ErrSDKHookNotFound),
-			mockManifestSource:   config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:   config.ManifestSourceLocal,
 			mockWorkingDirectory: "",
 			expectedError:        slackerror.New(slackerror.ErrInvalidAppDirectory),
 		},
 		"errors if the manifest source is set to remote": {
-			mockManifestSource:   config.MANIFEST_SOURCE_REMOTE,
+			mockManifestSource:   config.ManifestSourceRemote,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        slackerror.New(slackerror.ErrAppNotHosted),
 		},
@@ -141,19 +141,19 @@ func TestExternalAuthAddClientSecretCommand(t *testing.T) {
 		"no params": {
 			CmdArgs: []string{},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.ApiInterface.On("AppsAuthExternalList",
+				clientsMock.APIInterface.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(types.ExternalAuthorizationInfoLists{
 						Authorizations: []types.ExternalAuthorizationInfo{
 							{
 								ProviderName:       "Google",
 								ProviderKey:        "provider_a",
-								ClientId:           "xxxxx",
+								ClientID:           "xxxxx",
 								ClientSecretExists: true, ValidTokenExists: false,
 							},
 						}}, nil)
 
-				clientsMock.ApiInterface.On("AppsAuthExternalClientSecretAdd", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				clientsMock.APIInterface.On("AppsAuthExternalClientSecretAdd", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 				clientsMock.IO.On("PasswordPrompt", mock.Anything, "Enter the client secret", iostreams.MatchPromptConfig(iostreams.PasswordPromptConfig{
 					Flag: clientsMock.Config.Flags.Lookup("secret"),
 				})).Return(iostreams.PasswordPromptResponse{
@@ -169,26 +169,26 @@ func TestExternalAuthAddClientSecretCommand(t *testing.T) {
 			},
 			ExpectedOutputs: []string{},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.ApiInterface.AssertCalled(t, "AppsAuthExternalClientSecretAdd", mock.Anything, mock.Anything, fakeAppID, "provider_a", "secret_key_1234")
+				clientsMock.APIInterface.AssertCalled(t, "AppsAuthExternalClientSecretAdd", mock.Anything, mock.Anything, fakeAppID, "provider_a", "secret_key_1234")
 			},
 		},
 		"with --provider": {
 			CmdArgs: []string{"--provider", "provider_a"},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.ApiInterface.On("AppsAuthExternalList",
+				clientsMock.APIInterface.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(types.ExternalAuthorizationInfoLists{
 						Authorizations: []types.ExternalAuthorizationInfo{
 							{
 								ProviderName:       "Google",
 								ProviderKey:        "provider_google",
-								ClientId:           "xxxxx",
+								ClientID:           "xxxxx",
 								ClientSecretExists: true, ValidTokenExists: false,
 							},
 						},
 					}, nil)
 
-				clientsMock.ApiInterface.On("AppsAuthExternalClientSecretAdd", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				clientsMock.APIInterface.On("AppsAuthExternalClientSecretAdd", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 				clientsMock.IO.On("PasswordPrompt", mock.Anything, "Enter the client secret", iostreams.MatchPromptConfig(iostreams.PasswordPromptConfig{
 					Flag: clientsMock.Config.Flags.Lookup("secret"),
 				})).Return(iostreams.PasswordPromptResponse{
@@ -204,24 +204,24 @@ func TestExternalAuthAddClientSecretCommand(t *testing.T) {
 			},
 			ExpectedOutputs: []string{},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.ApiInterface.AssertCalled(t, "AppsAuthExternalClientSecretAdd", mock.Anything, mock.Anything, fakeAppID, "provider_a", "secret_key_1234")
+				clientsMock.APIInterface.AssertCalled(t, "AppsAuthExternalClientSecretAdd", mock.Anything, mock.Anything, fakeAppID, "provider_a", "secret_key_1234")
 			},
 		},
 		"with --secret": {
 			CmdArgs: []string{"--secret", "secret"},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.ApiInterface.On("AppsAuthExternalList",
+				clientsMock.APIInterface.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(types.ExternalAuthorizationInfoLists{
 						Authorizations: []types.ExternalAuthorizationInfo{
 							{
 								ProviderName:       "Google",
 								ProviderKey:        "provider_a",
-								ClientId:           "xxxxx",
+								ClientID:           "xxxxx",
 								ClientSecretExists: true, ValidTokenExists: false,
 							},
 						}}, nil)
-				clientsMock.ApiInterface.On("AppsAuthExternalClientSecretAdd", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				clientsMock.APIInterface.On("AppsAuthExternalClientSecretAdd", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 				clientsMock.IO.On("PasswordPrompt", mock.Anything, "Enter the client secret", iostreams.MatchPromptConfig(iostreams.PasswordPromptConfig{
 					Flag: clientsMock.Config.Flags.Lookup("secret"),
 				})).Return(iostreams.PasswordPromptResponse{
@@ -237,24 +237,24 @@ func TestExternalAuthAddClientSecretCommand(t *testing.T) {
 			},
 			ExpectedOutputs: []string{},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.ApiInterface.AssertCalled(t, "AppsAuthExternalClientSecretAdd", mock.Anything, mock.Anything, fakeAppID, "provider_a", "secret")
+				clientsMock.APIInterface.AssertCalled(t, "AppsAuthExternalClientSecretAdd", mock.Anything, mock.Anything, fakeAppID, "provider_a", "secret")
 			},
 		},
 		"with --provider and --secret": {
 			CmdArgs: []string{"--provider", "provider_a", "--secret", "secret"},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.ApiInterface.On("AppsAuthExternalList",
+				clientsMock.APIInterface.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything).
 					Return(types.ExternalAuthorizationInfoLists{
 						Authorizations: []types.ExternalAuthorizationInfo{
 							{
 								ProviderName:       "Google",
 								ProviderKey:        "provider_a",
-								ClientId:           "xxxxx",
+								ClientID:           "xxxxx",
 								ClientSecretExists: true, ValidTokenExists: false,
 							},
 						}}, nil)
-				clientsMock.ApiInterface.On("AppsAuthExternalClientSecretAdd", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				clientsMock.APIInterface.On("AppsAuthExternalClientSecretAdd", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 				clientsMock.IO.On("PasswordPrompt", mock.Anything, "Enter the client secret", iostreams.MatchPromptConfig(iostreams.PasswordPromptConfig{
 					Flag: clientsMock.Config.Flags.Lookup("secret"),
 				})).Return(iostreams.PasswordPromptResponse{
@@ -269,17 +269,17 @@ func TestExternalAuthAddClientSecretCommand(t *testing.T) {
 				require.NoError(t, err, "Cant write apps.json")
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.ApiInterface.AssertCalled(t, "AppsAuthExternalClientSecretAdd", mock.Anything, mock.Anything, fakeAppID, "provider_a", "secret")
+				clientsMock.APIInterface.AssertCalled(t, "AppsAuthExternalClientSecretAdd", mock.Anything, mock.Anything, fakeAppID, "provider_a", "secret")
 			},
 		},
 		"when list api returns error": {
 			CmdArgs: []string{"--provider", "provider_a", "--secret", "secret"},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.ApiInterface.On("AppsAuthExternalList",
+				clientsMock.APIInterface.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(types.ExternalAuthorizationInfoLists{
 						Authorizations: []types.ExternalAuthorizationInfo{}}, errors.New("test error"))
-				clientsMock.ApiInterface.On("AppsAuthExternalClientSecretAdd", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("https://authorizationurl.com", nil)
+				clientsMock.APIInterface.On("AppsAuthExternalClientSecretAdd", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("https://authorizationurl.com", nil)
 				clientsMock.IO.On("PasswordPrompt", mock.Anything, "Enter the client secret", iostreams.MatchPromptConfig(iostreams.PasswordPromptConfig{
 					Flag: clientsMock.Config.Flags.Lookup("secret"),
 				})).Return(iostreams.PasswordPromptResponse{
@@ -295,7 +295,7 @@ func TestExternalAuthAddClientSecretCommand(t *testing.T) {
 			},
 			ExpectedErrorStrings: []string{"test error"},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.ApiInterface.AssertNotCalled(t, "AppsAuthExternalClientSecretAdd", mock.Anything, mock.Anything, fakeAppID, "provider_a")
+				clientsMock.APIInterface.AssertNotCalled(t, "AppsAuthExternalClientSecretAdd", mock.Anything, mock.Anything, fakeAppID, "provider_a")
 			},
 		},
 	}, func(clients *shared.ClientFactory) *cobra.Command {

--- a/cmd/externalauth/add_test.go
+++ b/cmd/externalauth/add_test.go
@@ -44,12 +44,12 @@ func TestExternalAuthAddCommandPreRun(t *testing.T) {
 			mockManifestResponse: types.SlackYaml{
 				AppManifest: types.AppManifest{
 					Settings: &types.AppSettings{
-						FunctionRuntime: types.SLACK_HOSTED,
+						FunctionRuntime: types.SlackHosted,
 					},
 				},
 			},
 			mockManifestError:    nil,
-			mockManifestSource:   config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:   config.ManifestSourceLocal,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        nil,
 		},
@@ -57,12 +57,12 @@ func TestExternalAuthAddCommandPreRun(t *testing.T) {
 			mockManifestResponse: types.SlackYaml{
 				AppManifest: types.AppManifest{
 					Settings: &types.AppSettings{
-						FunctionRuntime: types.REMOTE,
+						FunctionRuntime: types.Remote,
 					},
 				},
 			},
 			mockManifestError:    nil,
-			mockManifestSource:   config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:   config.ManifestSourceLocal,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        slackerror.New(slackerror.ErrAppNotHosted),
 		},
@@ -74,19 +74,19 @@ func TestExternalAuthAddCommandPreRun(t *testing.T) {
 		"errors if the project manifest cannot be retrieved": {
 			mockManifestResponse: types.SlackYaml{},
 			mockManifestError:    slackerror.New(slackerror.ErrSDKHookInvocationFailed),
-			mockManifestSource:   config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:   config.ManifestSourceLocal,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        slackerror.New(slackerror.ErrSDKHookInvocationFailed),
 		},
 		"errors if the command is not run in a project": {
 			mockManifestResponse: types.SlackYaml{},
 			mockManifestError:    slackerror.New(slackerror.ErrSDKHookNotFound),
-			mockManifestSource:   config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:   config.ManifestSourceLocal,
 			mockWorkingDirectory: "",
 			expectedError:        slackerror.New(slackerror.ErrInvalidAppDirectory),
 		},
 		"errors if the manifest source is set to remote": {
-			mockManifestSource:   config.MANIFEST_SOURCE_REMOTE,
+			mockManifestSource:   config.ManifestSourceRemote,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        slackerror.New(slackerror.ErrAppNotHosted),
 		},
@@ -141,18 +141,18 @@ func TestExternalAuthAddCommand(t *testing.T) {
 			CmdArgs:         []string{},
 			ExpectedOutputs: []string{},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.ApiInterface.On("AppsAuthExternalList",
+				clientsMock.APIInterface.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(types.ExternalAuthorizationInfoLists{
 						Authorizations: []types.ExternalAuthorizationInfo{
 							{
 								ProviderName:       "Google",
 								ProviderKey:        "provider_a",
-								ClientId:           "xxxxx",
+								ClientID:           "xxxxx",
 								ClientSecretExists: true, ValidTokenExists: false,
 							},
 						}}, nil)
-				clientsMock.ApiInterface.On("AppsAuthExternalStart", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("https://authorizationurl1.com", nil)
+				clientsMock.APIInterface.On("AppsAuthExternalStart", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("https://authorizationurl1.com", nil)
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
 				// TODO this can probably be replaced by a helper that sets up an apps.json file in
@@ -161,7 +161,7 @@ func TestExternalAuthAddCommand(t *testing.T) {
 				require.NoError(t, err, "Cant write apps.json")
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.ApiInterface.AssertCalled(t, "AppsAuthExternalStart", mock.Anything, mock.Anything, fakeAppID, "provider_a")
+				clientsMock.APIInterface.AssertCalled(t, "AppsAuthExternalStart", mock.Anything, mock.Anything, fakeAppID, "provider_a")
 				clientsMock.Browser.AssertCalled(t, "OpenURL", "https://authorizationurl1.com")
 			},
 		},
@@ -169,18 +169,18 @@ func TestExternalAuthAddCommand(t *testing.T) {
 			CmdArgs:              []string{},
 			ExpectedErrorStrings: []string{"No client secret exists"},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.ApiInterface.On("AppsAuthExternalList",
+				clientsMock.APIInterface.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(types.ExternalAuthorizationInfoLists{
 						Authorizations: []types.ExternalAuthorizationInfo{
 							{
 								ProviderName:       "Google",
 								ProviderKey:        "provider_a",
-								ClientId:           "xxxxx",
+								ClientID:           "xxxxx",
 								ClientSecretExists: false, ValidTokenExists: false,
 							},
 						}}, nil)
-				clientsMock.ApiInterface.On("AppsAuthExternalStart", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("https://authorizationurl2.com/example", nil)
+				clientsMock.APIInterface.On("AppsAuthExternalStart", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("https://authorizationurl2.com/example", nil)
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
 				// TODO this can probably be replaced by a helper that sets up an apps.json file in
@@ -189,7 +189,7 @@ func TestExternalAuthAddCommand(t *testing.T) {
 				require.NoError(t, err, "Cant write apps.json")
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.ApiInterface.AssertNotCalled(t, "AppsAuthExternalStart")
+				clientsMock.APIInterface.AssertNotCalled(t, "AppsAuthExternalStart")
 				clientsMock.Browser.AssertNotCalled(t, "OpenURL")
 			},
 		},
@@ -197,18 +197,18 @@ func TestExternalAuthAddCommand(t *testing.T) {
 			CmdArgs:         []string{"--provider", "provider_a"},
 			ExpectedOutputs: []string{},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.ApiInterface.On("AppsAuthExternalList",
+				clientsMock.APIInterface.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(types.ExternalAuthorizationInfoLists{
 						Authorizations: []types.ExternalAuthorizationInfo{
 							{
 								ProviderName:       "Google",
 								ProviderKey:        "provider_a",
-								ClientId:           "xxxxx",
+								ClientID:           "xxxxx",
 								ClientSecretExists: true, ValidTokenExists: false,
 							},
 						}}, nil)
-				clientsMock.ApiInterface.On("AppsAuthExternalStart", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("https://authorizationurl3.com/provider", nil)
+				clientsMock.APIInterface.On("AppsAuthExternalStart", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("https://authorizationurl3.com/provider", nil)
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
 				// TODO this can probably be replaced by a helper that sets up an apps.json file in
@@ -217,7 +217,7 @@ func TestExternalAuthAddCommand(t *testing.T) {
 				require.NoError(t, err, "Cant write apps.json")
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.ApiInterface.AssertCalled(t, "AppsAuthExternalStart", mock.Anything, mock.Anything, fakeAppID, "provider_a")
+				clientsMock.APIInterface.AssertCalled(t, "AppsAuthExternalStart", mock.Anything, mock.Anything, fakeAppID, "provider_a")
 				clientsMock.Browser.AssertCalled(t, "OpenURL", "https://authorizationurl3.com/provider")
 			},
 		},
@@ -225,19 +225,19 @@ func TestExternalAuthAddCommand(t *testing.T) {
 			CmdArgs:              []string{"--provider", "provider_a"},
 			ExpectedErrorStrings: []string{"No client secret exists"},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.ApiInterface.On("AppsAuthExternalList",
+				clientsMock.APIInterface.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(types.ExternalAuthorizationInfoLists{
 						Authorizations: []types.ExternalAuthorizationInfo{
 							{
 								ProviderName:       "Google",
 								ProviderKey:        "provider_a",
-								ClientId:           "xxxxx",
+								ClientID:           "xxxxx",
 								ClientSecretExists: false, ValidTokenExists: false,
 							},
 						}}, nil)
 				providerSelectTeardown = setupMockProviderSelection()
-				clientsMock.ApiInterface.On("AppsAuthExternalStart", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("https://authorizationurl4.com/secret", nil)
+				clientsMock.APIInterface.On("AppsAuthExternalStart", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("https://authorizationurl4.com/secret", nil)
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
 				// TODO this can probably be replaced by a helper that sets up an apps.json file in
@@ -246,18 +246,18 @@ func TestExternalAuthAddCommand(t *testing.T) {
 				require.NoError(t, err, "Cant write apps.json")
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.ApiInterface.AssertNotCalled(t, "AppsAuthExternalStart")
+				clientsMock.APIInterface.AssertNotCalled(t, "AppsAuthExternalStart")
 				clientsMock.Browser.AssertNotCalled(t, "OpenURL")
 			},
 		},
 		"when list api returns error": {
 			CmdArgs: []string{"--provider", "provider_a"},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.ApiInterface.On("AppsAuthExternalList",
+				clientsMock.APIInterface.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(types.ExternalAuthorizationInfoLists{
 						Authorizations: []types.ExternalAuthorizationInfo{}}, errors.New("test error"))
-				clientsMock.ApiInterface.On("AppsAuthExternalStart", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("https://authorizationurl5.com/error", nil)
+				clientsMock.APIInterface.On("AppsAuthExternalStart", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("https://authorizationurl5.com/error", nil)
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
 				// TODO this can probably be replaced by a helper that sets up an apps.json file in
@@ -267,7 +267,7 @@ func TestExternalAuthAddCommand(t *testing.T) {
 			},
 			ExpectedErrorStrings: []string{"test error"},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.ApiInterface.AssertNotCalled(t, "AppsAuthExternalStart", mock.Anything, mock.Anything, fakeAppID, "provider_a")
+				clientsMock.APIInterface.AssertNotCalled(t, "AppsAuthExternalStart", mock.Anything, mock.Anything, fakeAppID, "provider_a")
 				clientsMock.Browser.AssertNotCalled(t, "OpenURL")
 			},
 		},

--- a/cmd/externalauth/helpers_test.go
+++ b/cmd/externalauth/helpers_test.go
@@ -61,7 +61,7 @@ func setupMockTokenSelection() func() {
 	var originalPromptFunc = tokenSelectionFunc
 	tokenSelectionFunc = externalAuthMock.TokenSelectPrompt
 	externalAuthMock.On("TokenSelectPrompt").Return(types.ExternalTokenInfo{
-		ExternalTokenId: "Et0548LABCDE",
+		ExternalTokenID: "Et0548LABCDE",
 	}, nil)
 	return func() {
 		tokenSelectionFunc = originalPromptFunc

--- a/cmd/externalauth/remove.go
+++ b/cmd/externalauth/remove.go
@@ -187,7 +187,7 @@ func runRemoveCommand(clients *shared.ClientFactory, cmd *cobra.Command) error {
 			if err != nil {
 				return err
 			}
-			externalTokenArg := externalTokenInfo.ExternalTokenId
+			externalTokenArg := externalTokenInfo.ExternalTokenID
 			if externalTokenArg == "" {
 				return slackerror.New("Unable to get a provider selection")
 			}

--- a/cmd/externalauth/remove.go
+++ b/cmd/externalauth/remove.go
@@ -121,7 +121,7 @@ func runRemoveCommand(clients *shared.ClientFactory, cmd *cobra.Command) error {
 			return nil
 		}
 
-		err = clients.ApiInterface().AppsAuthExternalDelete(
+		err = clients.APIInterface().AppsAuthExternalDelete(
 			ctx,
 			selection.Auth.Token,
 			selection.App.AppID,
@@ -142,7 +142,7 @@ func runRemoveCommand(clients *shared.ClientFactory, cmd *cobra.Command) error {
 			return nil
 		}
 
-		err = clients.ApiInterface().AppsAuthExternalDelete(
+		err = clients.APIInterface().AppsAuthExternalDelete(
 			ctx,
 			selection.Auth.Token,
 			selection.App.AppID,
@@ -154,7 +154,7 @@ func runRemoveCommand(clients *shared.ClientFactory, cmd *cobra.Command) error {
 		}
 	} else {
 		// Get oauth2 providerAuths
-		providerAuths, err := clients.ApiInterface().AppsAuthExternalList(
+		providerAuths, err := clients.APIInterface().AppsAuthExternalList(
 			ctx,
 			selection.Auth.Token,
 			selection.App.AppID,
@@ -191,7 +191,7 @@ func runRemoveCommand(clients *shared.ClientFactory, cmd *cobra.Command) error {
 			if externalTokenArg == "" {
 				return slackerror.New("Unable to get a provider selection")
 			}
-			err = clients.ApiInterface().AppsAuthExternalDelete(
+			err = clients.APIInterface().AppsAuthExternalDelete(
 				ctx,
 				selection.Auth.Token,
 				selection.App.AppID,
@@ -202,7 +202,7 @@ func runRemoveCommand(clients *shared.ClientFactory, cmd *cobra.Command) error {
 				return err
 			}
 		} else {
-			err = clients.ApiInterface().AppsAuthExternalDelete(
+			err = clients.APIInterface().AppsAuthExternalDelete(
 				ctx,
 				selection.Auth.Token,
 				selection.App.AppID,

--- a/cmd/externalauth/remove_test.go
+++ b/cmd/externalauth/remove_test.go
@@ -44,12 +44,12 @@ func TestExternalAuthRemoveCommandPreRun(t *testing.T) {
 			mockManifestResponse: types.SlackYaml{
 				AppManifest: types.AppManifest{
 					Settings: &types.AppSettings{
-						FunctionRuntime: types.SLACK_HOSTED,
+						FunctionRuntime: types.SlackHosted,
 					},
 				},
 			},
 			mockManifestError:    nil,
-			mockManifestSource:   config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:   config.ManifestSourceLocal,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        nil,
 		},
@@ -57,12 +57,12 @@ func TestExternalAuthRemoveCommandPreRun(t *testing.T) {
 			mockManifestResponse: types.SlackYaml{
 				AppManifest: types.AppManifest{
 					Settings: &types.AppSettings{
-						FunctionRuntime: types.REMOTE,
+						FunctionRuntime: types.Remote,
 					},
 				},
 			},
 			mockManifestError:    nil,
-			mockManifestSource:   config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:   config.ManifestSourceLocal,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        slackerror.New(slackerror.ErrAppNotHosted),
 		},
@@ -74,7 +74,7 @@ func TestExternalAuthRemoveCommandPreRun(t *testing.T) {
 		"errors if the project manifest cannot be retrieved": {
 			mockManifestResponse: types.SlackYaml{},
 			mockManifestError:    slackerror.New(slackerror.ErrSDKHookInvocationFailed),
-			mockManifestSource:   config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:   config.ManifestSourceLocal,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        slackerror.New(slackerror.ErrSDKHookInvocationFailed),
 		},
@@ -85,7 +85,7 @@ func TestExternalAuthRemoveCommandPreRun(t *testing.T) {
 			expectedError:        slackerror.New(slackerror.ErrInvalidAppDirectory),
 		},
 		"errors if the manifest source is set to remote": {
-			mockManifestSource:   config.MANIFEST_SOURCE_REMOTE,
+			mockManifestSource:   config.ManifestSourceRemote,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        slackerror.New(slackerror.ErrAppNotHosted),
 		},
@@ -142,18 +142,18 @@ func TestExternalAuthRemoveCommand(t *testing.T) {
 			CmdArgs:         []string{},
 			ExpectedOutputs: []string{},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.ApiInterface.On("AppsAuthExternalList",
+				clientsMock.APIInterface.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything).
 					Return(types.ExternalAuthorizationInfoLists{
 						Authorizations: []types.ExternalAuthorizationInfo{
 							{
 								ProviderName:       "Google",
 								ProviderKey:        "provider_a",
-								ClientId:           "xxxxx",
+								ClientID:           "xxxxx",
 								ClientSecretExists: false, ValidTokenExists: false,
 							},
 						}}, nil)
-				clientsMock.ApiInterface.On("AppsAuthExternalDelete", mock.Anything, mock.Anything, mock.Anything, mock.Anything, "").Return(nil)
+				clientsMock.APIInterface.On("AppsAuthExternalDelete", mock.Anything, mock.Anything, mock.Anything, mock.Anything, "").Return(nil)
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
 				// TODO this can probably be replaced by a helper that sets up an apps.json file in
@@ -162,75 +162,75 @@ func TestExternalAuthRemoveCommand(t *testing.T) {
 				require.NoError(t, err, "Cant write apps.json")
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.ApiInterface.AssertCalled(t, "AppsAuthExternalDelete", mock.Anything, mock.Anything, fakeAppID, "provider_a", "")
+				clientsMock.APIInterface.AssertCalled(t, "AppsAuthExternalDelete", mock.Anything, mock.Anything, fakeAppID, "provider_a", "")
 			},
 		},
 		"with --provider": {
 			CmdArgs:         []string{"--provider", "provider_a"},
 			ExpectedOutputs: []string{},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.ApiInterface.On("AppsAuthExternalList",
+				clientsMock.APIInterface.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything).
 					Return(types.ExternalAuthorizationInfoLists{
 						Authorizations: []types.ExternalAuthorizationInfo{
 							{
 								ProviderName:       "Google",
 								ProviderKey:        "provider_a",
-								ClientId:           "xxxxx",
+								ClientID:           "xxxxx",
 								ClientSecretExists: true, ValidTokenExists: false,
 							},
 						}}, nil)
-				clientsMock.ApiInterface.On("AppsAuthExternalDelete", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				clientsMock.APIInterface.On("AppsAuthExternalDelete", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 				clientsMock.AddDefaultMocks()
 				clientsMock.IO.On("ConfirmPrompt", mock.Anything, "Are you sure you want to remove all tokens for this app relevant to the specified provider from your current team/org?", mock.Anything).Return(true)
 				err := clients.AppClient().SaveDeployed(ctx, fakeApp)
 				require.NoError(t, err, "Cant write apps.json")
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.ApiInterface.AssertCalled(t, "AppsAuthExternalDelete", mock.Anything, mock.Anything, fakeAppID, "provider_a", "")
+				clientsMock.APIInterface.AssertCalled(t, "AppsAuthExternalDelete", mock.Anything, mock.Anything, fakeAppID, "provider_a", "")
 			},
 		},
 		"with --all": {
 			CmdArgs:         []string{"--all"},
 			ExpectedOutputs: []string{},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.ApiInterface.On("AppsAuthExternalList",
+				clientsMock.APIInterface.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything).
 					Return(types.ExternalAuthorizationInfoLists{
 						Authorizations: []types.ExternalAuthorizationInfo{
 							{
 								ProviderName:       "Google",
 								ProviderKey:        "provider_a",
-								ClientId:           "xxxxx",
+								ClientID:           "xxxxx",
 								ClientSecretExists: true, ValidTokenExists: false,
 							},
 						}}, nil)
-				clientsMock.ApiInterface.On("AppsAuthExternalDelete", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				clientsMock.APIInterface.On("AppsAuthExternalDelete", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 				clientsMock.AddDefaultMocks()
 				err := clients.AppClient().SaveDeployed(ctx, fakeApp)
 				require.NoError(t, err, "Cant write apps.json")
 				clientsMock.IO.On("ConfirmPrompt", mock.Anything, "Are you sure you want to remove all tokens for this app from your current team/org?", mock.Anything).Return(true)
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.ApiInterface.AssertCalled(t, "AppsAuthExternalDelete", mock.Anything, mock.Anything, fakeAppID, "", "")
+				clientsMock.APIInterface.AssertCalled(t, "AppsAuthExternalDelete", mock.Anything, mock.Anything, fakeAppID, "", "")
 			},
 		},
 		"with --all and --provider": {
 			CmdArgs:         []string{"--all", "--provider", "provider_a"},
 			ExpectedOutputs: []string{},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.ApiInterface.On("AppsAuthExternalList",
+				clientsMock.APIInterface.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything).
 					Return(types.ExternalAuthorizationInfoLists{
 						Authorizations: []types.ExternalAuthorizationInfo{
 							{
 								ProviderName:       "Google",
 								ProviderKey:        "provider_a",
-								ClientId:           "xxxxx",
+								ClientID:           "xxxxx",
 								ClientSecretExists: true, ValidTokenExists: false,
 							},
 						}}, nil)
-				clientsMock.ApiInterface.On("AppsAuthExternalDelete", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				clientsMock.APIInterface.On("AppsAuthExternalDelete", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 				clientsMock.AddDefaultMocks()
 				err := clients.AppClient().SaveDeployed(ctx, fakeApp)
 				require.NoError(t, err, "Cant write apps.json")
@@ -238,24 +238,24 @@ func TestExternalAuthRemoveCommand(t *testing.T) {
 				clientsMock.IO.On("ConfirmPrompt", mock.Anything, "Are you sure you want to remove all tokens for this app relevant to the specified provider from your current team/org?", mock.Anything).Return(true)
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.ApiInterface.AssertCalled(t, "AppsAuthExternalDelete", mock.Anything, mock.Anything, fakeAppID, "provider_a", "")
+				clientsMock.APIInterface.AssertCalled(t, "AppsAuthExternalDelete", mock.Anything, mock.Anything, fakeAppID, "provider_a", "")
 			},
 		},
 		"with --all but no auth present": {
 			CmdArgs: []string{"--all"},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.ApiInterface.On("AppsAuthExternalList",
+				clientsMock.APIInterface.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything).
 					Return(types.ExternalAuthorizationInfoLists{
 						Authorizations: []types.ExternalAuthorizationInfo{}}, errors.New("test error"))
-				clientsMock.ApiInterface.On("AppsAuthExternalDelete", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				clientsMock.APIInterface.On("AppsAuthExternalDelete", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 				clientsMock.AddDefaultMocks()
 				err := clients.AppClient().SaveDeployed(ctx, fakeApp)
 				require.NoError(t, err, "Cant write apps.json")
 				clientsMock.IO.On("ConfirmPrompt", mock.Anything, "Are you sure you want to remove all tokens for this app from your current team/org?", mock.Anything).Return(true)
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.ApiInterface.AssertCalled(t, "AppsAuthExternalDelete", mock.Anything, mock.Anything, fakeAppID, "", "")
+				clientsMock.APIInterface.AssertCalled(t, "AppsAuthExternalDelete", mock.Anything, mock.Anything, fakeAppID, "", "")
 			},
 		},
 	}, func(clients *shared.ClientFactory) *cobra.Command {

--- a/cmd/externalauth/select_auth.go
+++ b/cmd/externalauth/select_auth.go
@@ -138,7 +138,7 @@ func runSelectAuthCommand(clients *shared.ClientFactory, cmd *cobra.Command) err
 	if err != nil {
 		return err
 	}
-	if selectedAuth.ExternalTokenId == "" {
+	if selectedAuth.ExternalTokenID == "" {
 		return slackerror.New("Account is not used in the selected workflow")
 	}
 
@@ -148,7 +148,7 @@ func runSelectAuthCommand(clients *shared.ClientFactory, cmd *cobra.Command) err
 		selection.App.AppID,
 		selectedProviderAuth.ProviderKey,
 		selectedWorkflowAuth.WorkflowId,
-		selectedAuth.ExternalTokenId,
+		selectedAuth.ExternalTokenID,
 	)
 	if err != nil {
 		return slackerror.New(err.Error())

--- a/cmd/externalauth/select_auth.go
+++ b/cmd/externalauth/select_auth.go
@@ -92,7 +92,7 @@ func runSelectAuthCommand(clients *shared.ClientFactory, cmd *cobra.Command) err
 	}
 
 	// Get the oauth2 details for the app
-	externalAuths, err := clients.ApiInterface().AppsAuthExternalList(
+	externalAuths, err := clients.APIInterface().AppsAuthExternalList(
 		ctx,
 		selection.Auth.Token,
 		selection.App.AppID,
@@ -110,10 +110,10 @@ func runSelectAuthCommand(clients *shared.ClientFactory, cmd *cobra.Command) err
 		}
 		return err
 	}
-	if selectedWorkflowAuth.CallBackId == "" {
+	if selectedWorkflowAuth.CallBackID == "" {
 		return slackerror.New(slackerror.ErrWorkflowNotFound)
 	}
-	if selectedWorkflowAuth.WorkflowId == "" {
+	if selectedWorkflowAuth.WorkflowID == "" {
 		return slackerror.New("Unable to get a workflow selection")
 	}
 
@@ -142,12 +142,12 @@ func runSelectAuthCommand(clients *shared.ClientFactory, cmd *cobra.Command) err
 		return slackerror.New("Account is not used in the selected workflow")
 	}
 
-	err = clients.ApiInterface().AppsAuthExternalSelectAuth(
+	err = clients.APIInterface().AppsAuthExternalSelectAuth(
 		ctx,
 		selection.Auth.Token,
 		selection.App.AppID,
 		selectedProviderAuth.ProviderKey,
-		selectedWorkflowAuth.WorkflowId,
+		selectedWorkflowAuth.WorkflowID,
 		selectedAuth.ExternalTokenID,
 	)
 	if err != nil {
@@ -158,8 +158,8 @@ func runSelectAuthCommand(clients *shared.ClientFactory, cmd *cobra.Command) err
 		Emoji: "sparkles",
 		Text: fmt.Sprintf(
 			"Workflow #/workflows/%s will use developer account %s when making calls to %s APIs",
-			selectedWorkflowAuth.CallBackId,
-			selectedAuth.ExternalUserId,
+			selectedWorkflowAuth.CallBackID,
+			selectedAuth.ExternalUserID,
 			selectedProviderAuth.ProviderKey,
 		),
 	}))

--- a/cmd/externalauth/select_auth_test.go
+++ b/cmd/externalauth/select_auth_test.go
@@ -44,12 +44,12 @@ func TestExternalAuthSelectAuthCommandPreRun(t *testing.T) {
 			mockManifestResponse: types.SlackYaml{
 				AppManifest: types.AppManifest{
 					Settings: &types.AppSettings{
-						FunctionRuntime: types.SLACK_HOSTED,
+						FunctionRuntime: types.SlackHosted,
 					},
 				},
 			},
 			mockManifestError:    nil,
-			mockManifestSource:   config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:   config.ManifestSourceLocal,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        nil,
 		},
@@ -57,13 +57,13 @@ func TestExternalAuthSelectAuthCommandPreRun(t *testing.T) {
 			mockManifestResponse: types.SlackYaml{
 				AppManifest: types.AppManifest{
 					Settings: &types.AppSettings{
-						FunctionRuntime: types.REMOTE,
+						FunctionRuntime: types.Remote,
 					},
 				},
 			},
 			mockManifestError:    nil,
 			mockWorkingDirectory: "/slack/path/to/project",
-			mockManifestSource:   config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:   config.ManifestSourceLocal,
 			expectedError:        slackerror.New(slackerror.ErrAppNotHosted),
 		},
 		"continues if the force flag is used in a project": {
@@ -74,19 +74,19 @@ func TestExternalAuthSelectAuthCommandPreRun(t *testing.T) {
 		"errors if the project manifest cannot be retrieved": {
 			mockManifestResponse: types.SlackYaml{},
 			mockManifestError:    slackerror.New(slackerror.ErrSDKHookInvocationFailed),
-			mockManifestSource:   config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:   config.ManifestSourceLocal,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        slackerror.New(slackerror.ErrSDKHookInvocationFailed),
 		},
 		"errors if the command is not run in a project": {
 			mockManifestResponse: types.SlackYaml{},
 			mockManifestError:    slackerror.New(slackerror.ErrSDKHookNotFound),
-			mockManifestSource:   config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:   config.ManifestSourceLocal,
 			mockWorkingDirectory: "",
 			expectedError:        slackerror.New(slackerror.ErrInvalidAppDirectory),
 		},
 		"errors if the manifest source is set to remote": {
-			mockManifestSource:   config.MANIFEST_SOURCE_REMOTE,
+			mockManifestSource:   config.ManifestSourceRemote,
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        slackerror.New(slackerror.ErrAppNotHosted),
 		},
@@ -139,7 +139,7 @@ func TestExternalAuthSelectAuthCommand(t *testing.T) {
 			{
 				ProviderName:       "Google",
 				ProviderKey:        "provider_a",
-				ClientId:           "xxxxx",
+				ClientID:           "xxxxx",
 				ClientSecretExists: true,
 				ValidTokenExists:   false,
 			},
@@ -149,19 +149,19 @@ func TestExternalAuthSelectAuthCommand(t *testing.T) {
 			{
 				ProviderName:       "Provider_A",
 				ProviderKey:        "provider_a",
-				ClientId:           "xxxxx",
+				ClientID:           "xxxxx",
 				ClientSecretExists: true,
 				ValidTokenExists:   true,
 				ExternalTokenIDs:   []string{"Et0548LYDWCT"},
 				ExternalTokens: []types.ExternalTokenInfo{
 					{
 						ExternalTokenID: "Et0548LABCD1",
-						ExternalUserId:  "xyz@salesforce.com",
+						ExternalUserID:  "xyz@salesforce.com",
 						DateUpdated:     1682021142,
 					},
 					{
 						ExternalTokenID: "Et0548LABCDE2",
-						ExternalUserId:  "xyz2@salesforce.com",
+						ExternalUserID:  "xyz2@salesforce.com",
 						DateUpdated:     1682021192,
 					},
 				},
@@ -172,19 +172,19 @@ func TestExternalAuthSelectAuthCommand(t *testing.T) {
 			{
 				ProviderName:       "Provider_A",
 				ProviderKey:        "provider_a",
-				ClientId:           "xxxxx",
+				ClientID:           "xxxxx",
 				ClientSecretExists: true,
 				ValidTokenExists:   true,
 				ExternalTokenIDs:   []string{"Et0548LYDWCT"},
 				ExternalTokens: []types.ExternalTokenInfo{
 					{
 						ExternalTokenID: "Et0548LABCD1",
-						ExternalUserId:  "xyz@salesforce.com",
+						ExternalUserID:  "xyz@salesforce.com",
 						DateUpdated:     1682021142,
 					},
 					{
 						ExternalTokenID: "Et0548LABCDE2",
-						ExternalUserId:  "xyz2@salesforce.com",
+						ExternalUserID:  "xyz2@salesforce.com",
 						DateUpdated:     1682021192,
 					},
 				},
@@ -192,7 +192,7 @@ func TestExternalAuthSelectAuthCommand(t *testing.T) {
 			{
 				ProviderName:       "Provider_B",
 				ProviderKey:        "provider_b",
-				ClientId:           "xxxxx",
+				ClientID:           "xxxxx",
 				ClientSecretExists: true,
 				ValidTokenExists:   false,
 				ExternalTokenIDs:   []string{"Et0548LYDWCT"},
@@ -201,8 +201,8 @@ func TestExternalAuthSelectAuthCommand(t *testing.T) {
 		},
 		Workflows: []types.WorkflowsInfo{
 			{
-				WorkflowId: "Wf0548LABCD1",
-				CallBackId: "my_callback_id1",
+				WorkflowID: "Wf0548LABCD1",
+				CallBackID: "my_callback_id1",
 				Providers: []types.ProvidersInfo{
 					{
 						ProviderKey:  "provider_c",
@@ -217,15 +217,15 @@ func TestExternalAuthSelectAuthCommand(t *testing.T) {
 						ProviderName: "Provider_A",
 						SelectedAuth: types.ExternalTokenInfo{
 							ExternalTokenID: "Et0548LABCD1",
-							ExternalUserId:  "xyz@salesforce.com",
+							ExternalUserID:  "xyz@salesforce.com",
 							DateUpdated:     1682021142,
 						},
 					},
 				},
 			},
 			{
-				WorkflowId: "Wf0548LABCD2",
-				CallBackId: "my_callback_id2",
+				WorkflowID: "Wf0548LABCD2",
+				CallBackID: "my_callback_id2",
 				Providers: []types.ProvidersInfo{
 					{
 						ProviderKey:  "provider_a",
@@ -244,19 +244,19 @@ func TestExternalAuthSelectAuthCommand(t *testing.T) {
 		"list api returns error": {
 			CmdArgs: []string{},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.ApiInterface.On("AppsAuthExternalList",
+				clientsMock.APIInterface.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(types.ExternalAuthorizationInfoLists{}, errors.New("test error"))
 			},
 			ExpectedErrorStrings: []string{"test error"},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.ApiInterface.AssertNotCalled(t, "AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+				clientsMock.APIInterface.AssertNotCalled(t, "AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 			},
 		},
 		"list with no tokens and no params": {
 			CmdArgs: []string{},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.ApiInterface.On("AppsAuthExternalList",
+				clientsMock.APIInterface.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(sampleListReturnWithoutTokens, nil)
 				clientsMock.IO.On("SelectPrompt", mock.Anything, "Select a workflow", mock.Anything, iostreams.MatchPromptConfig(iostreams.SelectPromptConfig{
@@ -265,13 +265,13 @@ func TestExternalAuthSelectAuthCommand(t *testing.T) {
 			},
 			ExpectedErrorStrings: []string{"No workflows found that require developer authorization"},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.ApiInterface.AssertNotCalled(t, "AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, fakeAppID, mock.Anything, mock.Anything)
+				clientsMock.APIInterface.AssertNotCalled(t, "AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, fakeAppID, mock.Anything, mock.Anything)
 			},
 		},
 		"list with no tokens and workflow flag": {
 			CmdArgs: []string{"--workflow", "#/workflows/workflow_callback"},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.ApiInterface.On("AppsAuthExternalList",
+				clientsMock.APIInterface.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(sampleListReturnWithoutTokens, nil)
 				clientsMock.IO.On("SelectPrompt", mock.Anything, "Select a workflow", mock.Anything, iostreams.MatchPromptConfig(iostreams.SelectPromptConfig{
@@ -283,13 +283,13 @@ func TestExternalAuthSelectAuthCommand(t *testing.T) {
 			},
 			ExpectedErrorStrings: []string{"Workflow not found"},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.ApiInterface.AssertNotCalled(t, "AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, fakeAppID, mock.Anything, mock.Anything, mock.Anything)
+				clientsMock.APIInterface.AssertNotCalled(t, "AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, fakeAppID, mock.Anything, mock.Anything, mock.Anything)
 			},
 		},
 		"list with no workflows and no params": {
 			CmdArgs: []string{},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.ApiInterface.On("AppsAuthExternalList",
+				clientsMock.APIInterface.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(sampleListReturnWithoutWorkflows, nil)
 				clientsMock.IO.On("SelectPrompt", mock.Anything, "Select a workflow", mock.Anything, iostreams.MatchPromptConfig(iostreams.SelectPromptConfig{
@@ -298,13 +298,13 @@ func TestExternalAuthSelectAuthCommand(t *testing.T) {
 			},
 			ExpectedErrorStrings: []string{"No workflows found that require developer authorization"},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.ApiInterface.AssertNotCalled(t, "AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, fakeAppID, mock.Anything, mock.Anything, mock.Anything)
+				clientsMock.APIInterface.AssertNotCalled(t, "AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, fakeAppID, mock.Anything, mock.Anything, mock.Anything)
 			},
 		},
 		"list with no workflows and workflow flag": {
 			CmdArgs: []string{"--workflow", "#/workflows/workflow_callback"},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.ApiInterface.On("AppsAuthExternalList",
+				clientsMock.APIInterface.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(sampleListReturnWithoutWorkflows, nil)
 				clientsMock.IO.On("SelectPrompt", mock.Anything, "Select a workflow", mock.Anything, iostreams.MatchPromptConfig(iostreams.SelectPromptConfig{
@@ -316,13 +316,13 @@ func TestExternalAuthSelectAuthCommand(t *testing.T) {
 			},
 			ExpectedErrorStrings: []string{"Workflow not found"},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.ApiInterface.AssertNotCalled(t, "AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, fakeAppID, mock.Anything, mock.Anything, mock.Anything)
+				clientsMock.APIInterface.AssertNotCalled(t, "AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, fakeAppID, mock.Anything, mock.Anything, mock.Anything)
 			},
 		},
 		"list with workflows and no param": {
 			CmdArgs: []string{},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.ApiInterface.On("AppsAuthExternalList",
+				clientsMock.APIInterface.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(sampleListReturnWithWorkflows, nil)
 				clientsMock.IO.On("SelectPrompt", mock.Anything, "Select a workflow", mock.Anything, iostreams.MatchPromptConfig(iostreams.SelectPromptConfig{
@@ -342,13 +342,13 @@ func TestExternalAuthSelectAuthCommand(t *testing.T) {
 			},
 			ExpectedErrorStrings: []string{"No connected accounts found"},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.ApiInterface.AssertNotCalled(t, "AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, fakeAppID, mock.Anything, mock.Anything, mock.Anything)
+				clientsMock.APIInterface.AssertNotCalled(t, "AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, fakeAppID, mock.Anything, mock.Anything, mock.Anything)
 			},
 		},
 		"list with workflows and invalid workflow param": {
 			CmdArgs: []string{"--workflow", "#/workflows/workflow_callback"},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.ApiInterface.On("AppsAuthExternalList",
+				clientsMock.APIInterface.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(sampleListReturnWithWorkflows, nil)
 				clientsMock.IO.On("SelectPrompt", mock.Anything, "Select a workflow", mock.Anything, iostreams.MatchPromptConfig(iostreams.SelectPromptConfig{
@@ -374,16 +374,16 @@ func TestExternalAuthSelectAuthCommand(t *testing.T) {
 			},
 			ExpectedErrorStrings: []string{"Workflow not found"},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.ApiInterface.AssertNotCalled(t, "AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, fakeAppID, mock.Anything, mock.Anything, mock.Anything)
+				clientsMock.APIInterface.AssertNotCalled(t, "AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, fakeAppID, mock.Anything, mock.Anything, mock.Anything)
 			},
 		},
 		"list with workflows and valid workflow param": {
 			CmdArgs: []string{"--workflow", "#/workflows/my_callback_id2"},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.ApiInterface.On("AppsAuthExternalList",
+				clientsMock.APIInterface.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(sampleListReturnWithWorkflows, nil)
-				clientsMock.ApiInterface.On("AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				clientsMock.APIInterface.On("AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 				clientsMock.IO.On("SelectPrompt", mock.Anything, "Select a workflow", mock.Anything, iostreams.MatchPromptConfig(iostreams.SelectPromptConfig{
 					Flag: clientsMock.Config.Flags.Lookup("workflow"),
 				})).Return(iostreams.SelectPromptResponse{
@@ -399,13 +399,13 @@ func TestExternalAuthSelectAuthCommand(t *testing.T) {
 			},
 			ExpectedErrorStrings: []string{"No connected accounts found"},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.ApiInterface.AssertNotCalled(t, "AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, fakeAppID, mock.Anything, mock.Anything, mock.Anything)
+				clientsMock.APIInterface.AssertNotCalled(t, "AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, fakeAppID, mock.Anything, mock.Anything, mock.Anything)
 			},
 		},
 		"list with workflows and valid workflow invalid provider": {
 			CmdArgs: []string{"--workflow", "#/workflows/my_callback_id2", "--provider", "test_provider"},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.ApiInterface.On("AppsAuthExternalList",
+				clientsMock.APIInterface.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(sampleListReturnWithWorkflows, nil)
 				clientsMock.IO.On("SelectPrompt", mock.Anything, "Select a workflow", mock.Anything, iostreams.MatchPromptConfig(iostreams.SelectPromptConfig{
@@ -423,13 +423,13 @@ func TestExternalAuthSelectAuthCommand(t *testing.T) {
 			},
 			ExpectedErrorStrings: []string{"Provider is not used in the selected workflow"},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.ApiInterface.AssertNotCalled(t, "AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, fakeAppID, mock.Anything, mock.Anything, mock.Anything)
+				clientsMock.APIInterface.AssertNotCalled(t, "AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, fakeAppID, mock.Anything, mock.Anything, mock.Anything)
 			},
 		},
 		"list with workflows and valid workflow valid provider": {
 			CmdArgs: []string{"--workflow", "#/workflows/my_callback_id2", "--provider", "provider_b"},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.ApiInterface.On("AppsAuthExternalList",
+				clientsMock.APIInterface.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(sampleListReturnWithWorkflows, nil)
 				clientsMock.IO.On("SelectPrompt", mock.Anything, "Select a workflow", mock.Anything, iostreams.MatchPromptConfig(iostreams.SelectPromptConfig{
@@ -449,16 +449,16 @@ func TestExternalAuthSelectAuthCommand(t *testing.T) {
 			},
 			ExpectedErrorStrings: []string{"No connected accounts found"},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.ApiInterface.AssertNotCalled(t, "AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, fakeAppID, mock.Anything, mock.Anything, mock.Anything)
+				clientsMock.APIInterface.AssertNotCalled(t, "AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, fakeAppID, mock.Anything, mock.Anything, mock.Anything)
 			},
 		},
 		"list with workflows and valid workflow valid provider with tokens": {
 			CmdArgs: []string{"--workflow", "#/workflows/my_callback_id2", "--provider", "provider_a"},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.ApiInterface.On("AppsAuthExternalList",
+				clientsMock.APIInterface.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(sampleListReturnWithWorkflows, nil)
-				clientsMock.ApiInterface.On("AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				clientsMock.APIInterface.On("AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 				clientsMock.IO.On("SelectPrompt", mock.Anything, "Select a workflow", mock.Anything, iostreams.MatchPromptConfig(iostreams.SelectPromptConfig{
 					Flag: clientsMock.Config.Flags.Lookup("workflow"),
 				})).Return(iostreams.SelectPromptResponse{
@@ -481,16 +481,16 @@ func TestExternalAuthSelectAuthCommand(t *testing.T) {
 			},
 			ExpectedOutputs: []string{"Workflow #/workflows/my_callback_id2 will use developer account xyz2@salesforce.com when making calls to provider_a APIs"},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.ApiInterface.AssertCalled(t, "AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, fakeAppID, mock.Anything, mock.Anything, mock.Anything)
+				clientsMock.APIInterface.AssertCalled(t, "AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, fakeAppID, mock.Anything, mock.Anything, mock.Anything)
 			},
 		},
 		"list with workflows and valid workflow valid provider invalid account": {
 			CmdArgs: []string{"--workflow", "#/workflows/my_callback_id2", "--provider", "provider_a", "--external-account", "test_account"},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.ApiInterface.On("AppsAuthExternalList",
+				clientsMock.APIInterface.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(sampleListReturnWithWorkflows, nil)
-				clientsMock.ApiInterface.On("AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				clientsMock.APIInterface.On("AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 				clientsMock.IO.On("SelectPrompt", mock.Anything, "Select a workflow", mock.Anything, iostreams.MatchPromptConfig(iostreams.SelectPromptConfig{
 					Flag: clientsMock.Config.Flags.Lookup("workflow"),
 				})).Return(iostreams.SelectPromptResponse{
@@ -512,16 +512,16 @@ func TestExternalAuthSelectAuthCommand(t *testing.T) {
 			},
 			ExpectedErrorStrings: []string{"Account is not used in the selected workflow"},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.ApiInterface.AssertNotCalled(t, "AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, fakeAppID, mock.Anything, mock.Anything, mock.Anything)
+				clientsMock.APIInterface.AssertNotCalled(t, "AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, fakeAppID, mock.Anything, mock.Anything, mock.Anything)
 			},
 		},
 		"list with workflows and valid workflow valid provider valid account": {
 			CmdArgs: []string{"--workflow", "#/workflows/my_callback_id2", "--provider", "provider_a", "--external-account", "xyz2@salesforce.com"},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.ApiInterface.On("AppsAuthExternalList",
+				clientsMock.APIInterface.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(sampleListReturnWithWorkflows, nil)
-				clientsMock.ApiInterface.On("AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				clientsMock.APIInterface.On("AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 				clientsMock.IO.On("SelectPrompt", mock.Anything, "Select a workflow", mock.Anything, iostreams.MatchPromptConfig(iostreams.SelectPromptConfig{
 					Flag: clientsMock.Config.Flags.Lookup("workflow"),
 				})).Return(iostreams.SelectPromptResponse{
@@ -543,7 +543,7 @@ func TestExternalAuthSelectAuthCommand(t *testing.T) {
 			},
 			ExpectedOutputs: []string{"Workflow #/workflows/my_callback_id2 will use developer account xyz2@salesforce.com when making calls to provider_a APIs"},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.ApiInterface.AssertCalled(t, "AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, fakeAppID, mock.Anything, mock.Anything, mock.Anything)
+				clientsMock.APIInterface.AssertCalled(t, "AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, fakeAppID, mock.Anything, mock.Anything, mock.Anything)
 			},
 		}}, func(clients *shared.ClientFactory) *cobra.Command {
 		cmd := NewSelectAuthCommand(clients)

--- a/cmd/externalauth/select_auth_test.go
+++ b/cmd/externalauth/select_auth_test.go
@@ -152,15 +152,15 @@ func TestExternalAuthSelectAuthCommand(t *testing.T) {
 				ClientId:           "xxxxx",
 				ClientSecretExists: true,
 				ValidTokenExists:   true,
-				ExternalTokenIds:   []string{"Et0548LYDWCT"},
+				ExternalTokenIDs:   []string{"Et0548LYDWCT"},
 				ExternalTokens: []types.ExternalTokenInfo{
 					{
-						ExternalTokenId: "Et0548LABCD1",
+						ExternalTokenID: "Et0548LABCD1",
 						ExternalUserId:  "xyz@salesforce.com",
 						DateUpdated:     1682021142,
 					},
 					{
-						ExternalTokenId: "Et0548LABCDE2",
+						ExternalTokenID: "Et0548LABCDE2",
 						ExternalUserId:  "xyz2@salesforce.com",
 						DateUpdated:     1682021192,
 					},
@@ -175,15 +175,15 @@ func TestExternalAuthSelectAuthCommand(t *testing.T) {
 				ClientId:           "xxxxx",
 				ClientSecretExists: true,
 				ValidTokenExists:   true,
-				ExternalTokenIds:   []string{"Et0548LYDWCT"},
+				ExternalTokenIDs:   []string{"Et0548LYDWCT"},
 				ExternalTokens: []types.ExternalTokenInfo{
 					{
-						ExternalTokenId: "Et0548LABCD1",
+						ExternalTokenID: "Et0548LABCD1",
 						ExternalUserId:  "xyz@salesforce.com",
 						DateUpdated:     1682021142,
 					},
 					{
-						ExternalTokenId: "Et0548LABCDE2",
+						ExternalTokenID: "Et0548LABCDE2",
 						ExternalUserId:  "xyz2@salesforce.com",
 						DateUpdated:     1682021192,
 					},
@@ -195,7 +195,7 @@ func TestExternalAuthSelectAuthCommand(t *testing.T) {
 				ClientId:           "xxxxx",
 				ClientSecretExists: true,
 				ValidTokenExists:   false,
-				ExternalTokenIds:   []string{"Et0548LYDWCT"},
+				ExternalTokenIDs:   []string{"Et0548LYDWCT"},
 				ExternalTokens:     []types.ExternalTokenInfo{},
 			},
 		},
@@ -216,7 +216,7 @@ func TestExternalAuthSelectAuthCommand(t *testing.T) {
 						ProviderKey:  "provider_a",
 						ProviderName: "Provider_A",
 						SelectedAuth: types.ExternalTokenInfo{
-							ExternalTokenId: "Et0548LABCD1",
+							ExternalTokenID: "Et0548LABCD1",
 							ExternalUserId:  "xyz@salesforce.com",
 							DateUpdated:     1682021142,
 						},

--- a/cmd/fingerprint/fingerprint_test.go
+++ b/cmd/fingerprint/fingerprint_test.go
@@ -28,7 +28,7 @@ type FingerprintPkgMock struct {
 	mock.Mock
 }
 
-const fingerprintHash_test = "d41d8cd98f00b204e9800998ecf8427e"
+const fingerprintHashTest = "d41d8cd98f00b204e9800998ecf8427e"
 
 func TestFingerprintCommand(t *testing.T) {
 	// Create mocks
@@ -49,5 +49,5 @@ func TestFingerprintCommand(t *testing.T) {
 	}
 
 	output := clientsMock.GetCombinedOutput()
-	assert.Contains(t, output, fingerprintHash_test)
+	assert.Contains(t, output, fingerprintHashTest)
 }

--- a/cmd/function/access.go
+++ b/cmd/function/access.go
@@ -134,9 +134,9 @@ func handleUpdate(
 	if distributeFlags.file != "" {
 		return distributePermissionFile(ctx, clients, app, distributeFlags.file)
 	} else if distributeFlags.everyone || distributeFlags.appCollab {
-		distribution := types.EVERYONE
+		distribution := types.PermissionEveryone
 		if distributeFlags.appCollab {
-			distribution = types.APP_COLLABORATORS
+			distribution = types.PermissionAppCollaborators
 		}
 
 		_, err := clients.APIInterface().FunctionDistributionSet(ctx, functionFlag, app.AppID, distribution, "")
@@ -187,7 +187,7 @@ func handleUpdate(
 			return err
 		}
 
-		if dist == types.NAMED_ENTITIES {
+		if dist == types.PermissionNamedEntities {
 			err := printEntityAccess(ctx, cmd, clients, app)
 			if err != nil {
 				return err
@@ -271,15 +271,15 @@ func distributePermissionFile(ctx context.Context, clients *shared.ClientFactory
 						),
 						Remediation: fmt.Sprintf(
 							"Replace it with '%s', '%s', or '%s'",
-							types.EVERYONE,
-							types.APP_COLLABORATORS,
-							types.NAMED_ENTITIES,
+							types.PermissionEveryone,
+							types.PermissionAppCollaborators,
+							types.PermissionNamedEntities,
 						),
 					},
 				})
 		}
 		switch permissions.Type {
-		case types.NAMED_ENTITIES:
+		case types.PermissionNamedEntities:
 			if len(permissions.UserIDs) == 0 {
 				clients.IO.PrintWarning(ctx, fmt.Sprintf(
 					"No users will have access to '%s'",
@@ -317,7 +317,7 @@ func updateNamedEntitiesDistribution(
 	entities []string,
 ) error {
 	updatedUsers := strings.Join(entities, ",")
-	_, err := clients.APIInterface().FunctionDistributionSet(ctx, function, app.AppID, types.NAMED_ENTITIES, updatedUsers)
+	_, err := clients.APIInterface().FunctionDistributionSet(ctx, function, app.AppID, types.PermissionNamedEntities, updatedUsers)
 	if err != nil {
 		return err
 	}
@@ -353,7 +353,7 @@ func printDistribution(ctx context.Context, cmd *cobra.Command, clients *shared.
 		return err
 	}
 	var entities string
-	if dist == types.APP_COLLABORATORS {
+	if dist == types.PermissionAppCollaborators {
 		entities = "app collaborators"
 	} else {
 		entities = "the following users"
@@ -361,7 +361,7 @@ func printDistribution(ctx context.Context, cmd *cobra.Command, clients *shared.
 	var emoji string
 	var secondary []string
 	switch {
-	case dist == types.EVERYONE:
+	case dist == types.PermissionEveryone:
 		emoji = "busts_in_silhouette"
 		secondary = append(secondary, types.GetAccessTypeDescriptionForEveryone(app))
 	case len(userAccessList) <= 0:
@@ -391,7 +391,7 @@ func printEntityAccess(ctx context.Context, cmd *cobra.Command, clients *shared.
 	if err != nil {
 		return err
 	}
-	if distType != types.NAMED_ENTITIES {
+	if distType != types.PermissionNamedEntities {
 		return nil
 	}
 	var emoji string
@@ -426,11 +426,11 @@ func handleDistributionType(ctx context.Context, clients *shared.ClientFactory, 
 		return err
 	}
 
-	if distType == types.NAMED_ENTITIES {
+	if distType == types.PermissionNamedEntities {
 		return nil
 	}
 
-	_, err = clients.APIInterface().FunctionDistributionSet(ctx, functionFlag, app.AppID, types.NAMED_ENTITIES, "")
+	_, err = clients.APIInterface().FunctionDistributionSet(ctx, functionFlag, app.AppID, types.PermissionNamedEntities, "")
 	if err != nil {
 		return err
 	}

--- a/cmd/function/access.go
+++ b/cmd/function/access.go
@@ -139,7 +139,7 @@ func handleUpdate(
 			distribution = types.APP_COLLABORATORS
 		}
 
-		_, err := clients.ApiInterface().FunctionDistributionSet(ctx, functionFlag, app.AppID, distribution, "")
+		_, err := clients.APIInterface().FunctionDistributionSet(ctx, functionFlag, app.AppID, distribution, "")
 		if err != nil {
 			return err
 		}
@@ -154,7 +154,7 @@ func handleUpdate(
 			return err
 		}
 
-		err = clients.ApiInterface().FunctionDistributionAddUsers(ctx, functionFlag, app.AppID, distributeFlags.users)
+		err = clients.APIInterface().FunctionDistributionAddUsers(ctx, functionFlag, app.AppID, distributeFlags.users)
 		if err != nil {
 			return err
 		}
@@ -170,7 +170,7 @@ func handleUpdate(
 			return slackerror.New(slackerror.ErrMissingFlag).WithRemediation("To revoke a user's access, pass in their user ID with the --users flag: `--users U12345`")
 		}
 
-		err := clients.ApiInterface().FunctionDistributionRemoveUsers(ctx, functionFlag, app.AppID, distributeFlags.users)
+		err := clients.APIInterface().FunctionDistributionRemoveUsers(ctx, functionFlag, app.AppID, distributeFlags.users)
 		if err != nil {
 			return err
 		}
@@ -205,7 +205,7 @@ func handleUpdate(
 					return err
 				}
 
-				err = clients.ApiInterface().FunctionDistributionAddUsers(ctx, functionFlag, app.AppID, users)
+				err = clients.APIInterface().FunctionDistributionAddUsers(ctx, functionFlag, app.AppID, users)
 				if err != nil {
 					return err
 				}
@@ -216,7 +216,7 @@ func handleUpdate(
 					Text:  fmt.Sprintf("Function access granted to the provided %s", style.Pluralize("user", "users", len(users))),
 				})))
 			case "remove":
-				err = clients.ApiInterface().FunctionDistributionRemoveUsers(ctx, functionFlag, app.AppID, users)
+				err = clients.APIInterface().FunctionDistributionRemoveUsers(ctx, functionFlag, app.AppID, users)
 				if err != nil {
 					return err
 				}
@@ -228,7 +228,7 @@ func handleUpdate(
 			return printDistribution(ctx, cmd, clients, app)
 		}
 
-		_, err = clients.ApiInterface().FunctionDistributionSet(ctx, functionFlag, app.AppID, dist, "")
+		_, err = clients.APIInterface().FunctionDistributionSet(ctx, functionFlag, app.AppID, dist, "")
 		if err != nil {
 			return err
 		}
@@ -298,7 +298,7 @@ func distributePermissionFile(ctx context.Context, clients *shared.ClientFactory
 					permissions.Type,
 				))
 			}
-			_, err := clients.ApiInterface().FunctionDistributionSet(ctx, function, app.AppID, permissions.Type, "")
+			_, err := clients.APIInterface().FunctionDistributionSet(ctx, function, app.AppID, permissions.Type, "")
 			if err != nil {
 				return err
 			}
@@ -317,11 +317,11 @@ func updateNamedEntitiesDistribution(
 	entities []string,
 ) error {
 	updatedUsers := strings.Join(entities, ",")
-	_, err := clients.ApiInterface().FunctionDistributionSet(ctx, function, app.AppID, types.NAMED_ENTITIES, updatedUsers)
+	_, err := clients.APIInterface().FunctionDistributionSet(ctx, function, app.AppID, types.NAMED_ENTITIES, updatedUsers)
 	if err != nil {
 		return err
 	}
-	_, currentUsers, err := clients.ApiInterface().FunctionDistributionList(ctx, function, app.AppID)
+	_, currentUsers, err := clients.APIInterface().FunctionDistributionList(ctx, function, app.AppID)
 	if err != nil {
 		return err
 	}
@@ -339,7 +339,7 @@ func updateNamedEntitiesDistribution(
 		}
 	}
 	removals := strings.Join(removalSlice, ",")
-	err = clients.ApiInterface().FunctionDistributionRemoveUsers(ctx, function, app.AppID, removals)
+	err = clients.APIInterface().FunctionDistributionRemoveUsers(ctx, function, app.AppID, removals)
 	if err != nil {
 		return err
 	}
@@ -348,7 +348,7 @@ func updateNamedEntitiesDistribution(
 
 // printDistribution formats and displays access information
 func printDistribution(ctx context.Context, cmd *cobra.Command, clients *shared.ClientFactory, app types.App) error {
-	dist, userAccessList, err := clients.ApiInterface().FunctionDistributionList(ctx, functionFlag, app.AppID)
+	dist, userAccessList, err := clients.APIInterface().FunctionDistributionList(ctx, functionFlag, app.AppID)
 	if err != nil {
 		return err
 	}
@@ -387,7 +387,7 @@ func printDistribution(ctx context.Context, cmd *cobra.Command, clients *shared.
 
 // printEntityAccess formats and displays the users with access to an app's functions
 func printEntityAccess(ctx context.Context, cmd *cobra.Command, clients *shared.ClientFactory, app types.App) error {
-	distType, users, err := clients.ApiInterface().FunctionDistributionList(ctx, functionFlag, app.AppID)
+	distType, users, err := clients.APIInterface().FunctionDistributionList(ctx, functionFlag, app.AppID)
 	if err != nil {
 		return err
 	}
@@ -421,7 +421,7 @@ func printEntityAccess(ctx context.Context, cmd *cobra.Command, clients *shared.
 
 // handleDistributionType checks if the function's distribution type is named_entities and if not, updates it
 func handleDistributionType(ctx context.Context, clients *shared.ClientFactory, app types.App) error {
-	distType, _, err := clients.ApiInterface().FunctionDistributionList(ctx, functionFlag, app.AppID)
+	distType, _, err := clients.APIInterface().FunctionDistributionList(ctx, functionFlag, app.AppID)
 	if err != nil {
 		return err
 	}
@@ -430,7 +430,7 @@ func handleDistributionType(ctx context.Context, clients *shared.ClientFactory, 
 		return nil
 	}
 
-	_, err = clients.ApiInterface().FunctionDistributionSet(ctx, functionFlag, app.AppID, types.NAMED_ENTITIES, "")
+	_, err = clients.APIInterface().FunctionDistributionSet(ctx, functionFlag, app.AppID, types.NAMED_ENTITIES, "")
 	if err != nil {
 		return err
 	}
@@ -445,7 +445,7 @@ func AddCollaboratorsToNamedEntities(
 	app types.App,
 	token string,
 ) error {
-	collaborators, err := clients.ApiInterface().ListCollaborators(ctx, token, app.AppID)
+	collaborators, err := clients.APIInterface().ListCollaborators(ctx, token, app.AppID)
 	if err != nil {
 		return err
 	}
@@ -464,5 +464,5 @@ func AddCollaboratorsToNamedEntities(
 		return err
 	}
 
-	return clients.ApiInterface().FunctionDistributionAddUsers(ctx, functionFlag, app.AppID, userIDs)
+	return clients.APIInterface().FunctionDistributionAddUsers(ctx, functionFlag, app.AppID, userIDs)
 }

--- a/cmd/function/access_test.go
+++ b/cmd/function/access_test.go
@@ -42,11 +42,11 @@ func TestFunctionDistributionCommand(t *testing.T) {
 			},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				// set distribution
-				clientsMock.APIInterface.On("FunctionDistributionSet", mock.Anything, mock.Anything, mock.Anything, types.APP_COLLABORATORS, mock.Anything).
+				clientsMock.APIInterface.On("FunctionDistributionSet", mock.Anything, mock.Anything, mock.Anything, types.PermissionAppCollaborators, mock.Anything).
 					Return([]types.FunctionDistributionUser{}, nil).Once()
 
 				clientsMock.APIInterface.On("FunctionDistributionList", mock.Anything, mock.Anything, mock.Anything).
-					Return(types.APP_COLLABORATORS, []types.FunctionDistributionUser{}, nil).Once()
+					Return(types.PermissionAppCollaborators, []types.FunctionDistributionUser{}, nil).Once()
 
 				clientsMock.AddDefaultMocks()
 				appSelectTeardown = setupMockAppSelection(installedProdApp)
@@ -69,16 +69,16 @@ func TestFunctionDistributionCommand(t *testing.T) {
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				// check if distribution type is named_entities
 				clientsMock.APIInterface.On("FunctionDistributionList", mock.Anything, mock.Anything, mock.Anything).
-					Return(types.APP_COLLABORATORS, []types.FunctionDistributionUser{}, nil).Once()
+					Return(types.PermissionAppCollaborators, []types.FunctionDistributionUser{}, nil).Once()
 				// set distribution type to named_entities
-				clientsMock.APIInterface.On("FunctionDistributionSet", mock.Anything, mock.Anything, mock.Anything, types.NAMED_ENTITIES, mock.Anything).
+				clientsMock.APIInterface.On("FunctionDistributionSet", mock.Anything, mock.Anything, mock.Anything, types.PermissionNamedEntities, mock.Anything).
 					Return([]types.FunctionDistributionUser{}, nil).Once()
 				// add users
 				clientsMock.APIInterface.On("FunctionDistributionAddUsers", mock.Anything, mock.Anything, mock.Anything, "U00,U01").
 					Return(nil).Once()
 				// print access
 				clientsMock.APIInterface.On("FunctionDistributionList", mock.Anything, mock.Anything, mock.Anything).
-					Return(types.NAMED_ENTITIES, []types.FunctionDistributionUser{{UserName: "user 0", ID: "U00"}, {UserName: "user 1", ID: "U01"}}, nil).Once()
+					Return(types.PermissionNamedEntities, []types.FunctionDistributionUser{{UserName: "user 0", ID: "U00"}, {UserName: "user 1", ID: "U01"}}, nil).Once()
 
 				clientsMock.AddDefaultMocks()
 				appSelectTeardown = setupMockAppSelection(installedProdApp)
@@ -100,13 +100,13 @@ func TestFunctionDistributionCommand(t *testing.T) {
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				// check if distribution type is named_entities
 				clientsMock.APIInterface.On("FunctionDistributionList", mock.Anything, mock.Anything, mock.Anything).
-					Return(types.NAMED_ENTITIES, []types.FunctionDistributionUser{{UserName: "user 0", ID: "U00"}, {UserName: "user 1", ID: "U01"}}, nil).Once()
+					Return(types.PermissionNamedEntities, []types.FunctionDistributionUser{{UserName: "user 0", ID: "U00"}, {UserName: "user 1", ID: "U01"}}, nil).Once()
 				// remove users
 				clientsMock.APIInterface.On("FunctionDistributionRemoveUsers", mock.Anything, mock.Anything, mock.Anything, "U00").
 					Return(nil).Once()
 				// print access
 				clientsMock.APIInterface.On("FunctionDistributionList", mock.Anything, mock.Anything, mock.Anything).
-					Return(types.NAMED_ENTITIES, []types.FunctionDistributionUser{{UserName: "user 1", ID: "U01"}}, nil).Once()
+					Return(types.PermissionNamedEntities, []types.FunctionDistributionUser{{UserName: "user 1", ID: "U01"}}, nil).Once()
 
 				clientsMock.AddDefaultMocks()
 				appSelectTeardown = setupMockAppSelection(installedProdApp)
@@ -126,7 +126,7 @@ func TestFunctionDistributionCommand(t *testing.T) {
 			},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				clientsMock.APIInterface.On("FunctionDistributionList", mock.Anything, "F1234", fakeApp.AppID).
-					Return(types.EVERYONE, []types.FunctionDistributionUser{}, nil).Once()
+					Return(types.PermissionEveryone, []types.FunctionDistributionUser{}, nil).Once()
 				clientsMock.AddDefaultMocks()
 
 				appSelectTeardown = setupMockAppSelection(installedProdApp)
@@ -214,21 +214,21 @@ func TestFunctionDistributionCommand_PermissionsFile(t *testing.T) {
 				expectedEntities []types.FunctionDistributionUser
 			}{
 				"greeting_function": {
-					currentType:      types.EVERYONE,
+					currentType:      types.PermissionEveryone,
 					currentEntities:  []types.FunctionDistributionUser{},
-					expectedType:     types.EVERYONE,
+					expectedType:     types.PermissionEveryone,
 					expectedEntities: []types.FunctionDistributionUser{},
 				},
 				"goodbye_function": {
-					currentType:      types.EVERYONE,
+					currentType:      types.PermissionEveryone,
 					currentEntities:  []types.FunctionDistributionUser{},
-					expectedType:     types.APP_COLLABORATORS,
+					expectedType:     types.PermissionAppCollaborators,
 					expectedEntities: []types.FunctionDistributionUser{},
 				},
 				"momentary_function": {
-					currentType:     types.EVERYONE,
+					currentType:     types.PermissionEveryone,
 					currentEntities: []types.FunctionDistributionUser{},
-					expectedType:    types.NAMED_ENTITIES,
+					expectedType:    types.PermissionNamedEntities,
 					expectedEntities: []types.FunctionDistributionUser{
 						{ID: "USLACKBOT"},
 						{ID: "U123"},
@@ -255,9 +255,9 @@ func TestFunctionDistributionCommand_PermissionsFile(t *testing.T) {
 				expectedEntities []types.FunctionDistributionUser
 			}{
 				"greeting_function": {
-					currentType:      types.EVERYONE,
+					currentType:      types.PermissionEveryone,
 					currentEntities:  []types.FunctionDistributionUser{},
-					expectedType:     types.NAMED_ENTITIES,
+					expectedType:     types.PermissionNamedEntities,
 					expectedEntities: []types.FunctionDistributionUser{},
 				},
 			},
@@ -281,11 +281,11 @@ func TestFunctionDistributionCommand_PermissionsFile(t *testing.T) {
 				expectedEntities []types.FunctionDistributionUser
 			}{
 				"goodbye_function": {
-					currentType: types.NAMED_ENTITIES,
+					currentType: types.PermissionNamedEntities,
 					currentEntities: []types.FunctionDistributionUser{
 						{ID: "USLACKBOT"},
 					},
-					expectedType:     types.APP_COLLABORATORS,
+					expectedType:     types.PermissionAppCollaborators,
 					expectedEntities: []types.FunctionDistributionUser{},
 				},
 			},
@@ -306,17 +306,17 @@ func TestFunctionDistributionCommand_PermissionsFile(t *testing.T) {
 				expectedEntities []types.FunctionDistributionUser
 			}{
 				"greeting_function": {
-					currentType:      types.APP_COLLABORATORS,
+					currentType:      types.PermissionAppCollaborators,
 					currentEntities:  []types.FunctionDistributionUser{},
-					expectedType:     types.EVERYONE,
+					expectedType:     types.PermissionEveryone,
 					expectedEntities: []types.FunctionDistributionUser{},
 				},
 				"goodbye_function": {
-					currentType: types.NAMED_ENTITIES,
+					currentType: types.PermissionNamedEntities,
 					currentEntities: []types.FunctionDistributionUser{
 						{ID: "USLACKBOT"},
 					},
-					expectedType:     types.APP_COLLABORATORS,
+					expectedType:     types.PermissionAppCollaborators,
 					expectedEntities: []types.FunctionDistributionUser{},
 				},
 			},
@@ -403,11 +403,11 @@ func TestFunctionDistributeCommand_UpdateNamedEntitiesDistribution(t *testing.T)
 		t.Run(name, func(t *testing.T) {
 			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := shared.NewClientsMock()
-			clientsMock.APIInterface.On("FunctionDistributionSet", mock.Anything, mock.Anything, mock.Anything, types.NAMED_ENTITIES, mock.Anything).
+			clientsMock.APIInterface.On("FunctionDistributionSet", mock.Anything, mock.Anything, mock.Anything, types.PermissionNamedEntities, mock.Anything).
 				Return([]types.FunctionDistributionUser{}, nil).
 				Run(func(args mock.Arguments) {
 					clientsMock.APIInterface.On("FunctionDistributionList", mock.Anything, mock.Anything, mock.Anything).
-						Return(types.NAMED_ENTITIES, tt.currentEntities, nil).
+						Return(types.PermissionNamedEntities, tt.currentEntities, nil).
 						Run(func(args mock.Arguments) {
 							clientsMock.APIInterface.On("FunctionDistributionRemoveUsers", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 								Return(nil)
@@ -422,7 +422,7 @@ func TestFunctionDistributeCommand_UpdateNamedEntitiesDistribution(t *testing.T)
 			assert.NoError(t, err)
 			clientsMock.APIInterface.AssertCalled(t, "FunctionDistributionList", mock.Anything, function, app.AppID)
 			entities := strings.Join(tt.updatedEntities, ",")
-			clientsMock.APIInterface.AssertCalled(t, "FunctionDistributionSet", mock.Anything, function, app.AppID, types.NAMED_ENTITIES, entities)
+			clientsMock.APIInterface.AssertCalled(t, "FunctionDistributionSet", mock.Anything, function, app.AppID, types.PermissionNamedEntities, entities)
 			clientsMock.APIInterface.AssertCalled(t, "FunctionDistributionRemoveUsers", mock.Anything, function, app.AppID, tt.removedEntities)
 		})
 	}

--- a/cmd/function/access_test.go
+++ b/cmd/function/access_test.go
@@ -42,10 +42,10 @@ func TestFunctionDistributionCommand(t *testing.T) {
 			},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				// set distribution
-				clientsMock.ApiInterface.On("FunctionDistributionSet", mock.Anything, mock.Anything, mock.Anything, types.APP_COLLABORATORS, mock.Anything).
+				clientsMock.APIInterface.On("FunctionDistributionSet", mock.Anything, mock.Anything, mock.Anything, types.APP_COLLABORATORS, mock.Anything).
 					Return([]types.FunctionDistributionUser{}, nil).Once()
 
-				clientsMock.ApiInterface.On("FunctionDistributionList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("FunctionDistributionList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.APP_COLLABORATORS, []types.FunctionDistributionUser{}, nil).Once()
 
 				clientsMock.AddDefaultMocks()
@@ -68,16 +68,16 @@ func TestFunctionDistributionCommand(t *testing.T) {
 			},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				// check if distribution type is named_entities
-				clientsMock.ApiInterface.On("FunctionDistributionList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("FunctionDistributionList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.APP_COLLABORATORS, []types.FunctionDistributionUser{}, nil).Once()
 				// set distribution type to named_entities
-				clientsMock.ApiInterface.On("FunctionDistributionSet", mock.Anything, mock.Anything, mock.Anything, types.NAMED_ENTITIES, mock.Anything).
+				clientsMock.APIInterface.On("FunctionDistributionSet", mock.Anything, mock.Anything, mock.Anything, types.NAMED_ENTITIES, mock.Anything).
 					Return([]types.FunctionDistributionUser{}, nil).Once()
 				// add users
-				clientsMock.ApiInterface.On("FunctionDistributionAddUsers", mock.Anything, mock.Anything, mock.Anything, "U00,U01").
+				clientsMock.APIInterface.On("FunctionDistributionAddUsers", mock.Anything, mock.Anything, mock.Anything, "U00,U01").
 					Return(nil).Once()
 				// print access
-				clientsMock.ApiInterface.On("FunctionDistributionList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("FunctionDistributionList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.NAMED_ENTITIES, []types.FunctionDistributionUser{{UserName: "user 0", ID: "U00"}, {UserName: "user 1", ID: "U01"}}, nil).Once()
 
 				clientsMock.AddDefaultMocks()
@@ -99,13 +99,13 @@ func TestFunctionDistributionCommand(t *testing.T) {
 			},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				// check if distribution type is named_entities
-				clientsMock.ApiInterface.On("FunctionDistributionList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("FunctionDistributionList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.NAMED_ENTITIES, []types.FunctionDistributionUser{{UserName: "user 0", ID: "U00"}, {UserName: "user 1", ID: "U01"}}, nil).Once()
 				// remove users
-				clientsMock.ApiInterface.On("FunctionDistributionRemoveUsers", mock.Anything, mock.Anything, mock.Anything, "U00").
+				clientsMock.APIInterface.On("FunctionDistributionRemoveUsers", mock.Anything, mock.Anything, mock.Anything, "U00").
 					Return(nil).Once()
 				// print access
-				clientsMock.ApiInterface.On("FunctionDistributionList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("FunctionDistributionList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.NAMED_ENTITIES, []types.FunctionDistributionUser{{UserName: "user 1", ID: "U01"}}, nil).Once()
 
 				clientsMock.AddDefaultMocks()
@@ -125,7 +125,7 @@ func TestFunctionDistributionCommand(t *testing.T) {
 				"everyone in the workspace",
 			},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.ApiInterface.On("FunctionDistributionList", mock.Anything, "F1234", fakeApp.AppID).
+				clientsMock.APIInterface.On("FunctionDistributionList", mock.Anything, "F1234", fakeApp.AppID).
 					Return(types.EVERYONE, []types.FunctionDistributionUser{}, nil).Once()
 				clientsMock.AddDefaultMocks()
 
@@ -134,9 +134,9 @@ func TestFunctionDistributionCommand(t *testing.T) {
 				require.NoError(t, err, "Cant write apps.json")
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
-				cm.ApiInterface.AssertNotCalled(t, "FunctionDistributionAddUsers")
-				cm.ApiInterface.AssertNotCalled(t, "FunctionDistributionRemoveUsers")
-				cm.ApiInterface.AssertNotCalled(t, "FunctionDistributionSet")
+				cm.APIInterface.AssertNotCalled(t, "FunctionDistributionAddUsers")
+				cm.APIInterface.AssertNotCalled(t, "FunctionDistributionRemoveUsers")
+				cm.APIInterface.AssertNotCalled(t, "FunctionDistributionSet")
 			},
 			Teardown: func() {
 				appSelectTeardown()
@@ -333,12 +333,12 @@ func TestFunctionDistributionCommand_PermissionsFile(t *testing.T) {
 			err := afero.WriteFile(clientsMock.Fs, tt.filename, []byte(tt.data), 0644)
 			require.NoError(t, err)
 			for function, permissions := range tt.functions {
-				clientsMock.ApiInterface.On("FunctionDistributionList", mock.Anything, function, mock.Anything).
+				clientsMock.APIInterface.On("FunctionDistributionList", mock.Anything, function, mock.Anything).
 					Return(permissions.currentType, permissions.currentEntities, nil)
 			}
-			clientsMock.ApiInterface.On("FunctionDistributionRemoveUsers", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			clientsMock.APIInterface.On("FunctionDistributionRemoveUsers", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 				Return(nil)
-			clientsMock.ApiInterface.On("FunctionDistributionSet", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			clientsMock.APIInterface.On("FunctionDistributionSet", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 				Return([]types.FunctionDistributionUser{}, nil)
 
 			clients := shared.NewClientFactory(clientsMock.MockClientFactory())
@@ -359,7 +359,7 @@ func TestFunctionDistributionCommand_PermissionsFile(t *testing.T) {
 					entityIDs = append(entityIDs, entity.ID)
 				}
 				entities := strings.Join(entityIDs, ",")
-				clientsMock.ApiInterface.AssertCalled(t, "FunctionDistributionSet", mock.Anything, function, app.AppID, permissions.expectedType, entities)
+				clientsMock.APIInterface.AssertCalled(t, "FunctionDistributionSet", mock.Anything, function, app.AppID, permissions.expectedType, entities)
 			}
 		})
 	}
@@ -403,13 +403,13 @@ func TestFunctionDistributeCommand_UpdateNamedEntitiesDistribution(t *testing.T)
 		t.Run(name, func(t *testing.T) {
 			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := shared.NewClientsMock()
-			clientsMock.ApiInterface.On("FunctionDistributionSet", mock.Anything, mock.Anything, mock.Anything, types.NAMED_ENTITIES, mock.Anything).
+			clientsMock.APIInterface.On("FunctionDistributionSet", mock.Anything, mock.Anything, mock.Anything, types.NAMED_ENTITIES, mock.Anything).
 				Return([]types.FunctionDistributionUser{}, nil).
 				Run(func(args mock.Arguments) {
-					clientsMock.ApiInterface.On("FunctionDistributionList", mock.Anything, mock.Anything, mock.Anything).
+					clientsMock.APIInterface.On("FunctionDistributionList", mock.Anything, mock.Anything, mock.Anything).
 						Return(types.NAMED_ENTITIES, tt.currentEntities, nil).
 						Run(func(args mock.Arguments) {
-							clientsMock.ApiInterface.On("FunctionDistributionRemoveUsers", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+							clientsMock.APIInterface.On("FunctionDistributionRemoveUsers", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 								Return(nil)
 						})
 				})
@@ -420,10 +420,10 @@ func TestFunctionDistributeCommand_UpdateNamedEntitiesDistribution(t *testing.T)
 
 			err := updateNamedEntitiesDistribution(ctx, clients, app, function, tt.updatedEntities)
 			assert.NoError(t, err)
-			clientsMock.ApiInterface.AssertCalled(t, "FunctionDistributionList", mock.Anything, function, app.AppID)
+			clientsMock.APIInterface.AssertCalled(t, "FunctionDistributionList", mock.Anything, function, app.AppID)
 			entities := strings.Join(tt.updatedEntities, ",")
-			clientsMock.ApiInterface.AssertCalled(t, "FunctionDistributionSet", mock.Anything, function, app.AppID, types.NAMED_ENTITIES, entities)
-			clientsMock.ApiInterface.AssertCalled(t, "FunctionDistributionRemoveUsers", mock.Anything, function, app.AppID, tt.removedEntities)
+			clientsMock.APIInterface.AssertCalled(t, "FunctionDistributionSet", mock.Anything, function, app.AppID, types.NAMED_ENTITIES, entities)
+			clientsMock.APIInterface.AssertCalled(t, "FunctionDistributionRemoveUsers", mock.Anything, function, app.AppID, tt.removedEntities)
 		})
 	}
 }

--- a/cmd/function/prompt.go
+++ b/cmd/function/prompt.go
@@ -85,18 +85,18 @@ func chooseDistributionPrompt(
 		// Prefer named entities on mismatch then prompt for collaborators later
 		if slackerror.ToSlackError(err).Code == slackerror.ErrMismatchedFlags &&
 			!clients.Config.Flags.Lookup("everyone").Changed {
-			selectedDistribution = types.NAMED_ENTITIES
+			selectedDistribution = types.PermissionNamedEntities
 		} else {
 			return "", err
 		}
 	} else if selection.Flag {
 		switch {
 		case clients.Config.Flags.Lookup("app-collaborators").Changed:
-			selectedDistribution = types.APP_COLLABORATORS
+			selectedDistribution = types.PermissionAppCollaborators
 		case clients.Config.Flags.Lookup("everyone").Changed:
-			selectedDistribution = types.EVERYONE
+			selectedDistribution = types.PermissionEveryone
 		case clients.Config.Flags.Lookup("users").Changed:
-			selectedDistribution = types.NAMED_ENTITIES
+			selectedDistribution = types.PermissionNamedEntities
 		}
 	} else if selection.Prompt {
 		selectedDistribution = distributions[selection.Index]
@@ -104,8 +104,8 @@ func chooseDistributionPrompt(
 
 	// Optional follow-up: if the function is moving from an access type where collaborators have access,
 	// to named_entities where they do not unless explicitly added, offer to add them automatically
-	if (currentDist == types.APP_COLLABORATORS || currentDist == types.EVERYONE) &&
-		selectedDistribution == types.NAMED_ENTITIES {
+	if (currentDist == types.PermissionAppCollaborators || currentDist == types.PermissionEveryone) &&
+		selectedDistribution == types.PermissionNamedEntities {
 		err := addCollaboratorsToNamedEntitiesPrompt(ctx, clients, app, token)
 		if err != nil {
 			return "", err

--- a/cmd/function/prompt.go
+++ b/cmd/function/prompt.go
@@ -64,7 +64,7 @@ func chooseDistributionPrompt(
 ) (types.Permission, error) {
 
 	// Get the function's active distribution type
-	currentDist, _, err := clients.ApiInterface().FunctionDistributionList(ctx, functionFlag, app.AppID)
+	currentDist, _, err := clients.APIInterface().FunctionDistributionList(ctx, functionFlag, app.AppID)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/manifest/info.go
+++ b/cmd/manifest/info.go
@@ -39,8 +39,8 @@ func NewInfoCommand(clients *shared.ClientFactory) *cobra.Command {
 		Use:   "info",
 		Short: "Print the app manifest of a project or app",
 		Long: strings.Join([]string{
-			fmt.Sprintf("Get the manifest of an app using either the \"%s\" values on app settings", config.MANIFEST_SOURCE_REMOTE.String()),
-			fmt.Sprintf("or from the \"%s\" configurations.", config.MANIFEST_SOURCE_LOCAL.String()),
+			fmt.Sprintf("Get the manifest of an app using either the \"%s\" values on app settings", config.ManifestSourceRemote.String()),
+			fmt.Sprintf("or from the \"%s\" configurations.", config.ManifestSourceLocal.String()),
 			"",
 			"The manifest on app settings represents the latest version of the manifest.",
 			"",
@@ -73,11 +73,11 @@ func NewInfoCommand(clients *shared.ClientFactory) *cobra.Command {
 	cmd.Flags().StringVar(
 		&manifestFlags.source,
 		manifestFlagSource,
-		config.MANIFEST_SOURCE_LOCAL.String(),
+		config.ManifestSourceLocal.String(),
 		fmt.Sprintf(
 			"source of the app manifest (\"%s\" or \"%s\")",
-			config.MANIFEST_SOURCE_LOCAL.String(),
-			config.MANIFEST_SOURCE_REMOTE.String(),
+			config.ManifestSourceLocal.String(),
+			config.ManifestSourceRemote.String(),
 		),
 	)
 	return cmd
@@ -105,9 +105,9 @@ func getManifestInfo(ctx context.Context, clients *shared.ClientFactory, cmd *co
 		return types.AppManifest{}, err
 	}
 	switch {
-	case source.Equals(config.MANIFEST_SOURCE_LOCAL):
+	case source.Equals(config.ManifestSourceLocal):
 		return getManifestInfoProject(ctx, clients)
-	case source.Equals(config.MANIFEST_SOURCE_REMOTE):
+	case source.Equals(config.ManifestSourceRemote):
 		return getManifestInfoRemote(ctx, clients)
 	default:
 		return types.AppManifest{}, slackerror.New(slackerror.ErrInvalidManifestSource)

--- a/cmd/manifest/info_test.go
+++ b/cmd/manifest/info_test.go
@@ -136,7 +136,7 @@ func TestInfoCommand(t *testing.T) {
 				cm.Config.ExperimentsFlag = append(cm.Config.ExperimentsFlag, experiment.BoltFrameworks)
 				cm.Config.LoadExperiments(ctx, cm.IO.PrintDebug)
 				mockProjectConfig := config.NewProjectConfigMock()
-				mockProjectConfig.On("GetManifestSource", mock.Anything).Return(config.MANIFEST_SOURCE_LOCAL, nil)
+				mockProjectConfig.On("GetManifestSource", mock.Anything).Return(config.ManifestSourceLocal, nil)
 				cm.Config.ProjectConfig = mockProjectConfig
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
@@ -152,10 +152,10 @@ func TestInfoCommand(t *testing.T) {
 		},
 		"errors if project manifest source is remote with the bolt experiment": {
 			ExpectedError: slackerror.New(slackerror.ErrInvalidManifestSource).
-				WithMessage(`Cannot get manifest info from the "%s" source`, config.MANIFEST_SOURCE_REMOTE).
+				WithMessage(`Cannot get manifest info from the "%s" source`, config.ManifestSourceRemote).
 				WithRemediation("%s", strings.Join([]string{
 					fmt.Sprintf("Find the current manifest on app settings: %s", style.LinkText("https://api.slack.com/apps")),
-					fmt.Sprintf("Set \"manifest.source\" to \"%s\" in \"%s\" to continue", config.MANIFEST_SOURCE_LOCAL, filepath.Join(".slack", "config.json")),
+					fmt.Sprintf("Set \"manifest.source\" to \"%s\" in \"%s\" to continue", config.ManifestSourceLocal, filepath.Join(".slack", "config.json")),
 					fmt.Sprintf("Read about manifest sourcing with %s", style.Commandf("manifest info --help", false)),
 				}, "\n")),
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
@@ -166,7 +166,7 @@ func TestInfoCommand(t *testing.T) {
 				cm.Config.LoadExperiments(ctx, cm.IO.PrintDebug)
 				mockProjectConfig := config.NewProjectConfigMock()
 				mockProjectConfig.On("GetManifestSource", mock.Anything).
-					Return(config.ManifestSource(config.MANIFEST_SOURCE_REMOTE), nil)
+					Return(config.ManifestSource(config.ManifestSourceRemote), nil)
 				cm.Config.ProjectConfig = mockProjectConfig
 			},
 		},

--- a/cmd/manifest/manifest.go
+++ b/cmd/manifest/manifest.go
@@ -51,8 +51,8 @@ func NewCommand(clients *shared.ClientFactory) *cobra.Command {
 		Use:   "manifest",
 		Short: "Print the app manifest of a project or app",
 		Long: strings.Join([]string{
-			fmt.Sprintf("Get the manifest of an app using either the \"%s\" values on app settings", config.MANIFEST_SOURCE_REMOTE.String()),
-			fmt.Sprintf("or from the \"%s\" configurations.", config.MANIFEST_SOURCE_LOCAL.String()),
+			fmt.Sprintf("Get the manifest of an app using either the \"%s\" values on app settings", config.ManifestSourceRemote.String()),
+			fmt.Sprintf("or from the \"%s\" configurations.", config.ManifestSourceLocal.String()),
 			"",
 			"Subcommands unlock additional engagements and interactions with the manifest.",
 			"",
@@ -86,11 +86,11 @@ func NewCommand(clients *shared.ClientFactory) *cobra.Command {
 	cmd.Flags().StringVar(
 		&manifestFlags.source,
 		manifestFlagSource,
-		config.MANIFEST_SOURCE_LOCAL.String(),
+		config.ManifestSourceLocal.String(),
 		fmt.Sprintf(
 			"source of the app manifest (\"%s\" or \"%s\")",
-			config.MANIFEST_SOURCE_LOCAL.String(),
-			config.MANIFEST_SOURCE_REMOTE.String(),
+			config.ManifestSourceLocal.String(),
+			config.ManifestSourceRemote.String(),
 		),
 	)
 
@@ -101,15 +101,15 @@ func NewCommand(clients *shared.ClientFactory) *cobra.Command {
 // should be used based on the "--source" flag
 func getManifestSource(ctx context.Context, clients *shared.ClientFactory, cmd *cobra.Command) (config.ManifestSource, error) {
 	if clients.Config.AppFlag != "" {
-		if cmd.Flag(manifestFlagSource).Changed && !config.ManifestSource(manifestFlags.source).Equals(config.MANIFEST_SOURCE_REMOTE) {
+		if cmd.Flag(manifestFlagSource).Changed && !config.ManifestSource(manifestFlags.source).Equals(config.ManifestSourceRemote) {
 			return "", slackerror.New(slackerror.ErrMismatchedFlags).
 				WithMessage(
 					"The \"--%s\" flag must be \"%s\" when using \"--app\"",
 					manifestFlagSource,
-					config.MANIFEST_SOURCE_REMOTE.String(),
+					config.ManifestSourceRemote.String(),
 				)
 		}
-		return config.MANIFEST_SOURCE_REMOTE, nil
+		return config.ManifestSourceRemote, nil
 	}
 	if clients.Config.WithExperimentOn(experiment.BoltFrameworks) {
 		if !cmd.Flag(manifestFlagSource).Changed {
@@ -118,31 +118,31 @@ func getManifestSource(ctx context.Context, clients *shared.ClientFactory, cmd *
 				return "", err
 			}
 			switch {
-			case manifestConfigSource.Equals(config.MANIFEST_SOURCE_LOCAL):
+			case manifestConfigSource.Equals(config.ManifestSourceLocal):
 				return manifestConfigSource, nil
-			case manifestConfigSource.Equals(config.MANIFEST_SOURCE_REMOTE):
+			case manifestConfigSource.Equals(config.ManifestSourceRemote):
 				return "", slackerror.New(slackerror.ErrInvalidManifestSource).
-					WithMessage(`Cannot get manifest info from the "%s" source`, config.MANIFEST_SOURCE_REMOTE).
+					WithMessage(`Cannot get manifest info from the "%s" source`, config.ManifestSourceRemote).
 					WithRemediation("%s", strings.Join([]string{
 						fmt.Sprintf("Find the current manifest on app settings: %s", style.LinkText("https://api.slack.com/apps")),
-						fmt.Sprintf("Set \"manifest.source\" to \"%s\" in \"%s\" to continue", config.MANIFEST_SOURCE_LOCAL, filepath.Join(".slack", "config.json")),
+						fmt.Sprintf("Set \"manifest.source\" to \"%s\" in \"%s\" to continue", config.ManifestSourceLocal, filepath.Join(".slack", "config.json")),
 						fmt.Sprintf("Read about manifest sourcing with %s", style.Commandf("manifest info --help", false)),
 					}, "\n"))
 			}
 		}
 	}
 	switch {
-	case config.ManifestSource(manifestFlags.source).Equals(config.MANIFEST_SOURCE_LOCAL):
-		return config.MANIFEST_SOURCE_LOCAL, nil
-	case config.ManifestSource(manifestFlags.source).Equals(config.MANIFEST_SOURCE_REMOTE):
-		return config.MANIFEST_SOURCE_REMOTE, nil
+	case config.ManifestSource(manifestFlags.source).Equals(config.ManifestSourceLocal):
+		return config.ManifestSourceLocal, nil
+	case config.ManifestSource(manifestFlags.source).Equals(config.ManifestSourceRemote):
+		return config.ManifestSourceRemote, nil
 	default:
 		return "", slackerror.New(slackerror.ErrInvalidFlag).
 			WithMessage(
 				"The \"--%s\" flag must be \"%s\" or \"%s\"",
 				manifestFlagSource,
-				config.MANIFEST_SOURCE_LOCAL,
-				config.MANIFEST_SOURCE_REMOTE,
+				config.ManifestSourceLocal,
+				config.ManifestSourceRemote,
 			)
 	}
 }

--- a/cmd/manifest/validate_test.go
+++ b/cmd/manifest/validate_test.go
@@ -111,7 +111,7 @@ func TestManifestValidateCommand_HandleMissingAppInstallError_OneUserAuth(t *tes
 		{
 			Token:        "mocktokenval",
 			TeamDomain:   "mock",
-			TeamID:       "mockteamId",
+			TeamID:       "mockteamID",
 			UserID:       "mockuser",
 			LastUpdated:  time.Time{},
 			RefreshToken: "refresh",
@@ -177,7 +177,7 @@ func TestManifestValidateCommand_HandleMissingAppInstallError_MoreThanOneUserAut
 		{
 			Token:        "mocktokenval",
 			TeamDomain:   "mock",
-			TeamID:       "mockteamId",
+			TeamID:       "mockteamID",
 			UserID:       "mockuser",
 			LastUpdated:  time.Time{},
 			RefreshToken: "refresh",
@@ -186,7 +186,7 @@ func TestManifestValidateCommand_HandleMissingAppInstallError_MoreThanOneUserAut
 		{
 			Token:        "mocktokenval",
 			TeamDomain:   "mock2",
-			TeamID:       "mockteamId",
+			TeamID:       "mockteamID",
 			UserID:       "mockuser",
 			LastUpdated:  time.Time{},
 			RefreshToken: "refresh",

--- a/cmd/openformresponse/export.go
+++ b/cmd/openformresponse/export.go
@@ -31,7 +31,7 @@ import (
 
 type exportCmdFlags struct {
 	workflow string
-	stepId   string
+	stepID   string
 }
 
 var exportFlags exportCmdFlags
@@ -58,7 +58,7 @@ func NewExportCommand(clients *shared.ClientFactory) *cobra.Command {
 	}
 
 	cmd.PersistentFlags().StringVar(&exportFlags.workflow, "workflow", "", "a reference to the workflow containing the form\n  formatted as \"#/workflows/<workflow_callback_id>\"")
-	cmd.PersistentFlags().StringVar(&exportFlags.stepId, "step-id", "", "the ID of an OpenForm step in this workflow")
+	cmd.PersistentFlags().StringVar(&exportFlags.stepID, "step-id", "", "the ID of an OpenForm step in this workflow")
 
 	return &cmd
 }
@@ -74,22 +74,22 @@ func runExportCommand(clients *shared.ClientFactory, cmd *cobra.Command) error {
 	}
 
 	token := selection.Auth.Token
-	appId := selection.App.AppID
+	appID := selection.App.AppID
 	ctx = config.SetContextToken(ctx, token)
 
 	if exportFlags.workflow == "" {
 		return slackerror.New(slackerror.ErrMissingFlag).WithMessage("--workflow flag required")
 	}
 
-	var stepId = exportFlags.stepId
-	if stepId == "" {
-		stepId, err = pickStepFromPrompt(ctx, clients, token, exportFlags.workflow, appId)
+	var stepID = exportFlags.stepID
+	if stepID == "" {
+		stepID, err = pickStepFromPrompt(ctx, clients, token, exportFlags.workflow, appID)
 		if err != nil {
 			return err
 		}
 	}
 
-	err = clients.ApiInterface().StepsResponsesExport(ctx, token, exportFlags.workflow, appId, stepId)
+	err = clients.APIInterface().StepsResponsesExport(ctx, token, exportFlags.workflow, appID, stepID)
 	if err != nil {
 		return err
 	}
@@ -104,8 +104,8 @@ func runExportCommand(clients *shared.ClientFactory, cmd *cobra.Command) error {
 	return nil
 }
 
-func pickStepFromPrompt(ctx context.Context, clients *shared.ClientFactory, token string, workflow string, appId string) (string, error) {
-	stepVersions, err := clients.ApiInterface().StepsList(ctx, token, workflow, appId)
+func pickStepFromPrompt(ctx context.Context, clients *shared.ClientFactory, token string, workflow string, appID string) (string, error) {
+	stepVersions, err := clients.APIInterface().StepsList(ctx, token, workflow, appID)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/openformresponse/export_test.go
+++ b/cmd/openformresponse/export_test.go
@@ -27,9 +27,9 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-var appId = "appId"
+var appID = "appID"
 var token = "token"
-var installedProdApp = prompts.SelectedApp{Auth: types.SlackAuth{Token: token}, App: types.App{AppID: appId}}
+var installedProdApp = prompts.SelectedApp{Auth: types.SlackAuth{Token: token}, App: types.App{AppID: appID}}
 
 func TestExportCommand(t *testing.T) {
 	var appSelectTeardown func()
@@ -45,31 +45,31 @@ func TestExportCommand(t *testing.T) {
 			ExpectedErrorStrings: []string{"--workflow", "required"},
 		},
 		"with --step-id, API succeeds": {
-			CmdArgs:         []string{"--workflow", "#/workflows/my_workflow", "--step-id", "stepId"},
+			CmdArgs:         []string{"--workflow", "#/workflows/my_workflow", "--step-id", "stepID"},
 			ExpectedOutputs: []string{"Slackbot will DM you with a CSV file once it's ready"},
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
 				appSelectTeardown = setupMockCreateAppSelection(installedProdApp)
-				cm.ApiInterface.On("StepsResponsesExport", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				cm.APIInterface.On("StepsResponsesExport", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			},
 			Teardown: func() {
 				appSelectTeardown()
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
-				cm.ApiInterface.AssertCalled(t, "StepsResponsesExport", mock.Anything, token, "#/workflows/my_workflow", appId, "stepId")
+				cm.APIInterface.AssertCalled(t, "StepsResponsesExport", mock.Anything, token, "#/workflows/my_workflow", appID, "stepID")
 			},
 		},
 		"with --step-id, API fails": {
-			CmdArgs:              []string{"--workflow", "#/workflows/my_workflow", "--step-id", "stepId"},
+			CmdArgs:              []string{"--workflow", "#/workflows/my_workflow", "--step-id", "stepID"},
 			ExpectedErrorStrings: []string{"failed"},
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
 				appSelectTeardown = setupMockCreateAppSelection(installedProdApp)
-				cm.ApiInterface.On("StepsResponsesExport", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(errors.New("failed"))
+				cm.APIInterface.On("StepsResponsesExport", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(errors.New("failed"))
 			},
 			Teardown: func() {
 				appSelectTeardown()
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
-				cm.ApiInterface.AssertCalled(t, "StepsResponsesExport", mock.Anything, token, "#/workflows/my_workflow", appId, "stepId")
+				cm.APIInterface.AssertCalled(t, "StepsResponsesExport", mock.Anything, token, "#/workflows/my_workflow", appID, "stepID")
 			},
 		},
 	}, func(clients *shared.ClientFactory) *cobra.Command {

--- a/cmd/platform/activity.go
+++ b/cmd/platform/activity.go
@@ -42,9 +42,9 @@ var maxDateCreated int64
 var minLevel string
 var eventType string
 var componentType string
-var componentId string
+var componentID string
 var source string
-var traceId string
+var traceID string
 
 // Create handle to the function for testing
 // TODO - Stopgap until we learn the correct way to structure our code for testing.
@@ -72,25 +72,25 @@ func NewActivityCommand(clients *shared.ClientFactory) *cobra.Command {
 	}
 
 	cmd.Flags().BoolVarP(&tailArg, "tail", "t", false, "continuously poll for new activity")
-	cmd.Flags().IntVarP(&pollingIntervalS, "interval", "i", platform.ACTIVITY_POLLING_INTERVAL_SECONDS, "polling interval in seconds")
-	cmd.Flags().IntVarP(&idleTimeoutM, "idle", "", platform.ACTIVITY_IDLE_TIMEOUT, "time to poll without results before exiting\n  in minutes")
+	cmd.Flags().IntVarP(&pollingIntervalS, "interval", "i", platform.ActivityPollingIntervalDefault, "polling interval in seconds")
+	cmd.Flags().IntVarP(&idleTimeoutM, "idle", "", platform.ActivityIdleTimeoutDefault, "time to poll without results before exiting\n  in minutes")
 	cmd.Flags().BoolVarP(&browser, "browser", "", false, "open the default web browser to the log activity")
-	cmd.Flags().StringVar(&minLevel, "level", "", fmt.Sprintf("minimum log level to display (default \"%s\")\n  (trace, debug, info, warn, error, fatal)", platform.ACTIVITY_MIN_LEVEL))
-	cmd.Flags().IntVar(&limit, "limit", platform.ACTIVITY_LIMIT, "limit the amount of logs retrieved")
+	cmd.Flags().StringVar(&minLevel, "level", "", fmt.Sprintf("minimum log level to display (default \"%s\")\n  (trace, debug, info, warn, error, fatal)", platform.ActivityMinLevelDefault))
+	cmd.Flags().IntVar(&limit, "limit", platform.ActivityLimitDefault, "limit the amount of logs retrieved")
 	cmd.Flags().Int64Var(&minDateCreated, "min-date-created", 0, "minimum timestamp to filter\n  (unix timestamp in microseconds)")
 	cmd.Flags().Int64Var(&maxDateCreated, "max-date-created", 0, "maximum timestamp to filter\n  (unix timestamp in microseconds)")
 	cmd.Flags().StringVar(&eventType, "event", "", "event type to filter")
 	cmd.Flags().StringVar(&componentType, "component", "", "component type to filter")
-	cmd.Flags().StringVar(&componentId, "component-id", "", "component id to filter\n  (either a function id or workflow id)")
+	cmd.Flags().StringVar(&componentID, "component-id", "", "component id to filter\n  (either a function id or workflow id)")
 	cmd.Flags().StringVar(&source, "source", "", "source (slack or developer) to filter")
-	cmd.Flags().StringVar(&traceId, "trace-id", "", "trace id to filter")
+	cmd.Flags().StringVar(&traceID, "trace-id", "", "trace id to filter")
 
 	// Hidden flags
 	_ = cmd.Flags().MarkHidden("browser") // Hide until editing apps from the App Config UI is available
 
 	// Set defaults
 	if minLevel == "" {
-		minLevel = platform.ACTIVITY_MIN_LEVEL
+		minLevel = platform.ActivityMinLevelDefault
 	}
 
 	return cmd
@@ -113,8 +113,8 @@ func runActivityCommand(clients *shared.ClientFactory, cmd *cobra.Command, args 
 	ctx = config.SetContextToken(ctx, selection.Auth.Token)
 
 	activityArgs := types.ActivityArgs{
-		TeamId:            selection.Auth.TeamID,
-		AppId:             selection.App.AppID,
+		TeamID:            selection.Auth.TeamID,
+		AppID:             selection.App.AppID,
 		TailArg:           tailArg,
 		Browser:           browser,
 		PollingIntervalMS: pollingIntervalS * 1000,
@@ -125,9 +125,9 @@ func runActivityCommand(clients *shared.ClientFactory, cmd *cobra.Command, args 
 		MinLevel:          minLevel,
 		EventType:         eventType,
 		ComponentType:     componentType,
-		ComponentId:       componentId,
+		ComponentID:       componentID,
 		Source:            source,
-		TraceId:           traceId,
+		TraceID:           traceID,
 	}
 
 	log := newActivityLogger(cmd)

--- a/cmd/platform/deploy.go
+++ b/cmd/platform/deploy.go
@@ -92,7 +92,7 @@ func NewDeployCommand(clients *shared.ClientFactory) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if installState == types.REQUEST_PENDING || installState == types.REQUEST_CANCELLED || installState == types.REQUEST_NOT_SENT {
+			if installState == types.InstallRequestPending || installState == types.InstallRequestCancelled || installState == types.InstallRequestNotSent {
 				return nil
 			}
 			switch {

--- a/cmd/platform/deploy.go
+++ b/cmd/platform/deploy.go
@@ -163,18 +163,18 @@ func hasValidDeploymentMethod(
 		return err
 	}
 	switch {
-	case manifestSource.Equals(config.MANIFEST_SOURCE_LOCAL):
+	case manifestSource.Equals(config.ManifestSourceLocal):
 		manifest, err = clients.AppClient().Manifest.GetManifestLocal(ctx, clients.SDKConfig, clients.HookExecutor)
 		if err != nil {
 			return err
 		}
-	case manifestSource.Equals(config.MANIFEST_SOURCE_REMOTE):
+	case manifestSource.Equals(config.ManifestSourceRemote):
 		manifest, err = clients.AppClient().Manifest.GetManifestRemote(ctx, auth.Token, app.AppID)
 		if err != nil {
 			return err
 		}
 	}
-	if manifest.FunctionRuntime() == types.SLACK_HOSTED {
+	if manifest.FunctionRuntime() == types.SlackHosted {
 		return nil
 	}
 	return errorMissingDeployHook(clients)
@@ -256,9 +256,9 @@ func printDeployHostingCompletion(clients *shared.ClientFactory, cmd *cobra.Comm
 
 	parsedAppInfo := map[string]string{}
 
-	host := clients.ApiInterface().Host()
-	if appId := event.DataToString("appId"); appId != "" && host != "" {
-		parsedAppInfo["Dashboard"] = fmt.Sprintf("%s/apps/%s", host, appId)
+	host := clients.APIInterface().Host()
+	if appID := event.DataToString("appID"); appID != "" && host != "" {
+		parsedAppInfo["Dashboard"] = fmt.Sprintf("%s/apps/%s", host, appID)
 	}
 
 	if authSession.UserName != nil && authSession.UserID != nil {

--- a/cmd/platform/deploy_test.go
+++ b/cmd/platform/deploy_test.go
@@ -91,7 +91,7 @@ func TestDeployCommand(t *testing.T) {
 	manifestMock.On("GetManifestLocal", mock.Anything, mock.Anything, mock.Anything).Return(types.SlackYaml{
 		AppManifest: types.AppManifest{
 			Settings: &types.AppSettings{
-				FunctionRuntime: types.SLACK_HOSTED,
+				FunctionRuntime: types.SlackHosted,
 			},
 		},
 	}, nil)
@@ -119,29 +119,29 @@ func TestDeployCommand_HasValidDeploymentMethod(t *testing.T) {
 	}{
 		"fails when no manifest exists": {
 			manifestError:  slackerror.New(slackerror.ErrInvalidManifest),
-			manifestSource: config.MANIFEST_SOURCE_LOCAL,
+			manifestSource: config.ManifestSourceLocal,
 			expectedError:  slackerror.New(slackerror.ErrInvalidManifest),
 		},
 		"succeeds with a slack hosted function runtime": {
 			manifest: types.SlackYaml{
 				AppManifest: types.AppManifest{
 					Settings: &types.AppSettings{
-						FunctionRuntime: types.SLACK_HOSTED,
+						FunctionRuntime: types.SlackHosted,
 					},
 				},
 			},
-			manifestSource: config.MANIFEST_SOURCE_LOCAL,
+			manifestSource: config.ManifestSourceLocal,
 		},
 		"succeeds if a deploy hook script is available to project manifest sources": {
-			manifestSource: config.MANIFEST_SOURCE_LOCAL,
+			manifestSource: config.ManifestSourceLocal,
 			deployScript:   "echo go!",
 		},
 		"continues if a deploy hook script is available to remote manifest sources": {
-			manifestSource: config.MANIFEST_SOURCE_REMOTE,
+			manifestSource: config.ManifestSourceRemote,
 			deployScript:   "sleep 4",
 		},
 		"fails if no deploy hook is provided": {
-			manifestSource: config.MANIFEST_SOURCE_LOCAL,
+			manifestSource: config.ManifestSourceLocal,
 			expectedError:  slackerror.New(slackerror.ErrSDKHookNotFound),
 		},
 	}
@@ -236,7 +236,7 @@ func TestDeployCommand_DeployHook(t *testing.T) {
 			clientsMock := shared.NewClientsMock()
 			clientsMock.AddDefaultMocks()
 			sdkConfigMock := hooks.NewSDKConfigMock()
-			sdkConfigMock.Config.SupportedProtocols = []hooks.Protocol{hooks.HOOK_PROTOCOL_DEFAULT}
+			sdkConfigMock.Config.SupportedProtocols = []hooks.Protocol{hooks.HookProtocolDefault}
 			sdkConfigMock.Hooks.Deploy = hooks.HookScript{Name: "Deploy", Command: tt.command}
 
 			stdoutLogger := log.Logger{}
@@ -285,7 +285,7 @@ func TestDeployCommand_PrintHostingCompletion(t *testing.T) {
 		"information from a workspace deploy is printed": {
 			event: logger.LogData{
 				"appName":     "DeployerApp",
-				"appId":       "A123",
+				"appID":       "A123",
 				"deployTime":  "12.34",
 				"authSession": `{"user": "slackbot", "user_id": "USLACKBOT", "team": "speck", "team_id": "T001"}`,
 			},
@@ -299,7 +299,7 @@ func TestDeployCommand_PrintHostingCompletion(t *testing.T) {
 		"information from an enterprise deploy is printed": {
 			event: logger.LogData{
 				"appName":     "Spackulen",
-				"appId":       "A999",
+				"appID":       "A999",
 				"deployTime":  "8.05",
 				"authSession": `{"user": "stub", "user_id": "U111", "team": "spack", "team_id": "E002", "is_enterprise_install": true, "enterprise_id": "E002"}`,
 			},
@@ -322,7 +322,7 @@ func TestDeployCommand_PrintHostingCompletion(t *testing.T) {
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			clientsMock := shared.NewClientsMock()
-			clientsMock.ApiInterface.On("Host").Return("https://slacker.com")
+			clientsMock.APIInterface.On("Host").Return("https://slacker.com")
 			clientsMock.AddDefaultMocks()
 			clients := shared.NewClientFactory(clientsMock.MockClientFactory())
 			cmd := NewDeployCommand(clients)

--- a/cmd/platform/run.go
+++ b/cmd/platform/run.go
@@ -68,7 +68,7 @@ func NewRunCommand(clients *shared.ClientFactory) *cobra.Command {
 	}
 
 	// Add flags
-	cmd.Flags().StringVar(&runFlags.activityLevel, "activity-level", platform.ACTIVITY_MIN_LEVEL, "activity level to display")
+	cmd.Flags().StringVar(&runFlags.activityLevel, "activity-level", platform.ActivityMinLevelDefault, "activity level to display")
 	cmd.Flags().BoolVar(&runFlags.noActivity, "no-activity", false, "hide Slack Platform log activity")
 	cmd.Flags().BoolVar(&runFlags.cleanup, "cleanup", false, "uninstall the local app after exiting")
 	cmd.Flags().StringVar(&runFlags.orgGrantWorkspaceID, cmdutil.OrgGrantWorkspaceFlag, "", cmdutil.OrgGrantWorkspaceDescription())
@@ -80,7 +80,7 @@ func NewRunCommand(clients *shared.ClientFactory) *cobra.Command {
 		cmd.Flag("activity-level").DefValue = ""
 		cmd.Flag("activity-level").Usage = fmt.Sprintf(
 			"activity level to display (default \"%s\")\n  %s",
-			platform.ACTIVITY_MIN_LEVEL,
+			platform.ActivityMinLevelDefault,
 			style.Secondary("(trace, debug, info, warn, error, fatal)"),
 		)
 		cmd.Flag(cmdutil.OrgGrantWorkspaceFlag).Usage = cmdutil.OrgGrantWorkspaceDescription()

--- a/cmd/platform/run_test.go
+++ b/cmd/platform/run_test.go
@@ -50,7 +50,7 @@ type RunPkgMock struct {
 
 func (m *RunPkgMock) Run(ctx context.Context, clients *shared.ClientFactory, log *logger.Logger, runArgs platform.RunArgs) (*logger.LogEvent, types.InstallState, error) {
 	args := m.Called(ctx, clients, log, runArgs)
-	return log.SuccessEvent(), types.SUCCESS, args.Error(0)
+	return log.SuccessEvent(), types.InstallSuccess, args.Error(0)
 }
 
 func TestRunCommand_Flags(t *testing.T) {

--- a/cmd/project/create_samples_test.go
+++ b/cmd/project/create_samples_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-var MOCK_REPOS = []create.GithubRepo{
+var mockGitHubRepos = []create.GithubRepo{
 	{
 		ID:              1,
 		Name:            "deno-mock-repo",
@@ -129,12 +129,12 @@ func TestSamples_PromptSampleSelection(t *testing.T) {
 }
 
 func TestSamples_FilterRepos(t *testing.T) {
-	filteredRepos := filterRepos(MOCK_REPOS, "deno")
+	filteredRepos := filterRepos(mockGitHubRepos, "deno")
 	assert.Equal(t, len(filteredRepos), 2, "Expected filteredRepos length to be 2")
 }
 
 func TestSamples_SortRepos(t *testing.T) {
-	sortedRepos := sortRepos(MOCK_REPOS)
+	sortedRepos := sortRepos(mockGitHubRepos)
 	assert.Equal(t, sortedRepos[0].StargazersCount, 50, "Expected sortedRepos[0].StargazersCount to equal 50")
 	assert.Equal(t, sortedRepos[0].Description, "This is a popular sample")
 	assert.Equal(t, sortedRepos[3].StargazersCount, 0, "Expected sortedRepos[3].StargazersCount to equal 0")
@@ -142,7 +142,7 @@ func TestSamples_SortRepos(t *testing.T) {
 }
 
 func TestSamples_CreateSelectOptions(t *testing.T) {
-	selectOptions := createSelectOptions(MOCK_REPOS)
+	selectOptions := createSelectOptions(mockGitHubRepos)
 	assert.Equal(t, len(selectOptions), 4, "Expected selectOptions length to be 4")
-	assert.Contains(t, selectOptions[0], MOCK_REPOS[0].Name, "Expected selectOptions[0] to contain MOCK_REPOS[0].Name")
+	assert.Contains(t, selectOptions[0], mockGitHubRepos[0].Name, "Expected selectOptions[0] to contain mockGitHubRepos[0].Name")
 }

--- a/cmd/project/create_template.go
+++ b/cmd/project/create_template.go
@@ -211,7 +211,7 @@ func promptTemplateSelection(cmd *cobra.Command, clients *shared.ClientFactory) 
 	// Ensure user is okay to proceed if template source is from a non-trusted source
 	switch selectedTemplate {
 	case viewMoreSamples:
-		sampler := api.NewHttpClient(api.HttpClientOptions{
+		sampler := api.NewHTTPClient(api.HTTPClientOptions{
 			TotalTimeOut: 60 * time.Second,
 		})
 		selectedSample, err := PromptSampleSelection(ctx, clients, sampler)

--- a/cmd/project/init.go
+++ b/cmd/project/init.go
@@ -114,9 +114,9 @@ func projectInitCommandRunE(clients *shared.ClientFactory, cmd *cobra.Command, a
 	}
 
 	// Install the project dependencies, such as .slack/ and runtime packages
-	// Existing projects initialized always default to config.MANIFEST_SOURCE_LOCAL.
-	// The link command will switch it to config.MANIFEST_SOURCE_REMOTE
-	_ = create.InstallProjectDependencies(ctx, clients, projectDirPath, config.MANIFEST_SOURCE_LOCAL)
+	// Existing projects initialized always default to config.ManifestSourceLocal.
+	// The link command will switch it to config.ManifestSourceRemote
+	_ = create.InstallProjectDependencies(ctx, clients, projectDirPath, config.ManifestSourceLocal)
 
 	// Add an existing app to the project
 	err = app.LinkExistingApp(ctx, clients, &types.App{}, true)

--- a/cmd/project/init_test.go
+++ b/cmd/project/init_test.go
@@ -150,7 +150,7 @@ func Test_Project_InitCommand(t *testing.T) {
 					Option: "local",
 				}, nil)
 				// Mock status of app for footer
-				cm.ApiInterface.On("GetAppStatus",
+				cm.APIInterface.On("GetAppStatus",
 					mock.Anything,
 					mockLinkSlackAuth2.Token,
 					[]string{mockLinkAppID1},

--- a/cmd/project/samples.go
+++ b/cmd/project/samples.go
@@ -52,7 +52,7 @@ func NewSamplesCommand(clients *shared.ClientFactory) *cobra.Command {
 // runSamplesCommand prompts for a sample then clones with the create command
 func runSamplesCommand(clients *shared.ClientFactory, cmd *cobra.Command, args []string) error {
 	ctx := cmd.Context()
-	sampler := api.NewHttpClient(api.HttpClientOptions{
+	sampler := api.NewHTTPClient(api.HTTPClientOptions{
 		TotalTimeOut: 60 * time.Second,
 	})
 	selectedSample, err := PromptSampleSelection(ctx, clients, sampler)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -259,8 +259,8 @@ func InitConfig(ctx context.Context, clients *shared.ClientFactory, rootCmd *cob
 	clients.Config.TrustUnknownSources = trustSources
 
 	// Init clients that use flags
-	clients.Config.ApiHostResolved = clients.AuthInterface().ResolveApiHost(ctx, clients.Config.ApiHostFlag, nil)
-	clients.Config.LogstashHostResolved = clients.AuthInterface().ResolveLogstashHost(ctx, clients.Config.ApiHostResolved, clients.CliVersion)
+	clients.Config.APIHostResolved = clients.AuthInterface().ResolveAPIHost(ctx, clients.Config.APIHostFlag, nil)
+	clients.Config.LogstashHostResolved = clients.AuthInterface().ResolveLogstashHost(ctx, clients.Config.APIHostResolved, clients.CliVersion)
 
 	// Init System ID
 	if systemID, err := clients.Config.SystemConfig.InitSystemID(ctx); err != nil {

--- a/cmd/triggers/access_test.go
+++ b/cmd/triggers/access_test.go
@@ -43,13 +43,13 @@ func TestTriggersAccessCommand(t *testing.T) {
 				appSelectTeardown = setupMockAccessAppSelection(installedProdApp)
 				// get current access type
 				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
-					Return(types.EVERYONE, []string{}, nil).Once()
+					Return(types.PermissionEveryone, []string{}, nil).Once()
 				// set access type to collaborators
-				clientsMock.APIInterface.On("TriggerPermissionsSet", mock.Anything, mock.Anything, mock.Anything, mock.Anything, types.APP_COLLABORATORS, "").
+				clientsMock.APIInterface.On("TriggerPermissionsSet", mock.Anything, mock.Anything, mock.Anything, mock.Anything, types.PermissionAppCollaborators, "").
 					Return([]string{"collaborator_ID"}, nil)
 				// get access type from backend to display
 				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
-					Return(types.APP_COLLABORATORS, []string{"collaborator_ID"}, nil).Once()
+					Return(types.PermissionAppCollaborators, []string{"collaborator_ID"}, nil).Once()
 				// display user info for updated access
 				clientsMock.APIInterface.On("UsersInfo", mock.Anything, mock.Anything, "collaborator_ID").
 					Return(&types.UserInfo{}, nil).Once()
@@ -73,16 +73,16 @@ func TestTriggersAccessCommand(t *testing.T) {
 				appSelectTeardown = setupMockAccessAppSelection(installedProdApp)
 				// get current access type
 				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
-					Return(types.APP_COLLABORATORS, []string{"collaborator_ID"}, nil).Once()
+					Return(types.PermissionAppCollaborators, []string{"collaborator_ID"}, nil).Once()
 				// display user info for current access
 				clientsMock.APIInterface.On("UsersInfo", mock.Anything, mock.Anything, "collaborator_ID").
 					Return(&types.UserInfo{}, nil).Once()
 				// set access type to everyone
-				clientsMock.APIInterface.On("TriggerPermissionsSet", mock.Anything, mock.Anything, fakeTriggerID, mock.Anything, types.EVERYONE, "").
+				clientsMock.APIInterface.On("TriggerPermissionsSet", mock.Anything, mock.Anything, fakeTriggerID, mock.Anything, types.PermissionEveryone, "").
 					Return([]string{}, nil)
 				// get access type from backend to display
 				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
-					Return(types.EVERYONE, []string{}, nil).Once()
+					Return(types.PermissionEveryone, []string{}, nil).Once()
 
 				clientsMock.AddDefaultMocks()
 				err := clients.AppClient().SaveDeployed(ctx, fakeApp)
@@ -103,16 +103,16 @@ func TestTriggersAccessCommand(t *testing.T) {
 				appSelectTeardown = setupMockAccessAppSelection(installedProdOrgApp)
 				// get current access type
 				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
-					Return(types.APP_COLLABORATORS, []string{"collaborator_ID"}, nil).Once()
+					Return(types.PermissionAppCollaborators, []string{"collaborator_ID"}, nil).Once()
 				// display user info for current access
 				clientsMock.APIInterface.On("UsersInfo", mock.Anything, mock.Anything, "collaborator_ID").
 					Return(&types.UserInfo{}, nil).Once()
 				// set access type to everyone
-				clientsMock.APIInterface.On("TriggerPermissionsSet", mock.Anything, mock.Anything, fakeTriggerID, mock.Anything, types.EVERYONE, "").
+				clientsMock.APIInterface.On("TriggerPermissionsSet", mock.Anything, mock.Anything, fakeTriggerID, mock.Anything, types.PermissionEveryone, "").
 					Return([]string{}, nil)
 				// get access type from backend to display
 				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
-					Return(types.EVERYONE, []string{}, nil).Once()
+					Return(types.PermissionEveryone, []string{}, nil).Once()
 
 				clientsMock.AddDefaultMocks()
 				err := clients.AppClient().SaveDeployed(ctx, fakeApp)
@@ -130,16 +130,16 @@ func TestTriggersAccessCommand(t *testing.T) {
 				appSelectTeardown = setupMockAccessAppSelection(installedProdApp)
 				// get current access type
 				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
-					Return(types.APP_COLLABORATORS, []string{"collaborator_ID"}, nil).Once()
+					Return(types.PermissionAppCollaborators, []string{"collaborator_ID"}, nil).Once()
 				// display user info for current access
 				clientsMock.APIInterface.On("UserInfo", mock.Anything, mock.Anything, "collaborator_ID").
 					Return(&types.UserInfo{}, nil).Once()
 				// set access type to named_entities
-				clientsMock.APIInterface.On("TriggerPermissionsSet", mock.Anything, mock.Anything, fakeTriggerID, "USER1,USER2", types.NAMED_ENTITIES, "users").
+				clientsMock.APIInterface.On("TriggerPermissionsSet", mock.Anything, mock.Anything, fakeTriggerID, "USER1,USER2", types.PermissionNamedEntities, "users").
 					Return([]string{}, nil)
 				// get access type from backend to display
 				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
-					Return(types.NAMED_ENTITIES, []string{"USER1", "USER2"}, nil).Once()
+					Return(types.PermissionNamedEntities, []string{"USER1", "USER2"}, nil).Once()
 				// display user info for updated access
 				clientsMock.APIInterface.On("UsersInfo", mock.Anything, mock.Anything, "USER1").
 					Return(&types.UserInfo{RealName: "User One", Name: "USER1", Profile: user1Profile}, nil).Once()
@@ -162,16 +162,16 @@ func TestTriggersAccessCommand(t *testing.T) {
 				appSelectTeardown = setupMockAccessAppSelection(installedProdApp)
 				// get current access type
 				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
-					Return(types.APP_COLLABORATORS, []string{"collaborator_ID"}, nil).Once()
+					Return(types.PermissionAppCollaborators, []string{"collaborator_ID"}, nil).Once()
 				// display user info for current access
 				clientsMock.APIInterface.On("UserInfo", mock.Anything, mock.Anything, "collaborator_ID").
 					Return(&types.UserInfo{}, nil).Once()
 				// set access type to named_entities
-				clientsMock.APIInterface.On("TriggerPermissionsSet", mock.Anything, mock.Anything, fakeTriggerID, "CHANNEL1,CHANNEL2", types.NAMED_ENTITIES, "channels").
+				clientsMock.APIInterface.On("TriggerPermissionsSet", mock.Anything, mock.Anything, fakeTriggerID, "CHANNEL1,CHANNEL2", types.PermissionNamedEntities, "channels").
 					Return([]string{}, nil)
 				// get access type from backend to display
 				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
-					Return(types.NAMED_ENTITIES, []string{"CHANNEL1", "CHANNEL2"}, nil).Once()
+					Return(types.PermissionNamedEntities, []string{"CHANNEL1", "CHANNEL2"}, nil).Once()
 				// display channel info for updated access
 				clientsMock.APIInterface.On("ChannelsInfo", mock.Anything, mock.Anything, "CHANNEL1").
 					Return(&types.ChannelInfo{ID: "CHANNEL1", Name: "Channel One"}, nil).Once()
@@ -193,20 +193,20 @@ func TestTriggersAccessCommand(t *testing.T) {
 				appSelectTeardown = setupMockAccessAppSelection(installedProdApp)
 				// get current access type
 				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
-					Return(types.APP_COLLABORATORS, []string{"collaborator_ID"}, nil).Once()
+					Return(types.PermissionAppCollaborators, []string{"collaborator_ID"}, nil).Once()
 				// display user info for current access
 				clientsMock.APIInterface.On("UserInfo", mock.Anything, mock.Anything, "collaborator_ID").
 					Return(&types.UserInfo{}, nil).Once()
 				// confirm to add app collaborators
 				clientsMock.IO.On("ConfirmPrompt", mock.Anything, "Include app collaborators?", mock.Anything).Return(true, nil)
 				// set access type to named_entities
-				clientsMock.APIInterface.On("TriggerPermissionsSet", mock.Anything, mock.Anything, fakeTriggerID, "collaborator_ID", types.NAMED_ENTITIES, "users").
+				clientsMock.APIInterface.On("TriggerPermissionsSet", mock.Anything, mock.Anything, fakeTriggerID, "collaborator_ID", types.PermissionNamedEntities, "users").
 					Return([]string{}, nil)
 				clientsMock.APIInterface.On("TriggerPermissionsAddEntities", mock.Anything, mock.Anything, fakeTriggerID, "TEAM1", "workspaces").
 					Return(nil)
 				// get access type from backend to display
 				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
-					Return(types.NAMED_ENTITIES, []string{"collaborator_ID", "TEAM1"}, nil).Once()
+					Return(types.PermissionNamedEntities, []string{"collaborator_ID", "TEAM1"}, nil).Once()
 				clientsMock.APIInterface.On("UserInfo", mock.Anything, mock.Anything, "collaborator_ID").
 					Return(&types.UserInfo{}, nil).Once()
 				// display workspace info for updated access
@@ -230,18 +230,18 @@ func TestTriggersAccessCommand(t *testing.T) {
 				appSelectTeardown = setupMockAccessAppSelection(installedProdApp)
 				// get current access type
 				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
-					Return(types.APP_COLLABORATORS, []string{"collaborator_ID"}, nil).Once()
+					Return(types.PermissionAppCollaborators, []string{"collaborator_ID"}, nil).Once()
 				// display user info for current access
 				clientsMock.APIInterface.On("UserInfo", mock.Anything, mock.Anything, "collaborator_ID").
 					Return(&types.UserInfo{}, nil).Once()
 				// set access type to named_entities
-				clientsMock.APIInterface.On("TriggerPermissionsSet", mock.Anything, mock.Anything, fakeTriggerID, "collaborator_ID", types.NAMED_ENTITIES, "users").
+				clientsMock.APIInterface.On("TriggerPermissionsSet", mock.Anything, mock.Anything, fakeTriggerID, "collaborator_ID", types.PermissionNamedEntities, "users").
 					Return([]string{}, nil)
 				clientsMock.APIInterface.On("TriggerPermissionsAddEntities", mock.Anything, mock.Anything, fakeTriggerID, "TEAM1", "workspaces").
 					Return(nil)
 				// get access type from backend to display
 				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
-					Return(types.NAMED_ENTITIES, []string{"collaborator_ID", "TEAM1"}, nil).Once()
+					Return(types.PermissionNamedEntities, []string{"collaborator_ID", "TEAM1"}, nil).Once()
 				clientsMock.APIInterface.On("UserInfo", mock.Anything, mock.Anything, "collaborator_ID").
 					Return(&types.UserInfo{}, nil).Once()
 				// display workspace info for updated access
@@ -266,18 +266,18 @@ func TestTriggersAccessCommand(t *testing.T) {
 				appSelectTeardown = setupMockAccessAppSelection(installedProdApp)
 				// get current access type
 				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
-					Return(types.APP_COLLABORATORS, []string{"collaborator_ID"}, nil).Once()
+					Return(types.PermissionAppCollaborators, []string{"collaborator_ID"}, nil).Once()
 				// display user info for current access
 				clientsMock.APIInterface.On("UserInfo", mock.Anything, mock.Anything, "collaborator_ID").
 					Return(&types.UserInfo{}, nil).Once()
 				// confirm to add app collaborators
 				clientsMock.IO.On("ConfirmPrompt", mock.Anything, "Include app collaborators?", mock.Anything).Return(true)
 				// set access type to named_entities
-				clientsMock.APIInterface.On("TriggerPermissionsSet", mock.Anything, mock.Anything, fakeTriggerID, "collaborator_ID", types.NAMED_ENTITIES, "users").Maybe().
+				clientsMock.APIInterface.On("TriggerPermissionsSet", mock.Anything, mock.Anything, fakeTriggerID, "collaborator_ID", types.PermissionNamedEntities, "users").Maybe().
 					Return([]string{}, nil)
-				clientsMock.APIInterface.On("TriggerPermissionsAddEntities", mock.Anything, mock.Anything, fakeTriggerID, "USER1,USER2", types.NAMED_ENTITIES, "users").Maybe().
+				clientsMock.APIInterface.On("TriggerPermissionsAddEntities", mock.Anything, mock.Anything, fakeTriggerID, "USER1,USER2", types.PermissionNamedEntities, "users").Maybe().
 					Return([]string{}, nil)
-				clientsMock.APIInterface.On("TriggerPermissionsSet", mock.Anything, mock.Anything, fakeTriggerID, "CHANNEL1,CHANNEL2", types.NAMED_ENTITIES, "channels").Maybe().
+				clientsMock.APIInterface.On("TriggerPermissionsSet", mock.Anything, mock.Anything, fakeTriggerID, "CHANNEL1,CHANNEL2", types.PermissionNamedEntities, "channels").Maybe().
 					Return([]string{}, nil)
 				clientsMock.APIInterface.On("TriggerPermissionsAddEntities", mock.Anything, mock.Anything, fakeTriggerID, "CHANNEL1,CHANNEL2", "channels").Maybe().
 					Return(nil)
@@ -285,7 +285,7 @@ func TestTriggersAccessCommand(t *testing.T) {
 					Return(nil)
 				// get access type from backend to display
 				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
-					Return(types.NAMED_ENTITIES, []string{"USER1", "USER2", "CHANNEL1", "CHANNEL2"}, nil).Once()
+					Return(types.PermissionNamedEntities, []string{"USER1", "USER2", "CHANNEL1", "CHANNEL2"}, nil).Once()
 				// display user info for updated access
 				clientsMock.APIInterface.On("UsersInfo", mock.Anything, mock.Anything, "USER1").
 					Return(&types.UserInfo{RealName: "User One", Name: "USER1", Profile: user1Profile}, nil).Once()
@@ -316,7 +316,7 @@ func TestTriggersAccessCommand(t *testing.T) {
 				appSelectTeardown = setupMockAccessAppSelection(installedProdApp)
 				// get current access type
 				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
-					Return(types.NAMED_ENTITIES, []string{"USER1"}, nil).Once()
+					Return(types.PermissionNamedEntities, []string{"USER1"}, nil).Once()
 				// display user info for current access
 				clientsMock.APIInterface.On("UserInfo", mock.Anything, mock.Anything, "USER1").
 					Return(&types.UserInfo{}, nil).Once()
@@ -325,7 +325,7 @@ func TestTriggersAccessCommand(t *testing.T) {
 					Return(nil)
 				// get access type from backend to display
 				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
-					Return(types.NAMED_ENTITIES, []string{"USER1", "USER2"}, nil).Once()
+					Return(types.PermissionNamedEntities, []string{"USER1", "USER2"}, nil).Once()
 				// display user info for updated access
 				clientsMock.APIInterface.On("UsersInfo", mock.Anything, mock.Anything, "USER1").
 					Return(&types.UserInfo{RealName: "User One", Name: "USER1", Profile: user1Profile}, nil).Once()
@@ -348,7 +348,7 @@ func TestTriggersAccessCommand(t *testing.T) {
 				appSelectTeardown = setupMockAccessAppSelection(installedProdApp)
 				// get current access type
 				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
-					Return(types.NAMED_ENTITIES, []string{"CHANNEL1"}, nil).Once()
+					Return(types.PermissionNamedEntities, []string{"CHANNEL1"}, nil).Once()
 				// display user info for current access
 				// clientsMock.APIInterface.On("UserInfo", mock.Anything, mock.Anything, "USER1").
 				// 	Return(&types.UserInfo{}, nil).Once()
@@ -357,7 +357,7 @@ func TestTriggersAccessCommand(t *testing.T) {
 					Return(nil)
 				// get access type from backend to display
 				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
-					Return(types.NAMED_ENTITIES, []string{"CHANNEL1", "CHANNEL2"}, nil).Once()
+					Return(types.PermissionNamedEntities, []string{"CHANNEL1", "CHANNEL2"}, nil).Once()
 				// display channel info for updated access
 				clientsMock.APIInterface.On("ChannelsInfo", mock.Anything, mock.Anything, "CHANNEL1").
 					Return(&types.ChannelInfo{ID: "CHANNEL1", Name: "Channel One"}, nil).Once()
@@ -380,7 +380,7 @@ func TestTriggersAccessCommand(t *testing.T) {
 				appSelectTeardown = setupMockAccessAppSelection(installedProdApp)
 				// get current access type
 				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
-					Return(types.NAMED_ENTITIES, []string{"CHANNEL1"}, nil).Once()
+					Return(types.PermissionNamedEntities, []string{"CHANNEL1"}, nil).Once()
 				clientsMock.APIInterface.On("TriggerPermissionsAddEntities", mock.Anything, mock.Anything, fakeTriggerID, "CHANNEL2", "channels").
 					Return(nil)
 				clientsMock.APIInterface.On("TriggerPermissionsAddEntities", mock.Anything, mock.Anything, fakeTriggerID, "USER1,USER2", "users").
@@ -389,7 +389,7 @@ func TestTriggersAccessCommand(t *testing.T) {
 					Return(nil)
 				// get access type from backend to display
 				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
-					Return(types.NAMED_ENTITIES, []string{"USER1", "USER2", "CHANNEL1", "CHANNEL2", "TEAM1"}, nil).Once()
+					Return(types.PermissionNamedEntities, []string{"USER1", "USER2", "CHANNEL1", "CHANNEL2", "TEAM1"}, nil).Once()
 				// display user info for updated access
 				clientsMock.APIInterface.On("UsersInfo", mock.Anything, mock.Anything, "USER1").
 					Return(&types.UserInfo{RealName: "User One", Name: "USER1", Profile: user1Profile}, nil).Once()
@@ -422,7 +422,7 @@ func TestTriggersAccessCommand(t *testing.T) {
 				appSelectTeardown = setupMockAccessAppSelection(installedProdApp)
 				// get current access type
 				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
-					Return(types.NAMED_ENTITIES, []string{"USER1", "USER2"}, nil).Once()
+					Return(types.PermissionNamedEntities, []string{"USER1", "USER2"}, nil).Once()
 				// display user info for current access
 				clientsMock.APIInterface.On("UserInfo", mock.Anything, mock.Anything, "USER1").
 					Return(&types.UserInfo{}, nil).Once()
@@ -431,7 +431,7 @@ func TestTriggersAccessCommand(t *testing.T) {
 					Return(nil)
 				// get access type from backend to display
 				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
-					Return(types.NAMED_ENTITIES, []string{"USER1"}, nil).Once()
+					Return(types.PermissionNamedEntities, []string{"USER1"}, nil).Once()
 				// display user info for updated access
 				clientsMock.APIInterface.On("UsersInfo", mock.Anything, mock.Anything, "USER1").
 					Return(&types.UserInfo{RealName: "User One", Name: "USER1", Profile: user1Profile}, nil).Once()
@@ -451,13 +451,13 @@ func TestTriggersAccessCommand(t *testing.T) {
 				appSelectTeardown = setupMockAccessAppSelection(installedProdApp)
 				// get current access type
 				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
-					Return(types.NAMED_ENTITIES, []string{"CHANNEL1", "CHANNEL2"}, nil).Once()
+					Return(types.PermissionNamedEntities, []string{"CHANNEL1", "CHANNEL2"}, nil).Once()
 				// remove channel from named_entities ACL
 				clientsMock.APIInterface.On("TriggerPermissionsRemoveEntities", mock.Anything, mock.Anything, fakeTriggerID, "CHANNEL2", "channels").
 					Return(nil)
 				// get access type from backend to display
 				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
-					Return(types.NAMED_ENTITIES, []string{"CHANNEL1"}, nil).Once()
+					Return(types.PermissionNamedEntities, []string{"CHANNEL1"}, nil).Once()
 
 				// display channel info for updated access
 				clientsMock.APIInterface.On("ChannelsInfo", mock.Anything, mock.Anything, "CHANNEL1").
@@ -479,13 +479,13 @@ func TestTriggersAccessCommand(t *testing.T) {
 				appSelectTeardown = setupMockAccessAppSelection(installedProdApp)
 				// get current access type
 				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
-					Return(types.NAMED_ENTITIES, []string{"TEAM1", "TEAM2"}, nil).Once()
+					Return(types.PermissionNamedEntities, []string{"TEAM1", "TEAM2"}, nil).Once()
 				// remove workspace from named_entities ACL
 				clientsMock.APIInterface.On("TriggerPermissionsRemoveEntities", mock.Anything, mock.Anything, fakeTriggerID, "TEAM2", "workspaces").
 					Return(nil)
 				// get access type from backend to display
 				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
-					Return(types.NAMED_ENTITIES, []string{"TEAM1"}, nil).Once()
+					Return(types.PermissionNamedEntities, []string{"TEAM1"}, nil).Once()
 
 				// display team info for updated access
 				clientsMock.APIInterface.On("TeamsInfo", mock.Anything, mock.Anything, "TEAM1").
@@ -507,7 +507,7 @@ func TestTriggersAccessCommand(t *testing.T) {
 				appSelectTeardown = setupMockAccessAppSelection(installedProdApp)
 				// get current access type
 				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
-					Return(types.NAMED_ENTITIES, []string{"USER1", "USER2", "CHANNEL1", "CHANNEL2"}, nil).Once()
+					Return(types.PermissionNamedEntities, []string{"USER1", "USER2", "CHANNEL1", "CHANNEL2"}, nil).Once()
 				// remove user from named_entities ACL
 				clientsMock.APIInterface.On("TriggerPermissionsRemoveEntities", mock.Anything, mock.Anything, fakeTriggerID, "USER2", "users").
 					Return(nil)
@@ -516,7 +516,7 @@ func TestTriggersAccessCommand(t *testing.T) {
 					Return(nil)
 				// get access type from backend to display
 				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
-					Return(types.NAMED_ENTITIES, []string{"USER1", "CHANNEL1"}, nil).Once()
+					Return(types.PermissionNamedEntities, []string{"USER1", "CHANNEL1"}, nil).Once()
 				clientsMock.APIInterface.On("UsersInfo", mock.Anything, mock.Anything, "USER1").
 					Return(&types.UserInfo{RealName: "User One", Name: "USER1", Profile: user1Profile}, nil).Once()
 				clientsMock.AddDefaultMocks()
@@ -540,14 +540,14 @@ func TestTriggersAccessCommand(t *testing.T) {
 				clientsMock.APIInterface.On("WorkflowsTriggersList", mock.Anything, mock.Anything, mock.Anything).Return(
 					[]types.DeployedTrigger{{Name: "Trigger 1", ID: fakeTriggerID, Type: "Shortcut", Workflow: types.TriggerWorkflow{AppID: fakeAppID}}}, "", nil)
 				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
-					Return(types.EVERYONE, []string{}, nil).Once()
+					Return(types.PermissionEveryone, []string{}, nil).Once()
 				// set and display access
 				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
-					Return(types.EVERYONE, []string{}, nil).Once()
-				clientsMock.APIInterface.On("TriggerPermissionsSet", mock.Anything, mock.Anything, mock.Anything, mock.Anything, types.EVERYONE, "").
+					Return(types.PermissionEveryone, []string{}, nil).Once()
+				clientsMock.APIInterface.On("TriggerPermissionsSet", mock.Anything, mock.Anything, mock.Anything, mock.Anything, types.PermissionEveryone, "").
 					Return([]string{}, nil)
 				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
-					Return(types.EVERYONE, []string{}, nil).Once()
+					Return(types.PermissionEveryone, []string{}, nil).Once()
 
 				clientsMock.IO.On("SelectPrompt", mock.Anything, "Choose a trigger:", mock.Anything, iostreams.MatchPromptConfig(iostreams.SelectPromptConfig{
 					Flag: clientsMock.Config.Flags.Lookup("trigger-id"),

--- a/cmd/triggers/access_test.go
+++ b/cmd/triggers/access_test.go
@@ -42,16 +42,16 @@ func TestTriggersAccessCommand(t *testing.T) {
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				appSelectTeardown = setupMockAccessAppSelection(installedProdApp)
 				// get current access type
-				clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.EVERYONE, []string{}, nil).Once()
 				// set access type to collaborators
-				clientsMock.ApiInterface.On("TriggerPermissionsSet", mock.Anything, mock.Anything, mock.Anything, mock.Anything, types.APP_COLLABORATORS, "").
+				clientsMock.APIInterface.On("TriggerPermissionsSet", mock.Anything, mock.Anything, mock.Anything, mock.Anything, types.APP_COLLABORATORS, "").
 					Return([]string{"collaborator_ID"}, nil)
 				// get access type from backend to display
-				clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.APP_COLLABORATORS, []string{"collaborator_ID"}, nil).Once()
 				// display user info for updated access
-				clientsMock.ApiInterface.On("UsersInfo", mock.Anything, mock.Anything, "collaborator_ID").
+				clientsMock.APIInterface.On("UsersInfo", mock.Anything, mock.Anything, "collaborator_ID").
 					Return(&types.UserInfo{}, nil).Once()
 
 				clientsMock.AddDefaultMocks()
@@ -72,16 +72,16 @@ func TestTriggersAccessCommand(t *testing.T) {
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				appSelectTeardown = setupMockAccessAppSelection(installedProdApp)
 				// get current access type
-				clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.APP_COLLABORATORS, []string{"collaborator_ID"}, nil).Once()
 				// display user info for current access
-				clientsMock.ApiInterface.On("UsersInfo", mock.Anything, mock.Anything, "collaborator_ID").
+				clientsMock.APIInterface.On("UsersInfo", mock.Anything, mock.Anything, "collaborator_ID").
 					Return(&types.UserInfo{}, nil).Once()
 				// set access type to everyone
-				clientsMock.ApiInterface.On("TriggerPermissionsSet", mock.Anything, mock.Anything, fakeTriggerID, mock.Anything, types.EVERYONE, "").
+				clientsMock.APIInterface.On("TriggerPermissionsSet", mock.Anything, mock.Anything, fakeTriggerID, mock.Anything, types.EVERYONE, "").
 					Return([]string{}, nil)
 				// get access type from backend to display
-				clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.EVERYONE, []string{}, nil).Once()
 
 				clientsMock.AddDefaultMocks()
@@ -102,16 +102,16 @@ func TestTriggersAccessCommand(t *testing.T) {
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				appSelectTeardown = setupMockAccessAppSelection(installedProdOrgApp)
 				// get current access type
-				clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.APP_COLLABORATORS, []string{"collaborator_ID"}, nil).Once()
 				// display user info for current access
-				clientsMock.ApiInterface.On("UsersInfo", mock.Anything, mock.Anything, "collaborator_ID").
+				clientsMock.APIInterface.On("UsersInfo", mock.Anything, mock.Anything, "collaborator_ID").
 					Return(&types.UserInfo{}, nil).Once()
 				// set access type to everyone
-				clientsMock.ApiInterface.On("TriggerPermissionsSet", mock.Anything, mock.Anything, fakeTriggerID, mock.Anything, types.EVERYONE, "").
+				clientsMock.APIInterface.On("TriggerPermissionsSet", mock.Anything, mock.Anything, fakeTriggerID, mock.Anything, types.EVERYONE, "").
 					Return([]string{}, nil)
 				// get access type from backend to display
-				clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.EVERYONE, []string{}, nil).Once()
 
 				clientsMock.AddDefaultMocks()
@@ -129,21 +129,21 @@ func TestTriggersAccessCommand(t *testing.T) {
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				appSelectTeardown = setupMockAccessAppSelection(installedProdApp)
 				// get current access type
-				clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.APP_COLLABORATORS, []string{"collaborator_ID"}, nil).Once()
 				// display user info for current access
-				clientsMock.ApiInterface.On("UserInfo", mock.Anything, mock.Anything, "collaborator_ID").
+				clientsMock.APIInterface.On("UserInfo", mock.Anything, mock.Anything, "collaborator_ID").
 					Return(&types.UserInfo{}, nil).Once()
 				// set access type to named_entities
-				clientsMock.ApiInterface.On("TriggerPermissionsSet", mock.Anything, mock.Anything, fakeTriggerID, "USER1,USER2", types.NAMED_ENTITIES, "users").
+				clientsMock.APIInterface.On("TriggerPermissionsSet", mock.Anything, mock.Anything, fakeTriggerID, "USER1,USER2", types.NAMED_ENTITIES, "users").
 					Return([]string{}, nil)
 				// get access type from backend to display
-				clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.NAMED_ENTITIES, []string{"USER1", "USER2"}, nil).Once()
 				// display user info for updated access
-				clientsMock.ApiInterface.On("UsersInfo", mock.Anything, mock.Anything, "USER1").
+				clientsMock.APIInterface.On("UsersInfo", mock.Anything, mock.Anything, "USER1").
 					Return(&types.UserInfo{RealName: "User One", Name: "USER1", Profile: user1Profile}, nil).Once()
-				clientsMock.ApiInterface.On("UsersInfo", mock.Anything, mock.Anything, "USER2").
+				clientsMock.APIInterface.On("UsersInfo", mock.Anything, mock.Anything, "USER2").
 					Return(&types.UserInfo{RealName: "User Two", Name: "USER2", Profile: user2Profile}, nil).Once()
 
 				clientsMock.AddDefaultMocks()
@@ -161,21 +161,21 @@ func TestTriggersAccessCommand(t *testing.T) {
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				appSelectTeardown = setupMockAccessAppSelection(installedProdApp)
 				// get current access type
-				clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.APP_COLLABORATORS, []string{"collaborator_ID"}, nil).Once()
 				// display user info for current access
-				clientsMock.ApiInterface.On("UserInfo", mock.Anything, mock.Anything, "collaborator_ID").
+				clientsMock.APIInterface.On("UserInfo", mock.Anything, mock.Anything, "collaborator_ID").
 					Return(&types.UserInfo{}, nil).Once()
 				// set access type to named_entities
-				clientsMock.ApiInterface.On("TriggerPermissionsSet", mock.Anything, mock.Anything, fakeTriggerID, "CHANNEL1,CHANNEL2", types.NAMED_ENTITIES, "channels").
+				clientsMock.APIInterface.On("TriggerPermissionsSet", mock.Anything, mock.Anything, fakeTriggerID, "CHANNEL1,CHANNEL2", types.NAMED_ENTITIES, "channels").
 					Return([]string{}, nil)
 				// get access type from backend to display
-				clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.NAMED_ENTITIES, []string{"CHANNEL1", "CHANNEL2"}, nil).Once()
 				// display channel info for updated access
-				clientsMock.ApiInterface.On("ChannelsInfo", mock.Anything, mock.Anything, "CHANNEL1").
+				clientsMock.APIInterface.On("ChannelsInfo", mock.Anything, mock.Anything, "CHANNEL1").
 					Return(&types.ChannelInfo{ID: "CHANNEL1", Name: "Channel One"}, nil).Once()
-				clientsMock.ApiInterface.On("ChannelsInfo", mock.Anything, mock.Anything, "CHANNEL2").
+				clientsMock.APIInterface.On("ChannelsInfo", mock.Anything, mock.Anything, "CHANNEL2").
 					Return(&types.ChannelInfo{ID: "CHANNEL2", Name: "Channel Two"}, nil).Once()
 
 				clientsMock.AddDefaultMocks()
@@ -192,28 +192,28 @@ func TestTriggersAccessCommand(t *testing.T) {
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				appSelectTeardown = setupMockAccessAppSelection(installedProdApp)
 				// get current access type
-				clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.APP_COLLABORATORS, []string{"collaborator_ID"}, nil).Once()
 				// display user info for current access
-				clientsMock.ApiInterface.On("UserInfo", mock.Anything, mock.Anything, "collaborator_ID").
+				clientsMock.APIInterface.On("UserInfo", mock.Anything, mock.Anything, "collaborator_ID").
 					Return(&types.UserInfo{}, nil).Once()
 				// confirm to add app collaborators
 				clientsMock.IO.On("ConfirmPrompt", mock.Anything, "Include app collaborators?", mock.Anything).Return(true, nil)
 				// set access type to named_entities
-				clientsMock.ApiInterface.On("TriggerPermissionsSet", mock.Anything, mock.Anything, fakeTriggerID, "collaborator_ID", types.NAMED_ENTITIES, "users").
+				clientsMock.APIInterface.On("TriggerPermissionsSet", mock.Anything, mock.Anything, fakeTriggerID, "collaborator_ID", types.NAMED_ENTITIES, "users").
 					Return([]string{}, nil)
-				clientsMock.ApiInterface.On("TriggerPermissionsAddEntities", mock.Anything, mock.Anything, fakeTriggerID, "TEAM1", "workspaces").
+				clientsMock.APIInterface.On("TriggerPermissionsAddEntities", mock.Anything, mock.Anything, fakeTriggerID, "TEAM1", "workspaces").
 					Return(nil)
 				// get access type from backend to display
-				clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.NAMED_ENTITIES, []string{"collaborator_ID", "TEAM1"}, nil).Once()
-				clientsMock.ApiInterface.On("UserInfo", mock.Anything, mock.Anything, "collaborator_ID").
+				clientsMock.APIInterface.On("UserInfo", mock.Anything, mock.Anything, "collaborator_ID").
 					Return(&types.UserInfo{}, nil).Once()
 				// display workspace info for updated access
-				clientsMock.ApiInterface.On("TeamsInfo", mock.Anything, mock.Anything, "TEAM1").
+				clientsMock.APIInterface.On("TeamsInfo", mock.Anything, mock.Anything, "TEAM1").
 					Return(&types.TeamInfo{ID: "TEAM1", Name: "Team One"}, nil).Once()
 				// no-op add-collaborators
-				clientsMock.ApiInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
 
 				clientsMock.AddDefaultMocks()
 				err := clients.AppClient().SaveDeployed(ctx, fakeApp)
@@ -229,26 +229,26 @@ func TestTriggersAccessCommand(t *testing.T) {
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				appSelectTeardown = setupMockAccessAppSelection(installedProdApp)
 				// get current access type
-				clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.APP_COLLABORATORS, []string{"collaborator_ID"}, nil).Once()
 				// display user info for current access
-				clientsMock.ApiInterface.On("UserInfo", mock.Anything, mock.Anything, "collaborator_ID").
+				clientsMock.APIInterface.On("UserInfo", mock.Anything, mock.Anything, "collaborator_ID").
 					Return(&types.UserInfo{}, nil).Once()
 				// set access type to named_entities
-				clientsMock.ApiInterface.On("TriggerPermissionsSet", mock.Anything, mock.Anything, fakeTriggerID, "collaborator_ID", types.NAMED_ENTITIES, "users").
+				clientsMock.APIInterface.On("TriggerPermissionsSet", mock.Anything, mock.Anything, fakeTriggerID, "collaborator_ID", types.NAMED_ENTITIES, "users").
 					Return([]string{}, nil)
-				clientsMock.ApiInterface.On("TriggerPermissionsAddEntities", mock.Anything, mock.Anything, fakeTriggerID, "TEAM1", "workspaces").
+				clientsMock.APIInterface.On("TriggerPermissionsAddEntities", mock.Anything, mock.Anything, fakeTriggerID, "TEAM1", "workspaces").
 					Return(nil)
 				// get access type from backend to display
-				clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.NAMED_ENTITIES, []string{"collaborator_ID", "TEAM1"}, nil).Once()
-				clientsMock.ApiInterface.On("UserInfo", mock.Anything, mock.Anything, "collaborator_ID").
+				clientsMock.APIInterface.On("UserInfo", mock.Anything, mock.Anything, "collaborator_ID").
 					Return(&types.UserInfo{}, nil).Once()
 				// display workspace info for updated access
-				clientsMock.ApiInterface.On("TeamsInfo", mock.Anything, mock.Anything, "TEAM1").
+				clientsMock.APIInterface.On("TeamsInfo", mock.Anything, mock.Anything, "TEAM1").
 					Return(&types.TeamInfo{ID: "TEAM1", Name: "Team One"}, nil).Once()
 				// no-op add-collaborators
-				clientsMock.ApiInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
 
 				clientsMock.AddDefaultMocks()
 				err := clients.AppClient().SaveDeployed(ctx, fakeApp)
@@ -265,41 +265,41 @@ func TestTriggersAccessCommand(t *testing.T) {
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				appSelectTeardown = setupMockAccessAppSelection(installedProdApp)
 				// get current access type
-				clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.APP_COLLABORATORS, []string{"collaborator_ID"}, nil).Once()
 				// display user info for current access
-				clientsMock.ApiInterface.On("UserInfo", mock.Anything, mock.Anything, "collaborator_ID").
+				clientsMock.APIInterface.On("UserInfo", mock.Anything, mock.Anything, "collaborator_ID").
 					Return(&types.UserInfo{}, nil).Once()
 				// confirm to add app collaborators
 				clientsMock.IO.On("ConfirmPrompt", mock.Anything, "Include app collaborators?", mock.Anything).Return(true)
 				// set access type to named_entities
-				clientsMock.ApiInterface.On("TriggerPermissionsSet", mock.Anything, mock.Anything, fakeTriggerID, "collaborator_ID", types.NAMED_ENTITIES, "users").Maybe().
+				clientsMock.APIInterface.On("TriggerPermissionsSet", mock.Anything, mock.Anything, fakeTriggerID, "collaborator_ID", types.NAMED_ENTITIES, "users").Maybe().
 					Return([]string{}, nil)
-				clientsMock.ApiInterface.On("TriggerPermissionsAddEntities", mock.Anything, mock.Anything, fakeTriggerID, "USER1,USER2", types.NAMED_ENTITIES, "users").Maybe().
+				clientsMock.APIInterface.On("TriggerPermissionsAddEntities", mock.Anything, mock.Anything, fakeTriggerID, "USER1,USER2", types.NAMED_ENTITIES, "users").Maybe().
 					Return([]string{}, nil)
-				clientsMock.ApiInterface.On("TriggerPermissionsSet", mock.Anything, mock.Anything, fakeTriggerID, "CHANNEL1,CHANNEL2", types.NAMED_ENTITIES, "channels").Maybe().
+				clientsMock.APIInterface.On("TriggerPermissionsSet", mock.Anything, mock.Anything, fakeTriggerID, "CHANNEL1,CHANNEL2", types.NAMED_ENTITIES, "channels").Maybe().
 					Return([]string{}, nil)
-				clientsMock.ApiInterface.On("TriggerPermissionsAddEntities", mock.Anything, mock.Anything, fakeTriggerID, "CHANNEL1,CHANNEL2", "channels").Maybe().
+				clientsMock.APIInterface.On("TriggerPermissionsAddEntities", mock.Anything, mock.Anything, fakeTriggerID, "CHANNEL1,CHANNEL2", "channels").Maybe().
 					Return(nil)
-				clientsMock.ApiInterface.On("TriggerPermissionsAddEntities", mock.Anything, mock.Anything, fakeTriggerID, "USER1,USER2", "users").Maybe().
+				clientsMock.APIInterface.On("TriggerPermissionsAddEntities", mock.Anything, mock.Anything, fakeTriggerID, "USER1,USER2", "users").Maybe().
 					Return(nil)
 				// get access type from backend to display
-				clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.NAMED_ENTITIES, []string{"USER1", "USER2", "CHANNEL1", "CHANNEL2"}, nil).Once()
 				// display user info for updated access
-				clientsMock.ApiInterface.On("UsersInfo", mock.Anything, mock.Anything, "USER1").
+				clientsMock.APIInterface.On("UsersInfo", mock.Anything, mock.Anything, "USER1").
 					Return(&types.UserInfo{RealName: "User One", Name: "USER1", Profile: user1Profile}, nil).Once()
-				clientsMock.ApiInterface.On("UsersInfo", mock.Anything, mock.Anything, "USER2").
+				clientsMock.APIInterface.On("UsersInfo", mock.Anything, mock.Anything, "USER2").
 					Return(&types.UserInfo{RealName: "User Two", Name: "USER2", Profile: user2Profile}, nil).Once()
 
 				// display channel info for updated access
-				clientsMock.ApiInterface.On("ChannelsInfo", mock.Anything, mock.Anything, "CHANNEL1").
+				clientsMock.APIInterface.On("ChannelsInfo", mock.Anything, mock.Anything, "CHANNEL1").
 					Return(&types.ChannelInfo{ID: "CHANNEL1", Name: "Channel One"}, nil).Once()
-				clientsMock.ApiInterface.On("ChannelsInfo", mock.Anything, mock.Anything, "CHANNEL2").
+				clientsMock.APIInterface.On("ChannelsInfo", mock.Anything, mock.Anything, "CHANNEL2").
 					Return(&types.ChannelInfo{ID: "CHANNEL2", Name: "Channel Two"}, nil).Once()
 
 				// no-op add-collaborators
-				clientsMock.ApiInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
 
 				clientsMock.AddDefaultMocks()
 				err := clients.AppClient().SaveDeployed(ctx, fakeApp)
@@ -315,21 +315,21 @@ func TestTriggersAccessCommand(t *testing.T) {
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				appSelectTeardown = setupMockAccessAppSelection(installedProdApp)
 				// get current access type
-				clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.NAMED_ENTITIES, []string{"USER1"}, nil).Once()
 				// display user info for current access
-				clientsMock.ApiInterface.On("UserInfo", mock.Anything, mock.Anything, "USER1").
+				clientsMock.APIInterface.On("UserInfo", mock.Anything, mock.Anything, "USER1").
 					Return(&types.UserInfo{}, nil).Once()
 				// add users to named_entities ACL
-				clientsMock.ApiInterface.On("TriggerPermissionsAddEntities", mock.Anything, mock.Anything, fakeTriggerID, "USER2", "users").
+				clientsMock.APIInterface.On("TriggerPermissionsAddEntities", mock.Anything, mock.Anything, fakeTriggerID, "USER2", "users").
 					Return(nil)
 				// get access type from backend to display
-				clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.NAMED_ENTITIES, []string{"USER1", "USER2"}, nil).Once()
 				// display user info for updated access
-				clientsMock.ApiInterface.On("UsersInfo", mock.Anything, mock.Anything, "USER1").
+				clientsMock.APIInterface.On("UsersInfo", mock.Anything, mock.Anything, "USER1").
 					Return(&types.UserInfo{RealName: "User One", Name: "USER1", Profile: user1Profile}, nil).Once()
-				clientsMock.ApiInterface.On("UsersInfo", mock.Anything, mock.Anything, "USER2").
+				clientsMock.APIInterface.On("UsersInfo", mock.Anything, mock.Anything, "USER2").
 					Return(&types.UserInfo{RealName: "User Two", Name: "USER2", Profile: user2Profile}, nil).Once()
 
 				clientsMock.AddDefaultMocks()
@@ -347,21 +347,21 @@ func TestTriggersAccessCommand(t *testing.T) {
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				appSelectTeardown = setupMockAccessAppSelection(installedProdApp)
 				// get current access type
-				clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.NAMED_ENTITIES, []string{"CHANNEL1"}, nil).Once()
 				// display user info for current access
-				// clientsMock.ApiInterface.On("UserInfo", mock.Anything, mock.Anything, "USER1").
+				// clientsMock.APIInterface.On("UserInfo", mock.Anything, mock.Anything, "USER1").
 				// 	Return(&types.UserInfo{}, nil).Once()
 				// add users to named_entities ACL
-				clientsMock.ApiInterface.On("TriggerPermissionsAddEntities", mock.Anything, mock.Anything, fakeTriggerID, "CHANNEL2", "channels").
+				clientsMock.APIInterface.On("TriggerPermissionsAddEntities", mock.Anything, mock.Anything, fakeTriggerID, "CHANNEL2", "channels").
 					Return(nil)
 				// get access type from backend to display
-				clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.NAMED_ENTITIES, []string{"CHANNEL1", "CHANNEL2"}, nil).Once()
 				// display channel info for updated access
-				clientsMock.ApiInterface.On("ChannelsInfo", mock.Anything, mock.Anything, "CHANNEL1").
+				clientsMock.APIInterface.On("ChannelsInfo", mock.Anything, mock.Anything, "CHANNEL1").
 					Return(&types.ChannelInfo{ID: "CHANNEL1", Name: "Channel One"}, nil).Once()
-				clientsMock.ApiInterface.On("ChannelsInfo", mock.Anything, mock.Anything, "CHANNEL2").
+				clientsMock.APIInterface.On("ChannelsInfo", mock.Anything, mock.Anything, "CHANNEL2").
 					Return(&types.ChannelInfo{ID: "CHANNEL2", Name: "Channel Two"}, nil).Once()
 
 				clientsMock.AddDefaultMocks()
@@ -379,31 +379,31 @@ func TestTriggersAccessCommand(t *testing.T) {
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				appSelectTeardown = setupMockAccessAppSelection(installedProdApp)
 				// get current access type
-				clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.NAMED_ENTITIES, []string{"CHANNEL1"}, nil).Once()
-				clientsMock.ApiInterface.On("TriggerPermissionsAddEntities", mock.Anything, mock.Anything, fakeTriggerID, "CHANNEL2", "channels").
+				clientsMock.APIInterface.On("TriggerPermissionsAddEntities", mock.Anything, mock.Anything, fakeTriggerID, "CHANNEL2", "channels").
 					Return(nil)
-				clientsMock.ApiInterface.On("TriggerPermissionsAddEntities", mock.Anything, mock.Anything, fakeTriggerID, "USER1,USER2", "users").
+				clientsMock.APIInterface.On("TriggerPermissionsAddEntities", mock.Anything, mock.Anything, fakeTriggerID, "USER1,USER2", "users").
 					Return(nil)
-				clientsMock.ApiInterface.On("TriggerPermissionsAddEntities", mock.Anything, mock.Anything, fakeTriggerID, "TEAM1", "workspaces").
+				clientsMock.APIInterface.On("TriggerPermissionsAddEntities", mock.Anything, mock.Anything, fakeTriggerID, "TEAM1", "workspaces").
 					Return(nil)
 				// get access type from backend to display
-				clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.NAMED_ENTITIES, []string{"USER1", "USER2", "CHANNEL1", "CHANNEL2", "TEAM1"}, nil).Once()
 				// display user info for updated access
-				clientsMock.ApiInterface.On("UsersInfo", mock.Anything, mock.Anything, "USER1").
+				clientsMock.APIInterface.On("UsersInfo", mock.Anything, mock.Anything, "USER1").
 					Return(&types.UserInfo{RealName: "User One", Name: "USER1", Profile: user1Profile}, nil).Once()
-				clientsMock.ApiInterface.On("UsersInfo", mock.Anything, mock.Anything, "USER2").
+				clientsMock.APIInterface.On("UsersInfo", mock.Anything, mock.Anything, "USER2").
 					Return(&types.UserInfo{RealName: "User Two", Name: "USER2", Profile: user2Profile}, nil).Once()
 
 				// display channel info for updated access
-				clientsMock.ApiInterface.On("ChannelsInfo", mock.Anything, mock.Anything, "CHANNEL1").
+				clientsMock.APIInterface.On("ChannelsInfo", mock.Anything, mock.Anything, "CHANNEL1").
 					Return(&types.ChannelInfo{ID: "CHANNEL1", Name: "Channel One"}, nil).Once()
-				clientsMock.ApiInterface.On("ChannelsInfo", mock.Anything, mock.Anything, "CHANNEL2").
+				clientsMock.APIInterface.On("ChannelsInfo", mock.Anything, mock.Anything, "CHANNEL2").
 					Return(&types.ChannelInfo{ID: "CHANNEL2", Name: "Channel Two"}, nil).Once()
 
 				// display workspace info for updated access
-				clientsMock.ApiInterface.On("TeamsInfo", mock.Anything, mock.Anything, "TEAM1").
+				clientsMock.APIInterface.On("TeamsInfo", mock.Anything, mock.Anything, "TEAM1").
 					Return(&types.TeamInfo{ID: "TEAM1", Name: "Team One"}, nil).Once()
 
 				clientsMock.AddDefaultMocks()
@@ -421,19 +421,19 @@ func TestTriggersAccessCommand(t *testing.T) {
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				appSelectTeardown = setupMockAccessAppSelection(installedProdApp)
 				// get current access type
-				clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.NAMED_ENTITIES, []string{"USER1", "USER2"}, nil).Once()
 				// display user info for current access
-				clientsMock.ApiInterface.On("UserInfo", mock.Anything, mock.Anything, "USER1").
+				clientsMock.APIInterface.On("UserInfo", mock.Anything, mock.Anything, "USER1").
 					Return(&types.UserInfo{}, nil).Once()
 				// remove users from named_entities ACL
-				clientsMock.ApiInterface.On("TriggerPermissionsRemoveEntities", mock.Anything, mock.Anything, fakeTriggerID, "USER2", "users").
+				clientsMock.APIInterface.On("TriggerPermissionsRemoveEntities", mock.Anything, mock.Anything, fakeTriggerID, "USER2", "users").
 					Return(nil)
 				// get access type from backend to display
-				clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.NAMED_ENTITIES, []string{"USER1"}, nil).Once()
 				// display user info for updated access
-				clientsMock.ApiInterface.On("UsersInfo", mock.Anything, mock.Anything, "USER1").
+				clientsMock.APIInterface.On("UsersInfo", mock.Anything, mock.Anything, "USER1").
 					Return(&types.UserInfo{RealName: "User One", Name: "USER1", Profile: user1Profile}, nil).Once()
 
 				clientsMock.AddDefaultMocks()
@@ -450,17 +450,17 @@ func TestTriggersAccessCommand(t *testing.T) {
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				appSelectTeardown = setupMockAccessAppSelection(installedProdApp)
 				// get current access type
-				clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.NAMED_ENTITIES, []string{"CHANNEL1", "CHANNEL2"}, nil).Once()
 				// remove channel from named_entities ACL
-				clientsMock.ApiInterface.On("TriggerPermissionsRemoveEntities", mock.Anything, mock.Anything, fakeTriggerID, "CHANNEL2", "channels").
+				clientsMock.APIInterface.On("TriggerPermissionsRemoveEntities", mock.Anything, mock.Anything, fakeTriggerID, "CHANNEL2", "channels").
 					Return(nil)
 				// get access type from backend to display
-				clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.NAMED_ENTITIES, []string{"CHANNEL1"}, nil).Once()
 
 				// display channel info for updated access
-				clientsMock.ApiInterface.On("ChannelsInfo", mock.Anything, mock.Anything, "CHANNEL1").
+				clientsMock.APIInterface.On("ChannelsInfo", mock.Anything, mock.Anything, "CHANNEL1").
 					Return(&types.ChannelInfo{ID: "CHANNEL1", Name: "Channel One"}, nil).Once()
 
 				clientsMock.AddDefaultMocks()
@@ -478,17 +478,17 @@ func TestTriggersAccessCommand(t *testing.T) {
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				appSelectTeardown = setupMockAccessAppSelection(installedProdApp)
 				// get current access type
-				clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.NAMED_ENTITIES, []string{"TEAM1", "TEAM2"}, nil).Once()
 				// remove workspace from named_entities ACL
-				clientsMock.ApiInterface.On("TriggerPermissionsRemoveEntities", mock.Anything, mock.Anything, fakeTriggerID, "TEAM2", "workspaces").
+				clientsMock.APIInterface.On("TriggerPermissionsRemoveEntities", mock.Anything, mock.Anything, fakeTriggerID, "TEAM2", "workspaces").
 					Return(nil)
 				// get access type from backend to display
-				clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.NAMED_ENTITIES, []string{"TEAM1"}, nil).Once()
 
 				// display team info for updated access
-				clientsMock.ApiInterface.On("TeamsInfo", mock.Anything, mock.Anything, "TEAM1").
+				clientsMock.APIInterface.On("TeamsInfo", mock.Anything, mock.Anything, "TEAM1").
 					Return(&types.TeamInfo{ID: "TEAM1", Name: "Team One"}, nil).Once()
 
 				clientsMock.AddDefaultMocks()
@@ -506,22 +506,22 @@ func TestTriggersAccessCommand(t *testing.T) {
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				appSelectTeardown = setupMockAccessAppSelection(installedProdApp)
 				// get current access type
-				clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.NAMED_ENTITIES, []string{"USER1", "USER2", "CHANNEL1", "CHANNEL2"}, nil).Once()
 				// remove user from named_entities ACL
-				clientsMock.ApiInterface.On("TriggerPermissionsRemoveEntities", mock.Anything, mock.Anything, fakeTriggerID, "USER2", "users").
+				clientsMock.APIInterface.On("TriggerPermissionsRemoveEntities", mock.Anything, mock.Anything, fakeTriggerID, "USER2", "users").
 					Return(nil)
 				// remove channel from named_entities ACL
-				clientsMock.ApiInterface.On("TriggerPermissionsRemoveEntities", mock.Anything, mock.Anything, fakeTriggerID, "CHANNEL2", "channels").
+				clientsMock.APIInterface.On("TriggerPermissionsRemoveEntities", mock.Anything, mock.Anything, fakeTriggerID, "CHANNEL2", "channels").
 					Return(nil)
 				// get access type from backend to display
-				clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.NAMED_ENTITIES, []string{"USER1", "CHANNEL1"}, nil).Once()
-				clientsMock.ApiInterface.On("UsersInfo", mock.Anything, mock.Anything, "USER1").
+				clientsMock.APIInterface.On("UsersInfo", mock.Anything, mock.Anything, "USER1").
 					Return(&types.UserInfo{RealName: "User One", Name: "USER1", Profile: user1Profile}, nil).Once()
 				clientsMock.AddDefaultMocks()
 				// display channel info for updated access
-				clientsMock.ApiInterface.On("ChannelsInfo", mock.Anything, mock.Anything, "CHANNEL1").
+				clientsMock.APIInterface.On("ChannelsInfo", mock.Anything, mock.Anything, "CHANNEL1").
 					Return(&types.ChannelInfo{ID: "CHANNEL1", Name: "Channel One"}, nil).Once()
 				err := clients.AppClient().SaveDeployed(ctx, fakeApp)
 				require.NoError(t, err, "Cant write apps.json")
@@ -537,16 +537,16 @@ func TestTriggersAccessCommand(t *testing.T) {
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				appSelectTeardown = setupMockAccessAppSelection(installedProdApp)
 				// trigger ID prompt lists available triggers, including current access
-				clientsMock.ApiInterface.On("WorkflowsTriggersList", mock.Anything, mock.Anything, mock.Anything).Return(
+				clientsMock.APIInterface.On("WorkflowsTriggersList", mock.Anything, mock.Anything, mock.Anything).Return(
 					[]types.DeployedTrigger{{Name: "Trigger 1", ID: fakeTriggerID, Type: "Shortcut", Workflow: types.TriggerWorkflow{AppID: fakeAppID}}}, "", nil)
-				clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.EVERYONE, []string{}, nil).Once()
 				// set and display access
-				clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.EVERYONE, []string{}, nil).Once()
-				clientsMock.ApiInterface.On("TriggerPermissionsSet", mock.Anything, mock.Anything, mock.Anything, mock.Anything, types.EVERYONE, "").
+				clientsMock.APIInterface.On("TriggerPermissionsSet", mock.Anything, mock.Anything, mock.Anything, mock.Anything, types.EVERYONE, "").
 					Return([]string{}, nil)
-				clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.EVERYONE, []string{}, nil).Once()
 
 				clientsMock.IO.On("SelectPrompt", mock.Anything, "Choose a trigger:", mock.Anything, iostreams.MatchPromptConfig(iostreams.SelectPromptConfig{

--- a/cmd/triggers/create.go
+++ b/cmd/triggers/create.go
@@ -135,7 +135,7 @@ func runCreateCommand(clients *shared.ClientFactory, cmd *cobra.Command) error {
 	// def file for dev and prod.
 	triggerArg.WorkflowAppID = app.AppID
 
-	createdTrigger, err := clients.ApiInterface().WorkflowsTriggersCreate(ctx, token, triggerArg)
+	createdTrigger, err := clients.APIInterface().WorkflowsTriggersCreate(ctx, token, triggerArg)
 	if extendedErr, ok := err.(*api.TriggerCreateOrUpdateError); ok {
 		// If the user used --workflow and the creation failed because we were missing the interactivity
 		// context, lets prompt and optionally add it
@@ -149,7 +149,7 @@ func runCreateCommand(clients *shared.ClientFactory, cmd *cobra.Command) error {
 				return err
 			}
 			if retryTriggerCreate {
-				createdTrigger, err = clients.ApiInterface().WorkflowsTriggersCreate(ctx, token, triggerArg)
+				createdTrigger, err = clients.APIInterface().WorkflowsTriggersCreate(ctx, token, triggerArg)
 			}
 		}
 	}
@@ -191,7 +191,7 @@ func runCreateCommand(clients *shared.ClientFactory, cmd *cobra.Command) error {
 
 	clients.IO.PrintTrace(ctx, slacktrace.TriggersCreateSuccess)
 	if createdTrigger.Type == "shortcut" {
-		clients.IO.PrintTrace(ctx, slacktrace.TriggersCreateURL, createdTrigger.ShortcutUrl)
+		clients.IO.PrintTrace(ctx, slacktrace.TriggersCreateURL, createdTrigger.ShortcutURL)
 	}
 	if createdTrigger.Type == "webhook" {
 		clients.IO.PrintTrace(ctx, slacktrace.TriggersCreateURL, createdTrigger.Webhook)
@@ -215,7 +215,7 @@ func promptShouldInstallAndRetry(ctx context.Context, clients *shared.ClientFact
 			return types.DeployedTrigger{}, false, nil
 		}
 
-		trigger, err := clients.ApiInterface().WorkflowsTriggersCreate(ctx, token, triggerArg)
+		trigger, err := clients.APIInterface().WorkflowsTriggersCreate(ctx, token, triggerArg)
 		if err != nil {
 			return types.DeployedTrigger{}, false, err
 		}
@@ -240,8 +240,8 @@ func ListWorkflows(
 
 	if len(slackYaml.Workflows) > 0 {
 		workflows := ""
-		for cb_id := range slackYaml.Workflows {
-			workflows = workflows + fmt.Sprintf("- #/workflows/%s\n", cb_id)
+		for callbackID := range slackYaml.Workflows {
+			workflows = workflows + fmt.Sprintf("- #/workflows/%s\n", callbackID)
 		}
 		clients.IO.PrintInfo(ctx, false, style.Sectionf(style.TextSection{
 			Emoji: "bulb",

--- a/cmd/triggers/create.go
+++ b/cmd/triggers/create.go
@@ -133,7 +133,7 @@ func runCreateCommand(clients *shared.ClientFactory, cmd *cobra.Command) error {
 
 	// Fix the app ID selected from the menu. In the --trigger-def case, this lets you use the same
 	// def file for dev and prod.
-	triggerArg.WorkflowAppId = app.AppID
+	triggerArg.WorkflowAppID = app.AppID
 
 	createdTrigger, err := clients.ApiInterface().WorkflowsTriggersCreate(ctx, token, triggerArg)
 	if extendedErr, ok := err.(*api.TriggerCreateOrUpdateError); ok {

--- a/cmd/triggers/create.go
+++ b/cmd/triggers/create.go
@@ -109,7 +109,7 @@ func runCreateCommand(clients *shared.ClientFactory, cmd *cobra.Command) error {
 		if err != nil {
 			return err
 		}
-		if installState == types.REQUEST_PENDING || installState == types.REQUEST_CANCELLED || installState == types.REQUEST_NOT_SENT {
+		if installState == types.InstallRequestPending || installState == types.InstallRequestCancelled || installState == types.InstallRequestNotSent {
 			return nil
 		}
 		ctx = _ctx
@@ -211,7 +211,7 @@ func promptShouldInstallAndRetry(ctx context.Context, clients *shared.ClientFact
 		if err != nil {
 			return types.DeployedTrigger{}, false, slackerror.Wrap(err, slackerror.ErrInstallationFailed)
 		}
-		if installState == types.REQUEST_PENDING || installState == types.REQUEST_CANCELLED || installState == types.REQUEST_NOT_SENT {
+		if installState == types.InstallRequestPending || installState == types.InstallRequestCancelled || installState == types.InstallRequestNotSent {
 			return types.DeployedTrigger{}, false, nil
 		}
 

--- a/cmd/triggers/create_test.go
+++ b/cmd/triggers/create_test.go
@@ -65,7 +65,7 @@ func TestTriggersCreateCommand(t *testing.T) {
 				clientsMock.APIInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).Return(fakeTrigger, nil)
 				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
 				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
-					Return(types.EVERYONE, []string{}, nil).Once()
+					Return(types.PermissionEveryone, []string{}, nil).Once()
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
 				// TODO this can probably be replaced by a helper that sets up an apps.json file in
@@ -98,7 +98,7 @@ func TestTriggersCreateCommand(t *testing.T) {
 				clientsMock.APIInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).Return(fakeTrigger, nil)
 				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
 				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
-					Return(types.EVERYONE, []string{}, nil).Once()
+					Return(types.PermissionEveryone, []string{}, nil).Once()
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
 				err := clients.AppClient().SaveDeployed(ctx, fakeApp)
@@ -129,7 +129,7 @@ func TestTriggersCreateCommand(t *testing.T) {
 				clientsMock.APIInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).Return(fakeTrigger, nil)
 				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
 				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
-					Return(types.EVERYONE, []string{}, nil).Once()
+					Return(types.PermissionEveryone, []string{}, nil).Once()
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
 				err := clients.AppClient().SaveDeployed(ctx, fakeApp)
@@ -165,7 +165,7 @@ func TestTriggersCreateCommand(t *testing.T) {
 				clientsMock.APIInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).Return(fakeTrigger, nil)
 				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
 				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
-					Return(types.EVERYONE, []string{}, nil).Once()
+					Return(types.PermissionEveryone, []string{}, nil).Once()
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
 				err := clients.AppClient().SaveDeployed(ctx, fakeApp)
@@ -218,7 +218,7 @@ func TestTriggersCreateCommand(t *testing.T) {
 				// no collaborators on app
 				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
 				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
-					Return(types.EVERYONE, []string{}, nil).Once()
+					Return(types.PermissionEveryone, []string{}, nil).Once()
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
 				err := clients.AppClient().SaveDeployed(ctx, fakeApp)
@@ -272,7 +272,7 @@ func TestTriggersCreateCommand(t *testing.T) {
 				clientsMock.APIInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).Return(types.DeployedTrigger{}, nil)
 				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{{}}, nil)
 				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
-					Return(types.EVERYONE, []string{}, nil).Once()
+					Return(types.PermissionEveryone, []string{}, nil).Once()
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
 				clientsMock.HookExecutor.On("Execute", mock.Anything, mock.Anything).Return(`{}`, nil)
@@ -370,7 +370,7 @@ func TestTriggersCreateCommand_MissingParameters(t *testing.T) {
 				clientsMock.APIInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, triggerRequestWithInteractivityInputs).Return(fakeTrigger, nil)
 				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
 				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
-					Return(types.EVERYONE, []string{}, nil).Once()
+					Return(types.PermissionEveryone, []string{}, nil).Once()
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
 				err := clients.AppClient().SaveDeployed(ctx, fakeApp)
@@ -490,7 +490,7 @@ func TestTriggersCreateCommand_AppSelection(t *testing.T) {
 					workspaceInstallAppFunc = originalWorkspaceInstallAppFunc
 				}
 				appCommandMock.On("RunAddCommand", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-					Return(ctx, types.SUCCESS, newDevApp.App, nil)
+					Return(ctx, types.InstallSuccess, newDevApp.App, nil)
 				clientsMock.APIInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.DeployedTrigger{}, nil)
 				// Define default mocks
@@ -518,7 +518,7 @@ func TestTriggersCreateCommand_AppSelection(t *testing.T) {
 					workspaceInstallAppFunc = originalWorkspaceInstallAppFunc
 				}
 				appCommandMock.On("RunAddCommand", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-					Return(ctx, types.SUCCESS, newDevApp.App, nil)
+					Return(ctx, types.InstallSuccess, newDevApp.App, nil)
 				clientsMock.APIInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.DeployedTrigger{}, nil)
 				// Define default mocks
@@ -553,7 +553,7 @@ func TestTriggersCreateCommand_promptShouldInstallAndRetry(t *testing.T) {
 		{
 			name: "Accept prompt to reinstall and create the trigger successfully",
 			prepareMocks: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, appCmdMock *app.AppMock) {
-				appCmdMock.On("RunAddCommand", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(ctx, types.SUCCESS, types.App{}, nil)
+				appCmdMock.On("RunAddCommand", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(ctx, types.InstallSuccess, types.App{}, nil)
 				clientsMock.APIInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.DeployedTrigger{Name: "trigger name", ID: "Ft123", Type: "shortcut"}, nil)
 				clientsMock.IO.On("ConfirmPrompt", mock.Anything, "Re-install app to apply local file changes and try again?", mock.Anything).Return(true, nil)
@@ -577,7 +577,7 @@ func TestTriggersCreateCommand_promptShouldInstallAndRetry(t *testing.T) {
 		{
 			name: "Accept prompt to reinstall but fail to create the trigger",
 			prepareMocks: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, appCmdMock *app.AppMock) {
-				appCmdMock.On("RunAddCommand", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(ctx, types.SUCCESS, types.App{}, nil)
+				appCmdMock.On("RunAddCommand", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(ctx, types.InstallSuccess, types.App{}, nil)
 				clientsMock.APIInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.DeployedTrigger{}, errors.New("something_else_went_wrong"))
 				clientsMock.Os.On("UserHomeDir").Return("", nil) // Called by clients.IO.PrintError

--- a/cmd/triggers/create_test.go
+++ b/cmd/triggers/create_test.go
@@ -83,7 +83,7 @@ func TestTriggersCreateCommand(t *testing.T) {
 					Name:          fakeTriggerName,
 					Description:   "Runs the '#/workflows/my_workflow' workflow",
 					Workflow:      "#/workflows/my_workflow",
-					WorkflowAppId: fakeAppID,
+					WorkflowAppID: fakeAppID,
 				}
 				clientsMock.ApiInterface.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, expectedTriggerRequest)
 			},
@@ -114,7 +114,7 @@ func TestTriggersCreateCommand(t *testing.T) {
 					Description:   "are the best",
 					Shortcut:      &api.Shortcut{},
 					Workflow:      "#/workflows/my_workflow",
-					WorkflowAppId: fakeAppID,
+					WorkflowAppID: fakeAppID,
 				}
 				clientsMock.ApiInterface.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, expectedTriggerRequest)
 			},
@@ -145,7 +145,7 @@ func TestTriggersCreateCommand(t *testing.T) {
 					Description:   "are the best",
 					Shortcut:      &api.Shortcut{},
 					Workflow:      "#/workflows/my_workflow",
-					WorkflowAppId: fakeAppID,
+					WorkflowAppID: fakeAppID,
 					Inputs: api.Inputs{
 						"interactivity": &api.Input{
 							Value: "{{data.interactivity}}",
@@ -181,7 +181,7 @@ func TestTriggersCreateCommand(t *testing.T) {
 					Description:   "are the best",
 					Shortcut:      &api.Shortcut{},
 					Workflow:      "#/workflows/my_workflow",
-					WorkflowAppId: fakeAppID,
+					WorkflowAppID: fakeAppID,
 					Inputs: api.Inputs{
 						"custom-interactivity": &api.Input{
 							Value: "{{data.interactivity}}",
@@ -243,7 +243,7 @@ func TestTriggersCreateCommand(t *testing.T) {
 					Name:          "name",
 					Description:   "desc",
 					Workflow:      "#/workflows/my_workflow",
-					WorkflowAppId: fakeAppID,
+					WorkflowAppID: fakeAppID,
 					Schedule:      types.ToRawJson(`{"start_time":"2020-03-15","frequency":{"type":"daily"}}`),
 				}
 				clientsMock.ApiInterface.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, expectedTriggerRequest)
@@ -332,7 +332,7 @@ func TestTriggersCreateCommand_MissingParameters(t *testing.T) {
 		Name:          fakeTriggerName,
 		Description:   "Runs the '#/workflows/my_workflow' workflow",
 		Workflow:      "#/workflows/my_workflow",
-		WorkflowAppId: fakeAppID,
+		WorkflowAppID: fakeAppID,
 	}
 
 	triggerRequestWithInteractivityInputs := api.TriggerRequest{
@@ -341,7 +341,7 @@ func TestTriggersCreateCommand_MissingParameters(t *testing.T) {
 		Name:          fakeTriggerName,
 		Description:   "Runs the '#/workflows/my_workflow' workflow",
 		Workflow:      "#/workflows/my_workflow",
-		WorkflowAppId: fakeAppID,
+		WorkflowAppID: fakeAppID,
 		Inputs: api.Inputs{
 			"my-interactivity": &api.Input{
 				Value: "{{data.interactivity}}",

--- a/cmd/triggers/create_test.go
+++ b/cmd/triggers/create_test.go
@@ -62,9 +62,9 @@ func TestTriggersCreateCommand(t *testing.T) {
 				appSelectTeardown = setupMockCreateAppSelection(installedProdApp)
 				// TODO: always a) mock out calls and b) call AddDefaultMocks before making any clients.* calls
 				fakeTrigger := createFakeTrigger(fakeTriggerID, fakeTriggerName, fakeAppID, "shortcut")
-				clientsMock.ApiInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).Return(fakeTrigger, nil)
-				clientsMock.ApiInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-				clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).Return(fakeTrigger, nil)
+				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.EVERYONE, []string{}, nil).Once()
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
@@ -85,7 +85,7 @@ func TestTriggersCreateCommand(t *testing.T) {
 					Workflow:      "#/workflows/my_workflow",
 					WorkflowAppID: fakeAppID,
 				}
-				clientsMock.ApiInterface.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, expectedTriggerRequest)
+				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, expectedTriggerRequest)
 			},
 		},
 		"pass all shortcut parameters": {
@@ -95,9 +95,9 @@ func TestTriggersCreateCommand(t *testing.T) {
 				appSelectTeardown = setupMockCreateAppSelection(installedProdApp)
 				// TODO: always a) mock out calls and b) call AddDefaultMocks before making any clients.* calls
 				fakeTrigger := createFakeTrigger(fakeTriggerID, "unit tests", fakeAppID, "shortcut")
-				clientsMock.ApiInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).Return(fakeTrigger, nil)
-				clientsMock.ApiInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-				clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).Return(fakeTrigger, nil)
+				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.EVERYONE, []string{}, nil).Once()
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
@@ -116,7 +116,7 @@ func TestTriggersCreateCommand(t *testing.T) {
 					Workflow:      "#/workflows/my_workflow",
 					WorkflowAppID: fakeAppID,
 				}
-				clientsMock.ApiInterface.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, expectedTriggerRequest)
+				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, expectedTriggerRequest)
 			},
 		},
 		"pass --interactivity, default name": {
@@ -126,9 +126,9 @@ func TestTriggersCreateCommand(t *testing.T) {
 				appSelectTeardown = setupMockCreateAppSelection(installedProdApp)
 				// TODO: always a) mock out calls and b) call AddDefaultMocks before making any clients.* calls
 				fakeTrigger := createFakeTrigger(fakeTriggerID, "unit tests", fakeAppID, "shortcut")
-				clientsMock.ApiInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).Return(fakeTrigger, nil)
-				clientsMock.ApiInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-				clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).Return(fakeTrigger, nil)
+				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.EVERYONE, []string{}, nil).Once()
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
@@ -152,7 +152,7 @@ func TestTriggersCreateCommand(t *testing.T) {
 						},
 					},
 				}
-				clientsMock.ApiInterface.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, expectedTriggerRequest)
+				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, expectedTriggerRequest)
 			},
 		},
 		"pass --interactivity, custom name": {
@@ -162,9 +162,9 @@ func TestTriggersCreateCommand(t *testing.T) {
 				appSelectTeardown = setupMockCreateAppSelection(installedProdApp)
 				// TODO: always a) mock out calls and b) call AddDefaultMocks before making any clients.* calls
 				fakeTrigger := createFakeTrigger(fakeTriggerID, "unit tests", fakeAppID, "shortcut")
-				clientsMock.ApiInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).Return(fakeTrigger, nil)
-				clientsMock.ApiInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-				clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).Return(fakeTrigger, nil)
+				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.EVERYONE, []string{}, nil).Once()
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
@@ -188,7 +188,7 @@ func TestTriggersCreateCommand(t *testing.T) {
 						},
 					},
 				}
-				clientsMock.ApiInterface.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, expectedTriggerRequest)
+				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, expectedTriggerRequest)
 			},
 		},
 		"api call fails": {
@@ -197,7 +197,7 @@ func TestTriggersCreateCommand(t *testing.T) {
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				appSelectTeardown = setupMockCreateAppSelection(installedProdApp)
 				// TODO: always a) mock out calls and b) call AddDefaultMocks before making any clients.* calls
-				clientsMock.ApiInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).Return(types.DeployedTrigger{}, errors.New("invalid_auth"))
+				clientsMock.APIInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).Return(types.DeployedTrigger{}, errors.New("invalid_auth"))
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
 				err := clients.AppClient().SaveDeployed(ctx, fakeApp)
@@ -214,10 +214,10 @@ func TestTriggersCreateCommand(t *testing.T) {
 				appSelectTeardown = setupMockCreateAppSelection(installedProdApp)
 				// TODO: always a) mock out calls and b) call AddDefaultMocks before making any clients.* calls
 				fakeTrigger := createFakeTrigger(fakeTriggerID, "name", fakeAppID, "scheduled")
-				clientsMock.ApiInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).Return(fakeTrigger, nil)
+				clientsMock.APIInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).Return(fakeTrigger, nil)
 				// no collaborators on app
-				clientsMock.ApiInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-				clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.EVERYONE, []string{}, nil).Once()
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
@@ -244,9 +244,9 @@ func TestTriggersCreateCommand(t *testing.T) {
 					Description:   "desc",
 					Workflow:      "#/workflows/my_workflow",
 					WorkflowAppID: fakeAppID,
-					Schedule:      types.ToRawJson(`{"start_time":"2020-03-15","frequency":{"type":"daily"}}`),
+					Schedule:      types.ToRawJSON(`{"start_time":"2020-03-15","frequency":{"type":"daily"}}`),
 				}
-				clientsMock.ApiInterface.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, expectedTriggerRequest)
+				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, expectedTriggerRequest)
 			},
 		},
 		"--trigger-def, file missing": {
@@ -269,9 +269,9 @@ func TestTriggersCreateCommand(t *testing.T) {
 			ExpectedOutputs: []string{},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				appSelectTeardown = setupMockCreateAppSelection(installedProdApp)
-				clientsMock.ApiInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).Return(types.DeployedTrigger{}, nil)
-				clientsMock.ApiInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{{}}, nil)
-				clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).Return(types.DeployedTrigger{}, nil)
+				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{{}}, nil)
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.EVERYONE, []string{}, nil).Once()
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
@@ -288,7 +288,7 @@ func TestTriggersCreateCommand(t *testing.T) {
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
 				clientsMock.HookExecutor.AssertCalled(t, "Execute", mock.Anything, mock.Anything)
-				clientsMock.ApiInterface.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything)
+				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything)
 			},
 		},
 		"--trigger-def, not json, `get-trigger` hook missing": {
@@ -309,7 +309,7 @@ func TestTriggersCreateCommand(t *testing.T) {
 				appSelectTeardown()
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.ApiInterface.AssertNotCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything)
+				clientsMock.APIInterface.AssertNotCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything)
 			},
 		},
 	}, func(clients *shared.ClientFactory) *cobra.Command {
@@ -364,12 +364,12 @@ func TestTriggersCreateCommand_MissingParameters(t *testing.T) {
 						Type: "slack#/types/interactivity",
 					},
 				}
-				clientsMock.ApiInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, triggerRequestMissingInputs).Return(types.DeployedTrigger{}, extendedErr)
+				clientsMock.APIInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, triggerRequestMissingInputs).Return(types.DeployedTrigger{}, extendedErr)
 
 				fakeTrigger := createFakeTrigger(fakeTriggerID, "unit tests", fakeAppID, "shortcut")
-				clientsMock.ApiInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, triggerRequestWithInteractivityInputs).Return(fakeTrigger, nil)
-				clientsMock.ApiInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-				clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, triggerRequestWithInteractivityInputs).Return(fakeTrigger, nil)
+				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.EVERYONE, []string{}, nil).Once()
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
@@ -377,8 +377,8 @@ func TestTriggersCreateCommand_MissingParameters(t *testing.T) {
 				require.NoError(t, err, "Cant write apps.json")
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.ApiInterface.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, triggerRequestMissingInputs)
-				clientsMock.ApiInterface.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, triggerRequestWithInteractivityInputs)
+				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, triggerRequestMissingInputs)
+				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, triggerRequestWithInteractivityInputs)
 			},
 			Teardown: func() {
 				appSelectTeardown()
@@ -399,17 +399,17 @@ func TestTriggersCreateCommand_MissingParameters(t *testing.T) {
 						Type: "slack#/types/interactivity",
 					},
 				}
-				clientsMock.ApiInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, triggerRequestMissingInputs).Return(types.DeployedTrigger{}, extendedErr).Once()
+				clientsMock.APIInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, triggerRequestMissingInputs).Return(types.DeployedTrigger{}, extendedErr).Once()
 
-				clientsMock.ApiInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, triggerRequestWithInteractivityInputs).Return(types.DeployedTrigger{}, errors.New("internal_error")).Once()
+				clientsMock.APIInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, triggerRequestWithInteractivityInputs).Return(types.DeployedTrigger{}, errors.New("internal_error")).Once()
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
 				err := clients.AppClient().SaveDeployed(ctx, fakeApp)
 				require.NoError(t, err, "Cant write apps.json")
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.ApiInterface.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, triggerRequestMissingInputs)
-				clientsMock.ApiInterface.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, triggerRequestWithInteractivityInputs)
+				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, triggerRequestMissingInputs)
+				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, triggerRequestWithInteractivityInputs)
 			},
 			Teardown: func() {
 				appSelectTeardown()
@@ -430,14 +430,14 @@ func TestTriggersCreateCommand_MissingParameters(t *testing.T) {
 						Type: "number",
 					},
 				}
-				clientsMock.ApiInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).Return(types.DeployedTrigger{}, extendedErr)
+				clientsMock.APIInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).Return(types.DeployedTrigger{}, extendedErr)
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
 				err := clients.AppClient().SaveDeployed(ctx, fakeApp)
 				require.NoError(t, err, "Cant write apps.json")
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.ApiInterface.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything)
+				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything)
 			},
 			Teardown: func() {
 				appSelectTeardown()
@@ -491,7 +491,7 @@ func TestTriggersCreateCommand_AppSelection(t *testing.T) {
 				}
 				appCommandMock.On("RunAddCommand", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(ctx, types.SUCCESS, newDevApp.App, nil)
-				clientsMock.ApiInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.DeployedTrigger{}, nil)
 				// Define default mocks
 				clientsMock.AddDefaultMocks()
@@ -502,7 +502,7 @@ func TestTriggersCreateCommand_AppSelection(t *testing.T) {
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
 				appCommandMock.AssertCalled(t, "RunAddCommand", mock.Anything, mock.Anything, &newDevApp, mock.Anything)
-				clientsMock.ApiInterface.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything)
+				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything)
 			},
 		},
 		"select a non-installed prod app": {
@@ -519,7 +519,7 @@ func TestTriggersCreateCommand_AppSelection(t *testing.T) {
 				}
 				appCommandMock.On("RunAddCommand", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(ctx, types.SUCCESS, newDevApp.App, nil)
-				clientsMock.ApiInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.DeployedTrigger{}, nil)
 				// Define default mocks
 				clientsMock.AddDefaultMocks()
@@ -530,7 +530,7 @@ func TestTriggersCreateCommand_AppSelection(t *testing.T) {
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
 				appCommandMock.AssertCalled(t, "RunAddCommand", mock.Anything, mock.Anything, &newProdApp, mock.Anything)
-				clientsMock.ApiInterface.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything)
+				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything)
 			},
 		},
 	}, func(clients *shared.ClientFactory) *cobra.Command {
@@ -554,7 +554,7 @@ func TestTriggersCreateCommand_promptShouldInstallAndRetry(t *testing.T) {
 			name: "Accept prompt to reinstall and create the trigger successfully",
 			prepareMocks: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, appCmdMock *app.AppMock) {
 				appCmdMock.On("RunAddCommand", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(ctx, types.SUCCESS, types.App{}, nil)
-				clientsMock.ApiInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.DeployedTrigger{Name: "trigger name", ID: "Ft123", Type: "shortcut"}, nil)
 				clientsMock.IO.On("ConfirmPrompt", mock.Anything, "Re-install app to apply local file changes and try again?", mock.Anything).Return(true, nil)
 			},
@@ -578,7 +578,7 @@ func TestTriggersCreateCommand_promptShouldInstallAndRetry(t *testing.T) {
 			name: "Accept prompt to reinstall but fail to create the trigger",
 			prepareMocks: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, appCmdMock *app.AppMock) {
 				appCmdMock.On("RunAddCommand", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(ctx, types.SUCCESS, types.App{}, nil)
-				clientsMock.ApiInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.DeployedTrigger{}, errors.New("something_else_went_wrong"))
 				clientsMock.Os.On("UserHomeDir").Return("", nil) // Called by clients.IO.PrintError
 				clientsMock.IO.On("ConfirmPrompt", mock.Anything, "Re-install app to apply local file changes and try again?", mock.Anything).Return(true, nil)

--- a/cmd/triggers/delete.go
+++ b/cmd/triggers/delete.go
@@ -28,7 +28,7 @@ import (
 )
 
 type deleteCmdFlags struct {
-	triggerId string
+	triggerID string
 }
 
 var deleteFlags deleteCmdFlags
@@ -55,7 +55,7 @@ func NewDeleteCommand(clients *shared.ClientFactory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&deleteFlags.triggerId, "trigger-id", "", "the ID of the trigger")
+	cmd.Flags().StringVar(&deleteFlags.triggerID, "trigger-id", "", "the ID of the trigger")
 
 	return &cmd
 }
@@ -79,8 +79,8 @@ func runDeleteCommand(clients *shared.ClientFactory, cmd *cobra.Command) error {
 		return err
 	}
 
-	if deleteFlags.triggerId == "" {
-		deleteFlags.triggerId, err = promptForTriggerID(ctx, cmd, clients, app, token, defaultLabels)
+	if deleteFlags.triggerID == "" {
+		deleteFlags.triggerID, err = promptForTriggerID(ctx, cmd, clients, app, token, defaultLabels)
 		if err != nil {
 			if slackerror.ToSlackError(err).Code == slackerror.ErrNoTriggers {
 				printNoTriggersMessage(ctx, clients.IO)
@@ -90,14 +90,14 @@ func runDeleteCommand(clients *shared.ClientFactory, cmd *cobra.Command) error {
 		}
 	}
 
-	err = clients.ApiInterface().WorkflowsTriggersDelete(ctx, token, deleteFlags.triggerId)
+	err = clients.APIInterface().WorkflowsTriggersDelete(ctx, token, deleteFlags.triggerID)
 	if err != nil {
 		return err
 	}
 
 	clients.IO.PrintInfo(ctx, false, "\n%s", style.Sectionf(style.TextSection{
 		Emoji: "wastebasket",
-		Text:  fmt.Sprintf("Trigger '%s' deleted", deleteFlags.triggerId),
+		Text:  fmt.Sprintf("Trigger '%s' deleted", deleteFlags.triggerID),
 	}))
 	return nil
 }

--- a/cmd/triggers/delete_test.go
+++ b/cmd/triggers/delete_test.go
@@ -41,10 +41,10 @@ func TestTriggersDeleteCommand(t *testing.T) {
 				appSelectTeardown = setupMockDeleteAppSelection(installedProdApp)
 				clientsMock.AddDefaultMocks()
 				// promptForTriggerID lists available triggers
-				clientsMock.ApiInterface.On("WorkflowsTriggersList", mock.Anything, mock.Anything, mock.Anything).Return(
+				clientsMock.APIInterface.On("WorkflowsTriggersList", mock.Anything, mock.Anything, mock.Anything).Return(
 					[]types.DeployedTrigger{{Name: "Trigger 1", ID: fakeTriggerID, Type: "Shortcut", Workflow: types.TriggerWorkflow{AppID: fakeAppID}}}, "", nil)
 				clientsMock.IO.On("SelectPrompt", mock.Anything, "Choose a trigger:", mock.Anything, mock.Anything).Return(iostreams.SelectPromptResponse{}, nil)
-				clientsMock.ApiInterface.On("WorkflowsTriggersDelete", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				clientsMock.APIInterface.On("WorkflowsTriggersDelete", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			},
 			Teardown: func() {
 				appSelectTeardown()
@@ -66,7 +66,7 @@ func TestTriggersDeleteCommand(t *testing.T) {
 			ExpectedOutputs: []string{"Trigger '" + fakeTriggerID + "' deleted"},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				appSelectTeardown = setupMockDeleteAppSelection(installedProdApp)
-				clientsMock.ApiInterface.On("WorkflowsTriggersDelete", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				clientsMock.APIInterface.On("WorkflowsTriggersDelete", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
 				// TODO this can probably be replaced by a helper that sets up an apps.json file in
@@ -78,7 +78,7 @@ func TestTriggersDeleteCommand(t *testing.T) {
 				appSelectTeardown()
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.ApiInterface.AssertCalled(t, "WorkflowsTriggersDelete", mock.Anything, mock.Anything, fakeTriggerID)
+				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersDelete", mock.Anything, mock.Anything, fakeTriggerID)
 			},
 		},
 		"pass --trigger-id, failure": {
@@ -86,7 +86,7 @@ func TestTriggersDeleteCommand(t *testing.T) {
 			ExpectedErrorStrings: []string{"invalid_auth"},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				appSelectTeardown = setupMockDeleteAppSelection(installedProdApp)
-				clientsMock.ApiInterface.On("WorkflowsTriggersDelete", mock.Anything, mock.Anything, mock.Anything).Return(errors.New("invalid_auth"))
+				clientsMock.APIInterface.On("WorkflowsTriggersDelete", mock.Anything, mock.Anything, mock.Anything).Return(errors.New("invalid_auth"))
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
 				err := clients.AppClient().SaveDeployed(ctx, fakeApp)
@@ -96,7 +96,7 @@ func TestTriggersDeleteCommand(t *testing.T) {
 				appSelectTeardown()
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.ApiInterface.AssertCalled(t, "WorkflowsTriggersDelete", mock.Anything, mock.Anything, fakeTriggerID)
+				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersDelete", mock.Anything, mock.Anything, fakeTriggerID)
 			},
 		},
 	}, func(clients *shared.ClientFactory) *cobra.Command {

--- a/cmd/triggers/generate.go
+++ b/cmd/triggers/generate.go
@@ -54,7 +54,7 @@ func TriggerGenerate(ctx context.Context, clients *shared.ClientFactory, app typ
 		AppID: app.AppID,
 		Limit: 4, // Limit to improve performance for apps with many triggers
 	}
-	existingTriggers, _, err := clients.ApiInterface().WorkflowsTriggersList(ctx, token, args)
+	existingTriggers, _, err := clients.APIInterface().WorkflowsTriggersList(ctx, token, args)
 	if err != nil {
 		return nil, err
 	}
@@ -115,7 +115,7 @@ func TriggerGenerate(ctx context.Context, clients *shared.ClientFactory, app typ
 	// def file for dev and prod.
 	triggerArg.WorkflowAppID = app.AppID
 
-	createdTrigger, err := clients.ApiInterface().WorkflowsTriggersCreate(ctx, token, triggerArg)
+	createdTrigger, err := clients.APIInterface().WorkflowsTriggersCreate(ctx, token, triggerArg)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/triggers/generate.go
+++ b/cmd/triggers/generate.go
@@ -51,7 +51,7 @@ func TriggerGenerate(ctx context.Context, clients *shared.ClientFactory, app typ
 	// FIXME: Stop relying on context getters and setters
 	token := config.GetContextToken(ctx)
 	args := api.TriggerListRequest{
-		AppId: app.AppID,
+		AppID: app.AppID,
 		Limit: 4, // Limit to improve performance for apps with many triggers
 	}
 	existingTriggers, _, err := clients.ApiInterface().WorkflowsTriggersList(ctx, token, args)
@@ -113,7 +113,7 @@ func TriggerGenerate(ctx context.Context, clients *shared.ClientFactory, app typ
 
 	// Fix the app ID selected from the menu. In the --trigger-def case, this lets you use the same
 	// def file for dev and prod.
-	triggerArg.WorkflowAppId = app.AppID
+	triggerArg.WorkflowAppID = app.AppID
 
 	createdTrigger, err := clients.ApiInterface().WorkflowsTriggersCreate(ctx, token, triggerArg)
 	if err != nil {

--- a/cmd/triggers/generate_test.go
+++ b/cmd/triggers/generate_test.go
@@ -66,7 +66,7 @@ func Test_TriggerGenerate_accept_prompt(t *testing.T) {
 		}, nil)
 		clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
 		clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
-			Return(types.EVERYONE, []string{}, nil).Once()
+			Return(types.PermissionEveryone, []string{}, nil).Once()
 
 		clients := shared.NewClientFactory(clientsMock.MockClientFactory(), func(clients *shared.ClientFactory) {
 			clients.SDKConfig = hooks.NewSDKConfigMock()
@@ -131,7 +131,7 @@ func Test_TriggerGenerate_skip_prompt(t *testing.T) {
 		ctx, clientsMock := prepareMocks(t, tt.triggersListResponse, tt.globResponse, tt.triggersCreateResponse, nil /*trigger create error*/)
 		clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
 		clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
-			Return(types.EVERYONE, []string{}, nil).Once()
+			Return(types.PermissionEveryone, []string{}, nil).Once()
 		clients := shared.NewClientFactory(clientsMock.MockClientFactory(), func(clients *shared.ClientFactory) {
 			clients.SDKConfig = hooks.NewSDKConfigMock()
 			clients.SDKConfig.Hooks.GetTrigger = hooks.HookScript{
@@ -169,7 +169,7 @@ func Test_TriggerGenerate_handle_error(t *testing.T) {
 		}, nil)
 		clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
 		clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
-			Return(types.EVERYONE, []string{}, nil).Once()
+			Return(types.PermissionEveryone, []string{}, nil).Once()
 		clients := shared.NewClientFactory(clientsMock.MockClientFactory(), func(clients *shared.ClientFactory) {
 			clients.SDKConfig = hooks.NewSDKConfigMock()
 			clients.SDKConfig.Hooks.GetTrigger = hooks.HookScript{
@@ -237,7 +237,7 @@ func Test_TriggerGenerate_Config_TriggerPaths_Default(t *testing.T) {
 		}, nil)
 		clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
 		clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
-			Return(types.EVERYONE, []string{}, nil).Once()
+			Return(types.PermissionEveryone, []string{}, nil).Once()
 		clients := shared.NewClientFactory(clientsMock.MockClientFactory(), func(clients *shared.ClientFactory) {
 			clients.SDKConfig = hooks.NewSDKConfigMock()
 			clients.SDKConfig.Hooks.GetTrigger = hooks.HookScript{
@@ -277,7 +277,7 @@ func Test_TriggerGenerate_Config_TriggerPaths_Custom(t *testing.T) {
 		}, nil)
 		clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
 		clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
-			Return(types.EVERYONE, []string{}, nil).Once()
+			Return(types.PermissionEveryone, []string{}, nil).Once()
 		clients := shared.NewClientFactory(clientsMock.MockClientFactory(), func(clients *shared.ClientFactory) {
 			clients.SDKConfig = hooks.NewSDKConfigMock()
 			clients.SDKConfig.Hooks.GetTrigger = hooks.HookScript{

--- a/cmd/triggers/generate_test.go
+++ b/cmd/triggers/generate_test.go
@@ -64,8 +64,8 @@ func Test_TriggerGenerate_accept_prompt(t *testing.T) {
 			Option: "trigger/file.ts",
 			Index:  0,
 		}, nil)
-		clientsMock.ApiInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-		clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+		clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+		clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 			Return(types.EVERYONE, []string{}, nil).Once()
 
 		clients := shared.NewClientFactory(clientsMock.MockClientFactory(), func(clients *shared.ClientFactory) {
@@ -129,8 +129,8 @@ func Test_TriggerGenerate_skip_prompt(t *testing.T) {
 
 	t.Run(tt.name, func(t *testing.T) {
 		ctx, clientsMock := prepareMocks(t, tt.triggersListResponse, tt.globResponse, tt.triggersCreateResponse, nil /*trigger create error*/)
-		clientsMock.ApiInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-		clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+		clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+		clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 			Return(types.EVERYONE, []string{}, nil).Once()
 		clients := shared.NewClientFactory(clientsMock.MockClientFactory(), func(clients *shared.ClientFactory) {
 			clients.SDKConfig = hooks.NewSDKConfigMock()
@@ -167,8 +167,8 @@ func Test_TriggerGenerate_handle_error(t *testing.T) {
 			Option: "triggers/trigger.ts",
 			Index:  0,
 		}, nil)
-		clientsMock.ApiInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-		clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+		clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+		clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 			Return(types.EVERYONE, []string{}, nil).Once()
 		clients := shared.NewClientFactory(clientsMock.MockClientFactory(), func(clients *shared.ClientFactory) {
 			clients.SDKConfig = hooks.NewSDKConfigMock()
@@ -235,8 +235,8 @@ func Test_TriggerGenerate_Config_TriggerPaths_Default(t *testing.T) {
 			Option: "triggers/trigger.ts",
 			Index:  0,
 		}, nil)
-		clientsMock.ApiInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-		clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+		clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+		clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 			Return(types.EVERYONE, []string{}, nil).Once()
 		clients := shared.NewClientFactory(clientsMock.MockClientFactory(), func(clients *shared.ClientFactory) {
 			clients.SDKConfig = hooks.NewSDKConfigMock()
@@ -275,8 +275,8 @@ func Test_TriggerGenerate_Config_TriggerPaths_Custom(t *testing.T) {
 			Option: "triggers/trigger.ts",
 			Index:  0,
 		}, nil)
-		clientsMock.ApiInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-		clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+		clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+		clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 			Return(types.EVERYONE, []string{}, nil).Once()
 		clients := shared.NewClientFactory(clientsMock.MockClientFactory(), func(clients *shared.ClientFactory) {
 			clients.SDKConfig = hooks.NewSDKConfigMock()
@@ -458,9 +458,9 @@ func prepareMocks(t *testing.T, triggersListResponse []types.DeployedTrigger, gl
 	ctx = config.SetContextToken(ctx, "token")
 
 	clientsMock := shared.NewClientsMock()
-	clientsMock.ApiInterface.On("WorkflowsTriggersList", mock.Anything, mock.Anything, mock.Anything).Return(triggersListResponse, "", nil)
+	clientsMock.APIInterface.On("WorkflowsTriggersList", mock.Anything, mock.Anything, mock.Anything).Return(triggersListResponse, "", nil)
 	clientsMock.Os.On("Glob", mock.Anything).Return(globResponse, nil)
-	clientsMock.ApiInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).Return(triggersCreateResponse, triggersCreateResponseError)
+	clientsMock.APIInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).Return(triggersCreateResponse, triggersCreateResponseError)
 	clientsMock.HookExecutor.On("Execute", mock.Anything, mock.Anything).Return(`{}`, nil)
 
 	clientsMock.AddDefaultMocks()

--- a/cmd/triggers/helpers_test.go
+++ b/cmd/triggers/helpers_test.go
@@ -45,7 +45,7 @@ func createFakeTrigger(fakeTriggerID string, fakeTriggerName string, fakeAppID s
 			ID:          fakeTriggerID,
 			Type:        "shortcut",
 			Name:        fakeTriggerName,
-			ShortcutUrl: "https://app.slack.com/app/" + fakeAppID + "/shortcut/" + fakeTriggerID,
+			ShortcutURL: "https://app.slack.com/app/" + fakeAppID + "/shortcut/" + fakeTriggerID,
 		}
 	case "scheduled":
 		fakeTrigger = types.DeployedTrigger{

--- a/cmd/triggers/info.go
+++ b/cmd/triggers/info.go
@@ -28,7 +28,7 @@ import (
 )
 
 type infoCmdFlags struct {
-	triggerId string
+	triggerID string
 }
 
 var infoFlags infoCmdFlags
@@ -54,7 +54,7 @@ func NewInfoCommand(clients *shared.ClientFactory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&infoFlags.triggerId, "trigger-id", "", "the ID of the trigger")
+	cmd.Flags().StringVar(&infoFlags.triggerID, "trigger-id", "", "the ID of the trigger")
 
 	return cmd
 }
@@ -78,8 +78,8 @@ func runInfoCommand(cmd *cobra.Command, clients *shared.ClientFactory) error {
 		return err
 	}
 
-	if infoFlags.triggerId == "" {
-		infoFlags.triggerId, err = promptForTriggerID(ctx, cmd, clients, app, token, defaultLabels)
+	if infoFlags.triggerID == "" {
+		infoFlags.triggerID, err = promptForTriggerID(ctx, cmd, clients, app, token, defaultLabels)
 		if err != nil {
 			if slackerror.ToSlackError(err).Code == slackerror.ErrNoTriggers {
 				printNoTriggersMessage(ctx, clients.IO)
@@ -89,7 +89,7 @@ func runInfoCommand(cmd *cobra.Command, clients *shared.ClientFactory) error {
 		}
 	}
 
-	requestedTrigger, err := clients.ApiInterface().WorkflowsTriggersInfo(ctx, token, infoFlags.triggerId)
+	requestedTrigger, err := clients.APIInterface().WorkflowsTriggersInfo(ctx, token, infoFlags.triggerID)
 	if err != nil {
 		return err
 	}

--- a/cmd/triggers/info_test.go
+++ b/cmd/triggers/info_test.go
@@ -40,18 +40,18 @@ func TestTriggersInfoCommand(t *testing.T) {
 				appSelectTeardown = setupMockInfoAppSelection(installedProdApp)
 				mockRequestTrigger := createFakeTrigger(fakeTriggerID, "test trigger", "test app", "shortcut")
 				// promptForTriggerID lists available triggers
-				cm.ApiInterface.On("WorkflowsTriggersList", mock.Anything, mock.Anything, mock.Anything).Return(
+				cm.APIInterface.On("WorkflowsTriggersList", mock.Anything, mock.Anything, mock.Anything).Return(
 					[]types.DeployedTrigger{{Name: "test trigger", ID: fakeTriggerID, Type: "Shortcut", Workflow: types.TriggerWorkflow{AppID: fakeAppID}}}, "", nil)
 				cm.IO.On("SelectPrompt", mock.Anything, "Choose a trigger:", mock.Anything, mock.Anything).Return(iostreams.SelectPromptResponse{Index: 0, Prompt: true}, nil)
-				cm.ApiInterface.On("WorkflowsTriggersInfo", mock.Anything, mock.Anything, mock.Anything).Return(mockRequestTrigger, nil)
-				cm.ApiInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-				cm.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).Return(types.EVERYONE, []string{}, nil).Once()
+				cm.APIInterface.On("WorkflowsTriggersInfo", mock.Anything, mock.Anything, mock.Anything).Return(mockRequestTrigger, nil)
+				cm.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+				cm.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).Return(types.EVERYONE, []string{}, nil).Once()
 			},
 			ExpectedOutputs: []string{
 				"Trigger Info",
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.ApiInterface.AssertCalled(t, "WorkflowsTriggersInfo", mock.Anything, mock.Anything, fakeTriggerID)
+				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersInfo", mock.Anything, mock.Anything, fakeTriggerID)
 			},
 			Teardown: func() {
 				appSelectTeardown()
@@ -78,9 +78,9 @@ func TestTriggersInfoCommand(t *testing.T) {
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				appSelectTeardown = setupMockInfoAppSelection(installedProdApp)
 				mockRequestTrigger := createFakeTrigger(fakeTriggerID, "test trigger", "test app", "shortcut")
-				clientsMock.ApiInterface.On("WorkflowsTriggersInfo", mock.Anything, mock.Anything, mock.Anything).Return(mockRequestTrigger, nil)
-				clientsMock.ApiInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-				clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("WorkflowsTriggersInfo", mock.Anything, mock.Anything, mock.Anything).Return(mockRequestTrigger, nil)
+				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.EVERYONE, []string{}, nil).Once()
 				clientsMock.AddDefaultMocks()
 				err := clients.AppClient().SaveDeployed(ctx, fakeApp)
@@ -90,7 +90,7 @@ func TestTriggersInfoCommand(t *testing.T) {
 				appSelectTeardown()
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.ApiInterface.AssertCalled(t, "WorkflowsTriggersInfo", mock.Anything, mock.Anything, fakeTriggerID)
+				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersInfo", mock.Anything, mock.Anything, fakeTriggerID)
 			},
 		},
 		"pass --trigger-id for an org app, success": {
@@ -103,9 +103,9 @@ func TestTriggersInfoCommand(t *testing.T) {
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				appSelectTeardown = setupMockInfoAppSelection(installedProdOrgApp)
 				mockRequestTrigger := createFakeTrigger(fakeTriggerID, "test trigger", "test app", "shortcut")
-				clientsMock.ApiInterface.On("WorkflowsTriggersInfo", mock.Anything, mock.Anything, mock.Anything).Return(mockRequestTrigger, nil)
-				clientsMock.ApiInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-				clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("WorkflowsTriggersInfo", mock.Anything, mock.Anything, mock.Anything).Return(mockRequestTrigger, nil)
+				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.EVERYONE, []string{}, nil).Once()
 				clientsMock.AddDefaultMocks()
 				err := clients.AppClient().SaveDeployed(ctx, fakeApp)
@@ -115,7 +115,7 @@ func TestTriggersInfoCommand(t *testing.T) {
 				appSelectTeardown()
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.ApiInterface.AssertCalled(t, "WorkflowsTriggersInfo", mock.Anything, mock.Anything, fakeTriggerID)
+				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersInfo", mock.Anything, mock.Anything, fakeTriggerID)
 			},
 		},
 		"pass --trigger-id, failure": {
@@ -123,7 +123,7 @@ func TestTriggersInfoCommand(t *testing.T) {
 			ExpectedErrorStrings: []string{"invalid_auth"},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				appSelectTeardown = setupMockInfoAppSelection(installedProdApp)
-				clientsMock.ApiInterface.On("WorkflowsTriggersInfo", mock.Anything, mock.Anything, mock.Anything).Return(types.DeployedTrigger{}, errors.New("invalid_auth"))
+				clientsMock.APIInterface.On("WorkflowsTriggersInfo", mock.Anything, mock.Anything, mock.Anything).Return(types.DeployedTrigger{}, errors.New("invalid_auth"))
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
 				err := clients.AppClient().SaveDeployed(ctx, fakeApp)
@@ -133,7 +133,7 @@ func TestTriggersInfoCommand(t *testing.T) {
 				appSelectTeardown()
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.ApiInterface.AssertCalled(t, "WorkflowsTriggersInfo", mock.Anything, mock.Anything, fakeTriggerID)
+				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersInfo", mock.Anything, mock.Anything, fakeTriggerID)
 			},
 		},
 		"event trigger displays hints and warnings": {
@@ -141,9 +141,9 @@ func TestTriggersInfoCommand(t *testing.T) {
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				appSelectTeardown = setupMockInfoAppSelection(installedProdApp)
 				mockRequestTrigger := createFakeTrigger(fakeTriggerID, "test trigger", "test app", "event")
-				clientsMock.ApiInterface.On("WorkflowsTriggersInfo", mock.Anything, mock.Anything, mock.Anything).Return(mockRequestTrigger, nil)
-				clientsMock.ApiInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-				clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("WorkflowsTriggersInfo", mock.Anything, mock.Anything, mock.Anything).Return(mockRequestTrigger, nil)
+				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.EVERYONE, []string{}, nil).Once()
 				clientsMock.AddDefaultMocks()
 				err := clients.AppClient().SaveDeployed(ctx, fakeApp)
@@ -159,7 +159,7 @@ func TestTriggersInfoCommand(t *testing.T) {
 				"Warning:\n",
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.ApiInterface.AssertCalled(t, "WorkflowsTriggersInfo", mock.Anything, mock.Anything, fakeTriggerID)
+				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersInfo", mock.Anything, mock.Anything, fakeTriggerID)
 			},
 		},
 	}, func(clients *shared.ClientFactory) *cobra.Command {

--- a/cmd/triggers/info_test.go
+++ b/cmd/triggers/info_test.go
@@ -45,7 +45,7 @@ func TestTriggersInfoCommand(t *testing.T) {
 				cm.IO.On("SelectPrompt", mock.Anything, "Choose a trigger:", mock.Anything, mock.Anything).Return(iostreams.SelectPromptResponse{Index: 0, Prompt: true}, nil)
 				cm.APIInterface.On("WorkflowsTriggersInfo", mock.Anything, mock.Anything, mock.Anything).Return(mockRequestTrigger, nil)
 				cm.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-				cm.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).Return(types.EVERYONE, []string{}, nil).Once()
+				cm.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).Return(types.PermissionEveryone, []string{}, nil).Once()
 			},
 			ExpectedOutputs: []string{
 				"Trigger Info",
@@ -81,7 +81,7 @@ func TestTriggersInfoCommand(t *testing.T) {
 				clientsMock.APIInterface.On("WorkflowsTriggersInfo", mock.Anything, mock.Anything, mock.Anything).Return(mockRequestTrigger, nil)
 				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
 				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
-					Return(types.EVERYONE, []string{}, nil).Once()
+					Return(types.PermissionEveryone, []string{}, nil).Once()
 				clientsMock.AddDefaultMocks()
 				err := clients.AppClient().SaveDeployed(ctx, fakeApp)
 				require.NoError(t, err, "Cant write apps.json")
@@ -106,7 +106,7 @@ func TestTriggersInfoCommand(t *testing.T) {
 				clientsMock.APIInterface.On("WorkflowsTriggersInfo", mock.Anything, mock.Anything, mock.Anything).Return(mockRequestTrigger, nil)
 				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
 				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
-					Return(types.EVERYONE, []string{}, nil).Once()
+					Return(types.PermissionEveryone, []string{}, nil).Once()
 				clientsMock.AddDefaultMocks()
 				err := clients.AppClient().SaveDeployed(ctx, fakeApp)
 				require.NoError(t, err, "Cant write apps.json")
@@ -144,7 +144,7 @@ func TestTriggersInfoCommand(t *testing.T) {
 				clientsMock.APIInterface.On("WorkflowsTriggersInfo", mock.Anything, mock.Anything, mock.Anything).Return(mockRequestTrigger, nil)
 				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
 				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
-					Return(types.EVERYONE, []string{}, nil).Once()
+					Return(types.PermissionEveryone, []string{}, nil).Once()
 				clientsMock.AddDefaultMocks()
 				err := clients.AppClient().SaveDeployed(ctx, fakeApp)
 				require.NoError(t, err, "Cant write apps.json")

--- a/cmd/triggers/list.go
+++ b/cmd/triggers/list.go
@@ -98,7 +98,7 @@ func runListCommand(cmd *cobra.Command, clients *shared.ClientFactory) error {
 		Limit: listFlags.triggerLimit,
 		Type:  listFlags.triggerType,
 	}
-	deployedTriggers, cursor, err := clients.ApiInterface().WorkflowsTriggersList(ctx, token, args)
+	deployedTriggers, cursor, err := clients.APIInterface().WorkflowsTriggersList(ctx, token, args)
 	if err != nil {
 		return err
 	}
@@ -172,7 +172,7 @@ func showMoreTriggers(ctx context.Context, cmd *cobra.Command, clients *shared.C
 
 	for proceed && args.Cursor != "" {
 		proceed = false
-		deployedTriggers, nextCursor, err := clients.ApiInterface().WorkflowsTriggersList(ctx, token, args)
+		deployedTriggers, nextCursor, err := clients.APIInterface().WorkflowsTriggersList(ctx, token, args)
 		if err != nil {
 			return err
 		}

--- a/cmd/triggers/list.go
+++ b/cmd/triggers/list.go
@@ -94,7 +94,7 @@ func runListCommand(cmd *cobra.Command, clients *shared.ClientFactory) error {
 	}
 
 	args := api.TriggerListRequest{
-		AppId: app.AppID,
+		AppID: app.AppID,
 		Limit: listFlags.triggerLimit,
 		Type:  listFlags.triggerType,
 	}
@@ -159,7 +159,7 @@ func showMoreTriggers(ctx context.Context, cmd *cobra.Command, clients *shared.C
 
 	token := config.GetContextToken(ctx)
 	args := api.TriggerListRequest{
-		AppId:  app.AppID,
+		AppID:  app.AppID,
 		Limit:  listFlags.triggerLimit,
 		Cursor: cursor,
 		Type:   listFlags.triggerType,

--- a/cmd/triggers/list_test.go
+++ b/cmd/triggers/list_test.go
@@ -45,7 +45,7 @@ func TestTriggersListCommand(t *testing.T) {
 					Cursor: "",
 					Type:   listFlags.triggerType,
 				}
-				clientsMock.ApiInterface.On("WorkflowsTriggersList", mock.Anything, mock.Anything, triggerListRequestArgs).Return([]types.DeployedTrigger{}, "", nil)
+				clientsMock.APIInterface.On("WorkflowsTriggersList", mock.Anything, mock.Anything, triggerListRequestArgs).Return([]types.DeployedTrigger{}, "", nil)
 
 				clientsMock.AddDefaultMocks()
 			},
@@ -57,7 +57,7 @@ func TestTriggersListCommand(t *testing.T) {
 				"There are no triggers installed for the app",
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.ApiInterface.AssertCalled(t, "WorkflowsTriggersList", mock.Anything, mock.Anything, triggerListRequestArgs)
+				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersList", mock.Anything, mock.Anything, triggerListRequestArgs)
 			},
 		},
 
@@ -73,15 +73,15 @@ func TestTriggersListCommand(t *testing.T) {
 					Cursor: "",
 					Type:   listFlags.triggerType,
 				}
-				clientsMock.ApiInterface.On("WorkflowsTriggersList", mock.Anything, mock.Anything, triggerListRequestArgs).Return(
+				clientsMock.APIInterface.On("WorkflowsTriggersList", mock.Anything, mock.Anything, triggerListRequestArgs).Return(
 					[]types.DeployedTrigger{
 						createFakeTrigger(fakeTriggerID, fakeTriggerName, fakeAppID, "shortcut"),
 					},
 					"",
 					nil,
 				)
-				clientsMock.ApiInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-				clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).Return(types.EVERYONE, []string{}, nil)
+				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).Return(types.EVERYONE, []string{}, nil)
 
 				clientsMock.AddDefaultMocks()
 			},
@@ -94,7 +94,7 @@ func TestTriggersListCommand(t *testing.T) {
 				"everyone in the workspace",
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.ApiInterface.AssertCalled(t, "WorkflowsTriggersList", mock.Anything, mock.Anything, triggerListRequestArgs)
+				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersList", mock.Anything, mock.Anything, triggerListRequestArgs)
 			},
 		},
 
@@ -110,15 +110,15 @@ func TestTriggersListCommand(t *testing.T) {
 					Cursor: "",
 					Type:   listFlags.triggerType,
 				}
-				clientsMock.ApiInterface.On("WorkflowsTriggersList", mock.Anything, mock.Anything, triggerListRequestArgs).Return(
+				clientsMock.APIInterface.On("WorkflowsTriggersList", mock.Anything, mock.Anything, triggerListRequestArgs).Return(
 					[]types.DeployedTrigger{
 						createFakeTrigger(fakeTriggerID, fakeTriggerName, fakeAppID, "shortcut"),
 					},
 					"",
 					nil,
 				)
-				clientsMock.ApiInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-				clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).Return(types.EVERYONE, []string{}, nil)
+				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).Return(types.EVERYONE, []string{}, nil)
 
 				clientsMock.AddDefaultMocks()
 			},
@@ -131,7 +131,7 @@ func TestTriggersListCommand(t *testing.T) {
 				"everyone in all workspaces in this org granted to this app",
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.ApiInterface.AssertCalled(t, "WorkflowsTriggersList", mock.Anything, mock.Anything, triggerListRequestArgs)
+				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersList", mock.Anything, mock.Anything, triggerListRequestArgs)
 			},
 		},
 
@@ -147,7 +147,7 @@ func TestTriggersListCommand(t *testing.T) {
 					Cursor: "",
 					Type:   listFlags.triggerType,
 				}
-				clientsMock.ApiInterface.On("WorkflowsTriggersList", mock.Anything, mock.Anything, triggerListRequestArgs).Return(
+				clientsMock.APIInterface.On("WorkflowsTriggersList", mock.Anything, mock.Anything, triggerListRequestArgs).Return(
 					[]types.DeployedTrigger{
 						createFakeTrigger(fakeTriggerID, fakeTriggerName, fakeAppID, "shortcut"),
 						createFakeTrigger(fakeTriggerID, fakeTriggerName, fakeAppID, "scheduled"),
@@ -155,8 +155,8 @@ func TestTriggersListCommand(t *testing.T) {
 					"",
 					nil,
 				)
-				clientsMock.ApiInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-				clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).Return(types.EVERYONE, []string{}, nil)
+				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).Return(types.EVERYONE, []string{}, nil)
 
 				clientsMock.AddDefaultMocks()
 			},
@@ -169,7 +169,7 @@ func TestTriggersListCommand(t *testing.T) {
 				fmt.Sprintf("Trigger ID: %s (%s)", fakeTriggerID, "scheduled"),
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.ApiInterface.AssertCalled(t, "WorkflowsTriggersList", mock.Anything, mock.Anything, triggerListRequestArgs)
+				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersList", mock.Anything, mock.Anything, triggerListRequestArgs)
 			},
 		},
 	}, func(clients *shared.ClientFactory) *cobra.Command {

--- a/cmd/triggers/list_test.go
+++ b/cmd/triggers/list_test.go
@@ -81,7 +81,7 @@ func TestTriggersListCommand(t *testing.T) {
 					nil,
 				)
 				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).Return(types.EVERYONE, []string{}, nil)
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).Return(types.PermissionEveryone, []string{}, nil)
 
 				clientsMock.AddDefaultMocks()
 			},
@@ -118,7 +118,7 @@ func TestTriggersListCommand(t *testing.T) {
 					nil,
 				)
 				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).Return(types.EVERYONE, []string{}, nil)
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).Return(types.PermissionEveryone, []string{}, nil)
 
 				clientsMock.AddDefaultMocks()
 			},
@@ -156,7 +156,7 @@ func TestTriggersListCommand(t *testing.T) {
 					nil,
 				)
 				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).Return(types.EVERYONE, []string{}, nil)
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).Return(types.PermissionEveryone, []string{}, nil)
 
 				clientsMock.AddDefaultMocks()
 			},

--- a/cmd/triggers/list_test.go
+++ b/cmd/triggers/list_test.go
@@ -40,7 +40,7 @@ func TestTriggersListCommand(t *testing.T) {
 
 				// Mock API responses
 				triggerListRequestArgs = api.TriggerListRequest{
-					AppId:  fakeAppID,
+					AppID:  fakeAppID,
 					Limit:  listFlags.triggerLimit,
 					Cursor: "",
 					Type:   listFlags.triggerType,
@@ -68,7 +68,7 @@ func TestTriggersListCommand(t *testing.T) {
 
 				// Mock API responses
 				triggerListRequestArgs = api.TriggerListRequest{
-					AppId:  fakeAppID,
+					AppID:  fakeAppID,
 					Limit:  listFlags.triggerLimit,
 					Cursor: "",
 					Type:   listFlags.triggerType,
@@ -105,7 +105,7 @@ func TestTriggersListCommand(t *testing.T) {
 
 				// Mock API responses
 				triggerListRequestArgs = api.TriggerListRequest{
-					AppId:  fakeAppID,
+					AppID:  fakeAppID,
 					Limit:  listFlags.triggerLimit,
 					Cursor: "",
 					Type:   listFlags.triggerType,
@@ -142,7 +142,7 @@ func TestTriggersListCommand(t *testing.T) {
 
 				// Mock API responses
 				triggerListRequestArgs = api.TriggerListRequest{
-					AppId:  fakeAppID,
+					AppID:  fakeAppID,
 					Limit:  listFlags.triggerLimit,
 					Cursor: "",
 					Type:   listFlags.triggerType,

--- a/cmd/triggers/triggers.go
+++ b/cmd/triggers/triggers.go
@@ -349,7 +349,7 @@ const (
 
 func promptForTriggerID(ctx context.Context, cmd *cobra.Command, clients *shared.ClientFactory, app types.App, token string, labelOption promptForTriggerIDLabelOption) (string, error) {
 	args := api.TriggerListRequest{
-		AppId: app.AppID,
+		AppID: app.AppID,
 		Limit: 0,     // 0 means no pagation
 		Type:  "all", // all means showing all types of triggers
 	}

--- a/cmd/triggers/triggers.go
+++ b/cmd/triggers/triggers.go
@@ -136,19 +136,19 @@ func sprintTrigger(ctx context.Context, t types.DeployedTrigger, clients *shared
 	}
 	// Get trigger's ACL entities details
 	if singleTriggerInfo {
-		if accessType != types.EVERYONE && len(entitiesAccessList) <= 0 {
+		if accessType != types.PermissionEveryone && len(entitiesAccessList) <= 0 {
 			triggerText = append(triggerText, fmt.Sprintf(
 				style.Indent(style.Secondary("  %s")),
 				"nobody",
 			))
 		} else {
-			if accessType == types.EVERYONE {
+			if accessType == types.PermissionEveryone {
 				var everyoneAccessTypeDescription = types.GetAccessTypeDescriptionForEveryone(app)
 				triggerText = append(triggerText, fmt.Sprintf(
 					style.Indent(style.Secondary("Can be found and used by:\n  %s")),
 					style.Indent(style.Secondary(everyoneAccessTypeDescription)),
 				))
-			} else if accessType == types.APP_COLLABORATORS {
+			} else if accessType == types.PermissionAppCollaborators {
 				triggerText = append(triggerText, fmt.Sprint(
 					style.Indent(style.Secondary("Can be found and used by:")),
 				))
@@ -162,7 +162,7 @@ func sprintTrigger(ctx context.Context, t types.DeployedTrigger, clients *shared
 						userInfo.RealName, style.Secondary("@"+userInfo.Profile.DisplayName), style.Secondary(userInfo.ID),
 					))
 				}
-			} else if accessType == types.NAMED_ENTITIES {
+			} else if accessType == types.PermissionNamedEntities {
 				triggerText = append(triggerText, fmt.Sprint(
 					style.Indent(style.Secondary("Can be found and used by:")),
 				))
@@ -220,7 +220,7 @@ func sprintTrigger(ctx context.Context, t types.DeployedTrigger, clients *shared
 		}
 	} else {
 		accessTypeDescription := accessType.ToString()
-		if accessType == types.EVERYONE {
+		if accessType == types.PermissionEveryone {
 			accessTypeDescription = types.GetAccessTypeDescriptionForEveryone(app)
 		}
 

--- a/cmd/triggers/triggers.go
+++ b/cmd/triggers/triggers.go
@@ -110,7 +110,7 @@ func sprintTrigger(ctx context.Context, t types.DeployedTrigger, clients *shared
 	token := config.GetContextToken(ctx)
 
 	// Get app owners & collaborators
-	collaborators, err := clients.ApiInterface().ListCollaborators(ctx, token, app.AppID)
+	collaborators, err := clients.APIInterface().ListCollaborators(ctx, token, app.AppID)
 	if err != nil {
 		return []string{}, err
 	}
@@ -119,7 +119,7 @@ func sprintTrigger(ctx context.Context, t types.DeployedTrigger, clients *shared
 			style.Indent(style.Secondary("Collaborators:")),
 		))
 		for _, collaborator := range collaborators {
-			userInfo, err := clients.ApiInterface().UsersInfo(ctx, token, collaborator.ID)
+			userInfo, err := clients.APIInterface().UsersInfo(ctx, token, collaborator.ID)
 			if err != nil {
 				return []string{}, err
 			}
@@ -130,7 +130,7 @@ func sprintTrigger(ctx context.Context, t types.DeployedTrigger, clients *shared
 		}
 	}
 	// Get trigger's ACL type
-	accessType, entitiesAccessList, err := clients.ApiInterface().TriggerPermissionsList(ctx, token, t.ID)
+	accessType, entitiesAccessList, err := clients.APIInterface().TriggerPermissionsList(ctx, token, t.ID)
 	if err != nil {
 		return []string{}, err
 	}
@@ -153,7 +153,7 @@ func sprintTrigger(ctx context.Context, t types.DeployedTrigger, clients *shared
 					style.Indent(style.Secondary("Can be found and used by:")),
 				))
 				for _, entity := range entitiesAccessList {
-					userInfo, err := clients.ApiInterface().UsersInfo(ctx, token, entity)
+					userInfo, err := clients.APIInterface().UsersInfo(ctx, token, entity)
 					if err != nil {
 						return []string{}, err
 					}
@@ -170,7 +170,7 @@ func sprintTrigger(ctx context.Context, t types.DeployedTrigger, clients *shared
 				if len(namedEntitiesAccessMap["users"]) > 0 {
 
 					for _, entity := range namedEntitiesAccessMap["users"] {
-						userInfo, err := clients.ApiInterface().UsersInfo(ctx, token, entity)
+						userInfo, err := clients.APIInterface().UsersInfo(ctx, token, entity)
 						if err != nil {
 							return []string{}, err
 						}
@@ -182,7 +182,7 @@ func sprintTrigger(ctx context.Context, t types.DeployedTrigger, clients *shared
 				}
 				if len(namedEntitiesAccessMap["channels"]) > 0 {
 					for _, entity := range namedEntitiesAccessMap["channels"] {
-						channelInfo, err := clients.ApiInterface().ChannelsInfo(ctx, token, entity)
+						channelInfo, err := clients.APIInterface().ChannelsInfo(ctx, token, entity)
 						if err != nil {
 							return []string{}, err
 						}
@@ -194,7 +194,7 @@ func sprintTrigger(ctx context.Context, t types.DeployedTrigger, clients *shared
 				}
 				if len(namedEntitiesAccessMap["teams"]) > 0 {
 					for _, entity := range namedEntitiesAccessMap["teams"] {
-						teamInfo, err := clients.ApiInterface().TeamsInfo(ctx, token, entity)
+						teamInfo, err := clients.APIInterface().TeamsInfo(ctx, token, entity)
 						if err != nil {
 							return []string{}, err
 						}
@@ -206,7 +206,7 @@ func sprintTrigger(ctx context.Context, t types.DeployedTrigger, clients *shared
 				}
 				if len(namedEntitiesAccessMap["organizations"]) > 0 {
 					for _, entity := range namedEntitiesAccessMap["organizations"] {
-						orgInfo, err := clients.ApiInterface().TeamsInfo(ctx, token, entity)
+						orgInfo, err := clients.APIInterface().TeamsInfo(ctx, token, entity)
 						if err != nil {
 							return []string{}, err
 						}
@@ -235,9 +235,9 @@ func sprintTrigger(ctx context.Context, t types.DeployedTrigger, clients *shared
 			style.Indent(style.Faint(style.Underline(t.Webhook))))
 	}
 
-	if t.ShortcutUrl != "" {
+	if t.ShortcutURL != "" {
 		triggerText = append(triggerText,
-			style.Indent(style.Faint(style.Underline(t.ShortcutUrl))))
+			style.Indent(style.Faint(style.Underline(t.ShortcutURL))))
 	}
 
 	if t.Type == "event" {
@@ -353,7 +353,7 @@ func promptForTriggerID(ctx context.Context, cmd *cobra.Command, clients *shared
 		Limit: 0,     // 0 means no pagation
 		Type:  "all", // all means showing all types of triggers
 	}
-	triggers, _, err := clients.ApiInterface().WorkflowsTriggersList(ctx, token, args)
+	triggers, _, err := clients.APIInterface().WorkflowsTriggersList(ctx, token, args)
 	if err != nil {
 		return "", err
 	}
@@ -373,7 +373,7 @@ func promptForTriggerID(ctx context.Context, cmd *cobra.Command, clients *shared
 	triggerLabels := []string{}
 	for _, tr := range triggers {
 		if labelOption == labelsIncludeAccessType {
-			accessType, _, err := clients.ApiInterface().TriggerPermissionsList(ctx, token, tr.ID)
+			accessType, _, err := clients.APIInterface().TriggerPermissionsList(ctx, token, tr.ID)
 			if err != nil {
 				return "", err
 			}

--- a/cmd/triggers/triggers_test.go
+++ b/cmd/triggers/triggers_test.go
@@ -44,13 +44,13 @@ func TestTriggersCommand(t *testing.T) {
 	cmd := NewCommand(clients)
 	testutil.MockCmdIO(clients.IO, cmd)
 
-	clientsMock.ApiInterface.On("WorkflowsTriggersList", mock.Anything, mock.Anything, mock.Anything).Return([]types.DeployedTrigger{}, "", nil)
+	clientsMock.APIInterface.On("WorkflowsTriggersList", mock.Anything, mock.Anything, mock.Anything).Return([]types.DeployedTrigger{}, "", nil)
 
 	err := cmd.ExecuteContext(ctx)
 	if err != nil {
 		assert.Fail(t, "cmd.Execute had unexpected error")
 	}
 
-	clientsMock.ApiInterface.AssertCalled(t, "WorkflowsTriggersList", mock.Anything, mock.Anything, mock.Anything)
+	clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersList", mock.Anything, mock.Anything, mock.Anything)
 
 }

--- a/cmd/triggers/update.go
+++ b/cmd/triggers/update.go
@@ -33,7 +33,7 @@ import (
 
 type updateCmdFlags struct {
 	createCmdFlags
-	triggerId string
+	triggerID string
 }
 
 var updateFlags updateCmdFlags
@@ -61,7 +61,7 @@ func NewUpdateCommand(clients *shared.ClientFactory) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringVar(&updateFlags.triggerId, "trigger-id", "", "the ID of the trigger to update")
+	cmd.Flags().StringVar(&updateFlags.triggerID, "trigger-id", "", "the ID of the trigger to update")
 	cmd.Flags().StringVar(&updateFlags.workflow, "workflow", "", "a reference to the workflow to execute\n  formatted as:\n  \"#/workflows/<workflow_callback_id>\"")
 	cmd.Flags().StringVar(&updateFlags.title, "title", "My Trigger", "the title of this trigger\n  ")
 	cmd.Flags().StringVar(&updateFlags.description, "description", "", "the description of this trigger")
@@ -94,8 +94,8 @@ func runUpdateCommand(clients *shared.ClientFactory, cmd *cobra.Command) error {
 	}
 
 	// Get trigger ID from flag or prompt
-	if updateFlags.triggerId == "" {
-		updateFlags.triggerId, err = promptForTriggerID(ctx, cmd, clients, app, token, defaultLabels)
+	if updateFlags.triggerID == "" {
+		updateFlags.triggerID, err = promptForTriggerID(ctx, cmd, clients, app, token, defaultLabels)
 		if err != nil {
 			if slackerror.ToSlackError(err).Code == slackerror.ErrNoTriggers {
 				printNoTriggersMessage(ctx, clients.IO)
@@ -130,11 +130,11 @@ func runUpdateCommand(clients *shared.ClientFactory, cmd *cobra.Command) error {
 	triggerArg.WorkflowAppID = app.AppID
 
 	updateRequest := api.TriggerUpdateRequest{
-		TriggerID:      updateFlags.triggerId,
+		TriggerID:      updateFlags.triggerID,
 		TriggerRequest: triggerArg,
 	}
 
-	updatedTrigger, err := clients.ApiInterface().WorkflowsTriggersUpdate(ctx, token, updateRequest)
+	updatedTrigger, err := clients.APIInterface().WorkflowsTriggersUpdate(ctx, token, updateRequest)
 	if extendedErr, ok := err.(*api.TriggerCreateOrUpdateError); ok {
 		// If the user used --workflow and the creation failed because we were missing the interactivity
 		// context, lets prompt and optionally add it
@@ -149,7 +149,7 @@ func runUpdateCommand(clients *shared.ClientFactory, cmd *cobra.Command) error {
 			if shouldUpdate {
 				// TODO: based on the unit tests, I _think_ this should be the behaviour.. but needs a review.
 				// Assumption is: if trigger update fails due to missing interactivity, we prompt user to tweak their definition to include interactivity, recreate, and if successful, proceed.
-				updatedTrigger, innerErr = clients.ApiInterface().WorkflowsTriggersUpdate(ctx, token, updateRequest)
+				updatedTrigger, innerErr = clients.APIInterface().WorkflowsTriggersUpdate(ctx, token, updateRequest)
 				if innerErr != nil {
 					return innerErr
 				} else {

--- a/cmd/triggers/update.go
+++ b/cmd/triggers/update.go
@@ -127,10 +127,10 @@ func runUpdateCommand(clients *shared.ClientFactory, cmd *cobra.Command) error {
 
 	// Fix the app ID selected from the menu. In the --trigger-def case, this lets you use the same
 	// def file for dev and prod.
-	triggerArg.WorkflowAppId = app.AppID
+	triggerArg.WorkflowAppID = app.AppID
 
 	updateRequest := api.TriggerUpdateRequest{
-		TriggerId:      updateFlags.triggerId,
+		TriggerID:      updateFlags.triggerId,
 		TriggerRequest: triggerArg,
 	}
 

--- a/cmd/triggers/update_test.go
+++ b/cmd/triggers/update_test.go
@@ -52,9 +52,9 @@ func TestTriggersUpdateCommand(t *testing.T) {
 				// Execute update
 				fakeTrigger := createFakeTrigger(fakeTriggerID, fakeTriggerName, fakeAppID, "shortcut")
 				clientsMock.APIInterface.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, mock.Anything).Return(fakeTrigger, nil)
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).Return(types.EVERYONE, []string{}, nil).Once()
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).Return(types.PermissionEveryone, []string{}, nil).Once()
 				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).Return(types.EVERYONE, []string{}, nil).Once()
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).Return(types.PermissionEveryone, []string{}, nil).Once()
 			},
 			Teardown: func() {
 				appSelectTeardown()
@@ -114,7 +114,7 @@ func TestTriggersUpdateCommand(t *testing.T) {
 				clientsMock.APIInterface.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, mock.Anything).Return(fakeTrigger, nil)
 				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
 				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
-					Return(types.EVERYONE, []string{}, nil).Once()
+					Return(types.PermissionEveryone, []string{}, nil).Once()
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
 				// TODO this can probably be replaced by a helper that sets up an apps.json file in
@@ -150,7 +150,7 @@ func TestTriggersUpdateCommand(t *testing.T) {
 				clientsMock.APIInterface.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, mock.Anything).Return(fakeTrigger, nil)
 				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
 				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
-					Return(types.EVERYONE, []string{}, nil).Once()
+					Return(types.PermissionEveryone, []string{}, nil).Once()
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
 				// TODO this can probably be replaced by a helper that sets up an apps.json file in
@@ -191,7 +191,7 @@ func TestTriggersUpdateCommand(t *testing.T) {
 				clientsMock.APIInterface.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, mock.Anything).Return(fakeTrigger, nil)
 				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
 				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
-					Return(types.EVERYONE, []string{}, nil).Once()
+					Return(types.PermissionEveryone, []string{}, nil).Once()
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
 				// TODO this can probably be replaced by a helper that sets up an apps.json file in
@@ -232,7 +232,7 @@ func TestTriggersUpdateCommand(t *testing.T) {
 				clientsMock.APIInterface.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, mock.Anything).Return(fakeTrigger, nil)
 				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
 				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
-					Return(types.EVERYONE, []string{}, nil).Once()
+					Return(types.PermissionEveryone, []string{}, nil).Once()
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
 				err := clients.AppClient().SaveDeployed(ctx, fakeApp)
@@ -281,7 +281,7 @@ func TestTriggersUpdateCommand(t *testing.T) {
 				clientsMock.APIInterface.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, mock.Anything).Return(fakeTrigger, nil)
 				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
 				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
-					Return(types.EVERYONE, []string{}, nil).Once()
+					Return(types.PermissionEveryone, []string{}, nil).Once()
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
 				err := clients.AppClient().SaveDeployed(ctx, fakeApp)
@@ -337,7 +337,7 @@ func TestTriggersUpdateCommand(t *testing.T) {
 				clientsMock.APIInterface.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, mock.Anything).Return(types.DeployedTrigger{}, nil)
 				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
 				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
-					Return(types.EVERYONE, []string{}, nil).Once()
+					Return(types.PermissionEveryone, []string{}, nil).Once()
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
 				clientsMock.HookExecutor.On("Execute", mock.Anything, mock.Anything).Return(`{`, nil)
@@ -421,7 +421,7 @@ func TestTriggersUpdateCommand_MissingParameters(t *testing.T) {
 				clientsMock.APIInterface.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, triggerRequestWithInteractivityInputs).Return(fakeTrigger, nil)
 				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
 				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
-					Return(types.EVERYONE, []string{}, nil).Once()
+					Return(types.PermissionEveryone, []string{}, nil).Once()
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
 				err := clients.AppClient().SaveDeployed(ctx, fakeApp)

--- a/cmd/triggers/update_test.go
+++ b/cmd/triggers/update_test.go
@@ -61,12 +61,12 @@ func TestTriggersUpdateCommand(t *testing.T) {
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
 				expectedTriggerRequest := api.TriggerUpdateRequest{
-					TriggerId: fakeTriggerID,
+					TriggerID: fakeTriggerID,
 					TriggerRequest: api.TriggerRequest{
 						Type:          types.TriggerTypeShortcut,
 						Shortcut:      &api.Shortcut{},
 						Name:          fakeTriggerName,
-						WorkflowAppId: fakeAppID,
+						WorkflowAppID: fakeAppID,
 					},
 				}
 				clientsMock.ApiInterface.AssertCalled(t, "WorkflowsTriggersUpdate", mock.Anything, mock.Anything, expectedTriggerRequest)
@@ -127,14 +127,14 @@ func TestTriggersUpdateCommand(t *testing.T) {
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
 				expectedTriggerRequest := api.TriggerUpdateRequest{
-					TriggerId: fakeTriggerID,
+					TriggerID: fakeTriggerID,
 					TriggerRequest: api.TriggerRequest{
 						Type:          types.TriggerTypeShortcut,
 						Shortcut:      &api.Shortcut{},
 						Name:          fakeTriggerName,
 						Description:   "Runs the '#/workflows/my_workflow' workflow",
 						Workflow:      "#/workflows/my_workflow",
-						WorkflowAppId: fakeAppID,
+						WorkflowAppID: fakeAppID,
 					},
 				}
 				clientsMock.ApiInterface.AssertCalled(t, "WorkflowsTriggersUpdate", mock.Anything, mock.Anything, expectedTriggerRequest)
@@ -163,14 +163,14 @@ func TestTriggersUpdateCommand(t *testing.T) {
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
 				expectedTriggerRequest := api.TriggerUpdateRequest{
-					TriggerId: fakeTriggerID,
+					TriggerID: fakeTriggerID,
 					TriggerRequest: api.TriggerRequest{
 						Type:          types.TriggerTypeShortcut,
 						Shortcut:      &api.Shortcut{},
 						Name:          fakeTriggerName,
 						Description:   "Runs the '#/workflows/my_workflow' workflow",
 						Workflow:      "#/workflows/my_workflow",
-						WorkflowAppId: fakeAppID,
+						WorkflowAppID: fakeAppID,
 						Inputs: api.Inputs{
 							"interactivity": &api.Input{
 								Value: "{{data.interactivity}}",
@@ -204,14 +204,14 @@ func TestTriggersUpdateCommand(t *testing.T) {
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
 				expectedTriggerRequest := api.TriggerUpdateRequest{
-					TriggerId: fakeTriggerID,
+					TriggerID: fakeTriggerID,
 					TriggerRequest: api.TriggerRequest{
 						Type:          types.TriggerTypeShortcut,
 						Shortcut:      &api.Shortcut{},
 						Name:          fakeTriggerName,
 						Description:   "Runs the '#/workflows/my_workflow' workflow",
 						Workflow:      "#/workflows/my_workflow",
-						WorkflowAppId: fakeAppID,
+						WorkflowAppID: fakeAppID,
 						Inputs: api.Inputs{
 							"custom-interactivity": &api.Input{
 								Value: "{{data.interactivity}}",
@@ -243,14 +243,14 @@ func TestTriggersUpdateCommand(t *testing.T) {
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
 				expectedTriggerRequest := api.TriggerUpdateRequest{
-					TriggerId: fakeTriggerID,
+					TriggerID: fakeTriggerID,
 					TriggerRequest: api.TriggerRequest{
 						Type:          types.TriggerTypeShortcut,
 						Name:          "unit tests",
 						Description:   "are the best",
 						Shortcut:      &api.Shortcut{},
 						Workflow:      "#/workflows/my_workflow",
-						WorkflowAppId: fakeAppID,
+						WorkflowAppID: fakeAppID,
 					},
 				}
 				clientsMock.ApiInterface.AssertCalled(t, "WorkflowsTriggersUpdate", mock.Anything, mock.Anything, expectedTriggerRequest)
@@ -302,13 +302,13 @@ func TestTriggersUpdateCommand(t *testing.T) {
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
 				expectedTriggerRequest := api.TriggerUpdateRequest{
-					TriggerId: fakeTriggerID,
+					TriggerID: fakeTriggerID,
 					TriggerRequest: api.TriggerRequest{
 						Type:          types.TriggerTypeScheduled,
 						Name:          "name",
 						Description:   "desc",
 						Workflow:      "#/workflows/my_workflow",
-						WorkflowAppId: fakeAppID,
+						WorkflowAppID: fakeAppID,
 						Schedule:      types.ToRawJson(`{"start_time":"2020-03-15","frequency":{"type":"daily"}}`),
 					},
 				}
@@ -372,26 +372,26 @@ func TestTriggersUpdateCommand_MissingParameters(t *testing.T) {
 	var promptForInteractivityTeardown func()
 
 	triggerRequestMissingInputs := api.TriggerUpdateRequest{
-		TriggerId: fakeTriggerID,
+		TriggerID: fakeTriggerID,
 		TriggerRequest: api.TriggerRequest{
 			Type:          types.TriggerTypeShortcut,
 			Shortcut:      &api.Shortcut{},
 			Name:          fakeTriggerName,
 			Description:   "Runs the '#/workflows/my_workflow' workflow",
 			Workflow:      "#/workflows/my_workflow",
-			WorkflowAppId: fakeAppID,
+			WorkflowAppID: fakeAppID,
 		},
 	}
 
 	triggerRequestWithInteractivityInputs := api.TriggerUpdateRequest{
-		TriggerId: fakeTriggerID,
+		TriggerID: fakeTriggerID,
 		TriggerRequest: api.TriggerRequest{
 			Type:          types.TriggerTypeShortcut,
 			Shortcut:      &api.Shortcut{},
 			Name:          fakeTriggerName,
 			Description:   "Runs the '#/workflows/my_workflow' workflow",
 			Workflow:      "#/workflows/my_workflow",
-			WorkflowAppId: fakeAppID,
+			WorkflowAppID: fakeAppID,
 			Inputs: api.Inputs{
 				"my-interactivity": &api.Input{
 					Value: "{{data.interactivity}}",

--- a/cmd/triggers/update_test.go
+++ b/cmd/triggers/update_test.go
@@ -43,7 +43,7 @@ func TestTriggersUpdateCommand(t *testing.T) {
 				appSelectTeardown = setupMockUpdateAppSelection(installedProdApp)
 				clientsMock.AddDefaultMocks()
 				// Prompt for Trigger ID
-				clientsMock.ApiInterface.On("WorkflowsTriggersList", mock.Anything, mock.Anything, mock.Anything).Return(
+				clientsMock.APIInterface.On("WorkflowsTriggersList", mock.Anything, mock.Anything, mock.Anything).Return(
 					[]types.DeployedTrigger{{Name: fakeTriggerName, ID: fakeTriggerID, Type: "Shortcut", Workflow: types.TriggerWorkflow{AppID: fakeAppID}}}, "", nil)
 				clientsMock.IO.On("SelectPrompt", mock.Anything, "Choose a trigger:", mock.Anything, mock.Anything).Return(iostreams.SelectPromptResponse{Index: 0, Prompt: true}, nil)
 				// Prompt for trigger definition file
@@ -51,10 +51,10 @@ func TestTriggersUpdateCommand(t *testing.T) {
 				clientsMock.IO.On("SelectPrompt", mock.Anything, "Choose a trigger definition file:", mock.Anything, mock.Anything).Return(iostreams.SelectPromptResponse{Index: 0, Prompt: true}, nil)
 				// Execute update
 				fakeTrigger := createFakeTrigger(fakeTriggerID, fakeTriggerName, fakeAppID, "shortcut")
-				clientsMock.ApiInterface.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, mock.Anything).Return(fakeTrigger, nil)
-				clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).Return(types.EVERYONE, []string{}, nil).Once()
-				clientsMock.ApiInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-				clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).Return(types.EVERYONE, []string{}, nil).Once()
+				clientsMock.APIInterface.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, mock.Anything).Return(fakeTrigger, nil)
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).Return(types.EVERYONE, []string{}, nil).Once()
+				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).Return(types.EVERYONE, []string{}, nil).Once()
 			},
 			Teardown: func() {
 				appSelectTeardown()
@@ -69,7 +69,7 @@ func TestTriggersUpdateCommand(t *testing.T) {
 						WorkflowAppID: fakeAppID,
 					},
 				}
-				clientsMock.ApiInterface.AssertCalled(t, "WorkflowsTriggersUpdate", mock.Anything, mock.Anything, expectedTriggerRequest)
+				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersUpdate", mock.Anything, mock.Anything, expectedTriggerRequest)
 			},
 		},
 		"hosted app not installed": {
@@ -111,9 +111,9 @@ func TestTriggersUpdateCommand(t *testing.T) {
 				appSelectTeardown = setupMockUpdateAppSelection(installedProdApp)
 				// TODO: always a) mock out calls and b) call AddDefaultMocks before making any clients.* calls
 				fakeTrigger := createFakeTrigger(fakeTriggerID, fakeTriggerName, fakeAppID, "shortcut")
-				clientsMock.ApiInterface.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, mock.Anything).Return(fakeTrigger, nil)
-				clientsMock.ApiInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-				clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, mock.Anything).Return(fakeTrigger, nil)
+				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.EVERYONE, []string{}, nil).Once()
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
@@ -137,7 +137,7 @@ func TestTriggersUpdateCommand(t *testing.T) {
 						WorkflowAppID: fakeAppID,
 					},
 				}
-				clientsMock.ApiInterface.AssertCalled(t, "WorkflowsTriggersUpdate", mock.Anything, mock.Anything, expectedTriggerRequest)
+				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersUpdate", mock.Anything, mock.Anything, expectedTriggerRequest)
 			},
 		},
 		"only pass --workflow and --trigger-id, with interactivity": {
@@ -147,9 +147,9 @@ func TestTriggersUpdateCommand(t *testing.T) {
 				appSelectTeardown = setupMockUpdateAppSelection(installedProdApp)
 				// TODO: always a) mock out calls and b) call AddDefaultMocks before making any clients.* calls
 				fakeTrigger := createFakeTrigger(fakeTriggerID, fakeTriggerName, fakeAppID, "shortcut")
-				clientsMock.ApiInterface.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, mock.Anything).Return(fakeTrigger, nil)
-				clientsMock.ApiInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-				clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, mock.Anything).Return(fakeTrigger, nil)
+				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.EVERYONE, []string{}, nil).Once()
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
@@ -178,7 +178,7 @@ func TestTriggersUpdateCommand(t *testing.T) {
 						},
 					},
 				}
-				clientsMock.ApiInterface.AssertCalled(t, "WorkflowsTriggersUpdate", mock.Anything, mock.Anything, expectedTriggerRequest)
+				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersUpdate", mock.Anything, mock.Anything, expectedTriggerRequest)
 			},
 		},
 		"only pass --workflow and --trigger-id, with interactivity and custom name": {
@@ -188,9 +188,9 @@ func TestTriggersUpdateCommand(t *testing.T) {
 				appSelectTeardown = setupMockUpdateAppSelection(installedProdApp)
 				// TODO: always a) mock out calls and b) call AddDefaultMocks before making any clients.* calls
 				fakeTrigger := createFakeTrigger(fakeTriggerID, fakeTriggerName, fakeAppID, "shortcut")
-				clientsMock.ApiInterface.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, mock.Anything).Return(fakeTrigger, nil)
-				clientsMock.ApiInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-				clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, mock.Anything).Return(fakeTrigger, nil)
+				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.EVERYONE, []string{}, nil).Once()
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
@@ -219,7 +219,7 @@ func TestTriggersUpdateCommand(t *testing.T) {
 						},
 					},
 				}
-				clientsMock.ApiInterface.AssertCalled(t, "WorkflowsTriggersUpdate", mock.Anything, mock.Anything, expectedTriggerRequest)
+				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersUpdate", mock.Anything, mock.Anything, expectedTriggerRequest)
 			},
 		},
 		"pass all shortcut parameters": {
@@ -229,9 +229,9 @@ func TestTriggersUpdateCommand(t *testing.T) {
 				appSelectTeardown = setupMockUpdateAppSelection(installedProdApp)
 				// TODO: always a) mock out calls and b) call AddDefaultMocks before making any clients.* calls
 				fakeTrigger := createFakeTrigger(fakeTriggerID, "unit tests", fakeAppID, "shortcut")
-				clientsMock.ApiInterface.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, mock.Anything).Return(fakeTrigger, nil)
-				clientsMock.ApiInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-				clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, mock.Anything).Return(fakeTrigger, nil)
+				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.EVERYONE, []string{}, nil).Once()
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
@@ -253,7 +253,7 @@ func TestTriggersUpdateCommand(t *testing.T) {
 						WorkflowAppID: fakeAppID,
 					},
 				}
-				clientsMock.ApiInterface.AssertCalled(t, "WorkflowsTriggersUpdate", mock.Anything, mock.Anything, expectedTriggerRequest)
+				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersUpdate", mock.Anything, mock.Anything, expectedTriggerRequest)
 			},
 		},
 		"api call fails": {
@@ -261,7 +261,7 @@ func TestTriggersUpdateCommand(t *testing.T) {
 			ExpectedErrorStrings: []string{"invalid_auth"},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				appSelectTeardown = setupMockUpdateAppSelection(installedProdApp)
-				clientsMock.ApiInterface.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, mock.Anything).Return(types.DeployedTrigger{}, errors.New("invalid_auth"))
+				clientsMock.APIInterface.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, mock.Anything).Return(types.DeployedTrigger{}, errors.New("invalid_auth"))
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
 				err := clients.AppClient().SaveDeployed(ctx, fakeApp)
@@ -278,9 +278,9 @@ func TestTriggersUpdateCommand(t *testing.T) {
 				appSelectTeardown = setupMockUpdateAppSelection(installedProdApp)
 				// TODO: always a) mock out calls and b) call AddDefaultMocks before making any clients.* calls
 				fakeTrigger := createFakeTrigger(fakeTriggerID, "name", fakeAppID, "scheduled")
-				clientsMock.ApiInterface.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, mock.Anything).Return(fakeTrigger, nil)
-				clientsMock.ApiInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-				clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, mock.Anything).Return(fakeTrigger, nil)
+				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.EVERYONE, []string{}, nil).Once()
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
@@ -309,10 +309,10 @@ func TestTriggersUpdateCommand(t *testing.T) {
 						Description:   "desc",
 						Workflow:      "#/workflows/my_workflow",
 						WorkflowAppID: fakeAppID,
-						Schedule:      types.ToRawJson(`{"start_time":"2020-03-15","frequency":{"type":"daily"}}`),
+						Schedule:      types.ToRawJSON(`{"start_time":"2020-03-15","frequency":{"type":"daily"}}`),
 					},
 				}
-				clientsMock.ApiInterface.AssertCalled(t, "WorkflowsTriggersUpdate", mock.Anything, mock.Anything, expectedTriggerRequest)
+				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersUpdate", mock.Anything, mock.Anything, expectedTriggerRequest)
 			},
 		},
 		"--trigger-def, file missing": {
@@ -334,9 +334,9 @@ func TestTriggersUpdateCommand(t *testing.T) {
 			ExpectedErrorStrings: []string{"unexpected end of JSON"},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				appSelectTeardown = setupMockUpdateAppSelection(installedProdApp)
-				clientsMock.ApiInterface.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, mock.Anything).Return(types.DeployedTrigger{}, nil)
-				clientsMock.ApiInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-				clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, mock.Anything).Return(types.DeployedTrigger{}, nil)
+				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.EVERYONE, []string{}, nil).Once()
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
@@ -415,12 +415,12 @@ func TestTriggersUpdateCommand_MissingParameters(t *testing.T) {
 						Type: "slack#/types/interactivity",
 					},
 				}
-				clientsMock.ApiInterface.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, triggerRequestMissingInputs).Return(types.DeployedTrigger{}, extendedErr)
+				clientsMock.APIInterface.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, triggerRequestMissingInputs).Return(types.DeployedTrigger{}, extendedErr)
 
 				fakeTrigger := createFakeTrigger(fakeTriggerID, "unit tests", fakeAppID, "shortcut")
-				clientsMock.ApiInterface.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, triggerRequestWithInteractivityInputs).Return(fakeTrigger, nil)
-				clientsMock.ApiInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-				clientsMock.ApiInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.APIInterface.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, triggerRequestWithInteractivityInputs).Return(fakeTrigger, nil)
+				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.EVERYONE, []string{}, nil).Once()
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
@@ -432,8 +432,8 @@ func TestTriggersUpdateCommand_MissingParameters(t *testing.T) {
 				promptForInteractivityTeardown()
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.ApiInterface.AssertCalled(t, "WorkflowsTriggersUpdate", mock.Anything, mock.Anything, triggerRequestMissingInputs)
-				clientsMock.ApiInterface.AssertCalled(t, "WorkflowsTriggersUpdate", mock.Anything, mock.Anything, triggerRequestWithInteractivityInputs)
+				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersUpdate", mock.Anything, mock.Anything, triggerRequestMissingInputs)
+				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersUpdate", mock.Anything, mock.Anything, triggerRequestWithInteractivityInputs)
 			},
 		},
 		"initial api call fails, missing interactivity, fails on retry": {
@@ -450,9 +450,9 @@ func TestTriggersUpdateCommand_MissingParameters(t *testing.T) {
 						Type: "slack#/types/interactivity",
 					},
 				}
-				clientsMock.ApiInterface.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, triggerRequestMissingInputs).Return(types.DeployedTrigger{}, extendedErr)
+				clientsMock.APIInterface.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, triggerRequestMissingInputs).Return(types.DeployedTrigger{}, extendedErr)
 
-				clientsMock.ApiInterface.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, triggerRequestWithInteractivityInputs).Return(types.DeployedTrigger{}, errors.New("internal_error"))
+				clientsMock.APIInterface.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, triggerRequestWithInteractivityInputs).Return(types.DeployedTrigger{}, errors.New("internal_error"))
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
 				err := clients.AppClient().SaveDeployed(ctx, fakeApp)
@@ -463,8 +463,8 @@ func TestTriggersUpdateCommand_MissingParameters(t *testing.T) {
 				promptForInteractivityTeardown()
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.ApiInterface.AssertCalled(t, "WorkflowsTriggersUpdate", mock.Anything, mock.Anything, triggerRequestMissingInputs)
-				clientsMock.ApiInterface.AssertCalled(t, "WorkflowsTriggersUpdate", mock.Anything, mock.Anything, triggerRequestWithInteractivityInputs)
+				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersUpdate", mock.Anything, mock.Anything, triggerRequestMissingInputs)
+				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersUpdate", mock.Anything, mock.Anything, triggerRequestWithInteractivityInputs)
 			},
 		},
 		"initial api call fails, missing a different type": {
@@ -481,7 +481,7 @@ func TestTriggersUpdateCommand_MissingParameters(t *testing.T) {
 						Type: "number",
 					},
 				}
-				clientsMock.ApiInterface.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, mock.Anything).Return(types.DeployedTrigger{}, extendedErr)
+				clientsMock.APIInterface.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, mock.Anything).Return(types.DeployedTrigger{}, extendedErr)
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
 				err := clients.AppClient().SaveDeployed(ctx, fakeApp)
@@ -492,7 +492,7 @@ func TestTriggersUpdateCommand_MissingParameters(t *testing.T) {
 				promptForInteractivityTeardown()
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.ApiInterface.AssertCalled(t, "WorkflowsTriggersUpdate", mock.Anything, mock.Anything, mock.Anything)
+				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersUpdate", mock.Anything, mock.Anything, mock.Anything)
 			},
 		},
 	}, func(clients *shared.ClientFactory) *cobra.Command {

--- a/internal/api/activity.go
+++ b/internal/api/activity.go
@@ -35,12 +35,12 @@ type ActivityResult struct {
 }
 
 type Activity struct {
-	TraceId       string                 `json:"trace_id,omitempty"`
+	TraceID       string                 `json:"trace_id,omitempty"`
 	Level         types.ActivityLevel    `json:"level,omitempty"`
 	EventType     types.EventType        `json:"event_type,omitempty"`
 	Source        string                 `json:"source,omitempty"`
 	ComponentType string                 `json:"component_type,omitempty"`
-	ComponentId   string                 `json:"component_id,omitempty"`
+	ComponentID   string                 `json:"component_id,omitempty"`
 	Payload       map[string]interface{} `json:"payload,omitempty"`
 	Created       int64                  `json:"created,omitempty"`
 }
@@ -68,12 +68,12 @@ func (c *Client) Activity(ctx context.Context, token string, activityRequest typ
 	span, ctx = opentracing.StartSpanFromContext(ctx, "apiclient.Activity")
 	defer span.Finish()
 
-	if activityRequest.AppId == "" {
+	if activityRequest.AppID == "" {
 		return ActivityResult{}, slackerror.New("app is not deployed")
 	}
 
 	// Add the mandatory app_id field
-	url := fmt.Sprintf("%s?app_id=%s", appActivityMethod, activityRequest.AppId)
+	url := fmt.Sprintf("%s?app_id=%s", appActivityMethod, activityRequest.AppID)
 
 	// Along with any optional filters requested
 	url += fmt.Sprintf("&limit=%d", activityRequest.Limit)
@@ -98,16 +98,16 @@ func (c *Client) Activity(ctx context.Context, token string, activityRequest typ
 		url += fmt.Sprintf("&component_type=%s", activityRequest.ComponentType)
 	}
 
-	if activityRequest.ComponentId != "" {
-		url += fmt.Sprintf("&component_id=%s", activityRequest.ComponentId)
+	if activityRequest.ComponentID != "" {
+		url += fmt.Sprintf("&component_id=%s", activityRequest.ComponentID)
 	}
 
 	if activityRequest.Source != "" {
 		url += fmt.Sprintf("&source=%s", activityRequest.Source)
 	}
 
-	if activityRequest.TraceId != "" {
-		url += fmt.Sprintf("&trace_id=%s", activityRequest.TraceId)
+	if activityRequest.TraceID != "" {
+		url += fmt.Sprintf("&trace_id=%s", activityRequest.TraceID)
 	}
 
 	b, err := c.get(ctx, url, token, "")
@@ -116,13 +116,13 @@ func (c *Client) Activity(ctx context.Context, token string, activityRequest typ
 	}
 
 	resp := activityResponse{}
-	err = goutils.JsonUnmarshal(b, &resp)
+	err = goutils.JSONUnmarshal(b, &resp)
 	if err != nil {
-		return ActivityResult{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appActivityMethod)
+		return ActivityResult{}, errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(appActivityMethod)
 	}
 
 	if !resp.Ok {
-		return ActivityResult{}, slackerror.NewApiError(resp.Error, resp.Description, resp.Errors, appActivityMethod)
+		return ActivityResult{}, slackerror.NewAPIError(resp.Error, resp.Description, resp.Errors, appActivityMethod)
 	}
 	resp.ActivityResult.NextCursor = resp.ResponseMetadata.NextCursor
 

--- a/internal/api/activity.go
+++ b/internal/api/activity.go
@@ -112,13 +112,13 @@ func (c *Client) Activity(ctx context.Context, token string, activityRequest typ
 
 	b, err := c.get(ctx, url, token, "")
 	if err != nil {
-		return ActivityResult{}, errHttpRequestFailed.WithRootCause(err)
+		return ActivityResult{}, errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	resp := activityResponse{}
 	err = goutils.JsonUnmarshal(b, &resp)
 	if err != nil {
-		return ActivityResult{}, errHttpResponseInvalid.WithRootCause(err).AddApiMethod(appActivityMethod)
+		return ActivityResult{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appActivityMethod)
 	}
 
 	if !resp.Ok {

--- a/internal/api/activity_test.go
+++ b/internal/api/activity_test.go
@@ -194,7 +194,7 @@ func Test_ApiClient_ActivityInvalidResponse(t *testing.T) {
 		AppId: "A123",
 	})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), slackerror.ErrHttpResponseInvalid)
+	require.Contains(t, err.Error(), slackerror.ErrHTTPResponseInvalid)
 }
 
 func Test_ApiClient_ActivityInvalidJSON(t *testing.T) {
@@ -209,5 +209,5 @@ func Test_ApiClient_ActivityInvalidJSON(t *testing.T) {
 		AppId: "A123",
 	})
 	require.Error(t, err)
-	require.Contains(t, err.Error(), slackerror.ErrUnableToParseJson)
+	require.Contains(t, err.Error(), slackerror.ErrUnableToParseJSON)
 }

--- a/internal/api/activity_test.go
+++ b/internal/api/activity_test.go
@@ -27,20 +27,20 @@ var fakeResult = `{"ok":true,
 "activities": [{"trace_id":"12345"}]
 }`
 
-func Test_ApiClient_ActivityErrorsIfAppIdIsEmpty(t *testing.T) {
+func Test_APIClient_ActivityErrorsIfAppIDIsEmpty(t *testing.T) {
 	ctx := slackcontext.MockContext(t.Context())
 	c, teardown := NewFakeClient(t, FakeClientParams{
 		ExpectedMethod: appActivityMethod,
 	})
 	defer teardown()
 	_, err := c.Activity(ctx, "token", types.ActivityRequest{
-		AppId: "",
+		AppID: "",
 	})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "app is not deployed")
 }
 
-func Test_ApiClient_ActivityBasicSuccessfulGET(t *testing.T) {
+func Test_APIClient_ActivityBasicSuccessfulGET(t *testing.T) {
 	ctx := slackcontext.MockContext(t.Context())
 	c, teardown := NewFakeClient(t, FakeClientParams{
 		ExpectedMethod:      appActivityMethod,
@@ -49,13 +49,13 @@ func Test_ApiClient_ActivityBasicSuccessfulGET(t *testing.T) {
 	})
 	defer teardown()
 	result, err := c.Activity(ctx, "token", types.ActivityRequest{
-		AppId: "A123",
+		AppID: "A123",
 	})
 	require.NoError(t, err)
-	require.Equal(t, result.Activities[0].TraceId, "12345")
+	require.Equal(t, result.Activities[0].TraceID, "12345")
 }
 
-func Test_ApiClient_ActivityEventType(t *testing.T) {
+func Test_APIClient_ActivityEventType(t *testing.T) {
 	ctx := slackcontext.MockContext(t.Context())
 	c, teardown := NewFakeClient(t, FakeClientParams{
 		ExpectedMethod:      appActivityMethod,
@@ -64,14 +64,14 @@ func Test_ApiClient_ActivityEventType(t *testing.T) {
 	})
 	defer teardown()
 	result, err := c.Activity(ctx, "token", types.ActivityRequest{
-		AppId:     "A123",
+		AppID:     "A123",
 		EventType: "silly",
 	})
 	require.NoError(t, err)
-	require.Equal(t, result.Activities[0].TraceId, "12345")
+	require.Equal(t, result.Activities[0].TraceID, "12345")
 }
 
-func Test_ApiClient_ActivityLogLevel(t *testing.T) {
+func Test_APIClient_ActivityLogLevel(t *testing.T) {
 	ctx := slackcontext.MockContext(t.Context())
 	c, teardown := NewFakeClient(t, FakeClientParams{
 		ExpectedMethod:      appActivityMethod,
@@ -80,14 +80,14 @@ func Test_ApiClient_ActivityLogLevel(t *testing.T) {
 	})
 	defer teardown()
 	result, err := c.Activity(ctx, "token", types.ActivityRequest{
-		AppId:           "A123",
+		AppID:           "A123",
 		MinimumLogLevel: "silly",
 	})
 	require.NoError(t, err)
-	require.Equal(t, result.Activities[0].TraceId, "12345")
+	require.Equal(t, result.Activities[0].TraceID, "12345")
 }
 
-func Test_ApiClient_ActivityMinDateCreated(t *testing.T) {
+func Test_APIClient_ActivityMinDateCreated(t *testing.T) {
 	ctx := slackcontext.MockContext(t.Context())
 	c, teardown := NewFakeClient(t, FakeClientParams{
 		ExpectedMethod:      appActivityMethod,
@@ -96,14 +96,14 @@ func Test_ApiClient_ActivityMinDateCreated(t *testing.T) {
 	})
 	defer teardown()
 	result, err := c.Activity(ctx, "token", types.ActivityRequest{
-		AppId:              "A123",
+		AppID:              "A123",
 		MinimumDateCreated: 1337,
 	})
 	require.NoError(t, err)
-	require.Equal(t, result.Activities[0].TraceId, "12345")
+	require.Equal(t, result.Activities[0].TraceID, "12345")
 }
 
-func Test_ApiClient_ActivityComponentType(t *testing.T) {
+func Test_APIClient_ActivityComponentType(t *testing.T) {
 	ctx := slackcontext.MockContext(t.Context())
 	c, teardown := NewFakeClient(t, FakeClientParams{
 		ExpectedMethod:      appActivityMethod,
@@ -112,14 +112,14 @@ func Test_ApiClient_ActivityComponentType(t *testing.T) {
 	})
 	defer teardown()
 	result, err := c.Activity(ctx, "token", types.ActivityRequest{
-		AppId:         "A123",
+		AppID:         "A123",
 		ComponentType: "defirbulator",
 	})
 	require.NoError(t, err)
-	require.Equal(t, result.Activities[0].TraceId, "12345")
+	require.Equal(t, result.Activities[0].TraceID, "12345")
 }
 
-func Test_ApiClient_ActivityComponentId(t *testing.T) {
+func Test_APIClient_ActivityComponentID(t *testing.T) {
 	ctx := slackcontext.MockContext(t.Context())
 	c, teardown := NewFakeClient(t, FakeClientParams{
 		ExpectedMethod:      appActivityMethod,
@@ -128,14 +128,14 @@ func Test_ApiClient_ActivityComponentId(t *testing.T) {
 	})
 	defer teardown()
 	result, err := c.Activity(ctx, "token", types.ActivityRequest{
-		AppId:       "A123",
-		ComponentId: "raspberry",
+		AppID:       "A123",
+		ComponentID: "raspberry",
 	})
 	require.NoError(t, err)
-	require.Equal(t, result.Activities[0].TraceId, "12345")
+	require.Equal(t, result.Activities[0].TraceID, "12345")
 }
 
-func Test_ApiClient_ActivitySource(t *testing.T) {
+func Test_APIClient_ActivitySource(t *testing.T) {
 	ctx := slackcontext.MockContext(t.Context())
 	c, teardown := NewFakeClient(t, FakeClientParams{
 		ExpectedMethod:      appActivityMethod,
@@ -144,14 +144,14 @@ func Test_ApiClient_ActivitySource(t *testing.T) {
 	})
 	defer teardown()
 	result, err := c.Activity(ctx, "token", types.ActivityRequest{
-		AppId:  "A123",
+		AppID:  "A123",
 		Source: "beer",
 	})
 	require.NoError(t, err)
-	require.Equal(t, result.Activities[0].TraceId, "12345")
+	require.Equal(t, result.Activities[0].TraceID, "12345")
 }
 
-func Test_ApiClient_ActivityTraceId(t *testing.T) {
+func Test_APIClient_ActivityTraceID(t *testing.T) {
 	ctx := slackcontext.MockContext(t.Context())
 	c, teardown := NewFakeClient(t, FakeClientParams{
 		ExpectedMethod:      appActivityMethod,
@@ -160,14 +160,14 @@ func Test_ApiClient_ActivityTraceId(t *testing.T) {
 	})
 	defer teardown()
 	result, err := c.Activity(ctx, "token", types.ActivityRequest{
-		AppId:   "A123",
-		TraceId: "stealth",
+		AppID:   "A123",
+		TraceID: "stealth",
 	})
 	require.NoError(t, err)
-	require.Equal(t, result.Activities[0].TraceId, "12345")
+	require.Equal(t, result.Activities[0].TraceID, "12345")
 }
 
-func Test_ApiClient_ActivityResponseNotOK(t *testing.T) {
+func Test_APIClient_ActivityResponseNotOK(t *testing.T) {
 	ctx := slackcontext.MockContext(t.Context())
 	c, teardown := NewFakeClient(t, FakeClientParams{
 		ExpectedMethod:      appActivityMethod,
@@ -176,13 +176,13 @@ func Test_ApiClient_ActivityResponseNotOK(t *testing.T) {
 	})
 	defer teardown()
 	_, err := c.Activity(ctx, "token", types.ActivityRequest{
-		AppId: "A123",
+		AppID: "A123",
 	})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "internal_error")
 }
 
-func Test_ApiClient_ActivityInvalidResponse(t *testing.T) {
+func Test_APIClient_ActivityInvalidResponse(t *testing.T) {
 	ctx := slackcontext.MockContext(t.Context())
 	c, teardown := NewFakeClient(t, FakeClientParams{
 		ExpectedMethod:      appActivityMethod,
@@ -191,13 +191,13 @@ func Test_ApiClient_ActivityInvalidResponse(t *testing.T) {
 	})
 	defer teardown()
 	_, err := c.Activity(ctx, "token", types.ActivityRequest{
-		AppId: "A123",
+		AppID: "A123",
 	})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), slackerror.ErrHTTPResponseInvalid)
 }
 
-func Test_ApiClient_ActivityInvalidJSON(t *testing.T) {
+func Test_APIClient_ActivityInvalidJSON(t *testing.T) {
 	ctx := slackcontext.MockContext(t.Context())
 	c, teardown := NewFakeClient(t, FakeClientParams{
 		ExpectedMethod:      appActivityMethod,
@@ -206,7 +206,7 @@ func Test_ApiClient_ActivityInvalidJSON(t *testing.T) {
 	})
 	defer teardown()
 	_, err := c.Activity(ctx, "token", types.ActivityRequest{
-		AppId: "A123",
+		AppID: "A123",
 	})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), slackerror.ErrUnableToParseJSON)

--- a/internal/api/api_mock.go
+++ b/internal/api/api_mock.go
@@ -23,344 +23,344 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-type ApiMock struct {
+type APIMock struct {
 	mock.Mock
 }
 
 // WorkflowsClient
 
-func (m *ApiMock) AddDefaultMocks() {
+func (m *APIMock) AddDefaultMocks() {
 	m.On("Host").Return("https://slack.com")
 }
 
-func (m *ApiMock) WorkflowsTriggersCreate(ctx context.Context, token string, createRequest TriggerRequest) (types.DeployedTrigger, error) {
+func (m *APIMock) WorkflowsTriggersCreate(ctx context.Context, token string, createRequest TriggerRequest) (types.DeployedTrigger, error) {
 	args := m.Called(ctx, token, createRequest)
 	return args.Get(0).(types.DeployedTrigger), args.Error(1)
 }
 
-func (m *ApiMock) WorkflowsTriggersUpdate(ctx context.Context, token string, updateRequest TriggerUpdateRequest) (types.DeployedTrigger, error) {
+func (m *APIMock) WorkflowsTriggersUpdate(ctx context.Context, token string, updateRequest TriggerUpdateRequest) (types.DeployedTrigger, error) {
 	args := m.Called(ctx, token, updateRequest)
 	return args.Get(0).(types.DeployedTrigger), args.Error(1)
 }
 
-func (m *ApiMock) WorkflowsTriggersDelete(ctx context.Context, token string, triggerId string) error {
-	args := m.Called(ctx, token, triggerId)
+func (m *APIMock) WorkflowsTriggersDelete(ctx context.Context, token string, triggerID string) error {
+	args := m.Called(ctx, token, triggerID)
 	return args.Error(0)
 }
 
-func (m *ApiMock) WorkflowsTriggersInfo(ctx context.Context, token string, triggerId string) (types.DeployedTrigger, error) {
-	args := m.Called(ctx, token, triggerId)
+func (m *APIMock) WorkflowsTriggersInfo(ctx context.Context, token string, triggerID string) (types.DeployedTrigger, error) {
+	args := m.Called(ctx, token, triggerID)
 	return args.Get(0).(types.DeployedTrigger), args.Error(1)
 }
 
-func (m *ApiMock) WorkflowsTriggersList(ctx context.Context, token string, listArgs TriggerListRequest) ([]types.DeployedTrigger, string, error) {
+func (m *APIMock) WorkflowsTriggersList(ctx context.Context, token string, listArgs TriggerListRequest) ([]types.DeployedTrigger, string, error) {
 	args := m.Called(ctx, token, listArgs)
 	return args.Get(0).([]types.DeployedTrigger), args.Get(1).(string), args.Error(2)
 }
 
 // SessionsClient
 
-func (m *ApiMock) ValidateSession(ctx context.Context, token string) (AuthSession, error) {
+func (m *APIMock) ValidateSession(ctx context.Context, token string) (AuthSession, error) {
 	args := m.Called(ctx, token)
 	return args.Get(0).(AuthSession), args.Error(1)
 }
 
-func (m *ApiMock) RevokeToken(ctx context.Context, token string) error {
+func (m *APIMock) RevokeToken(ctx context.Context, token string) error {
 	args := m.Called(ctx, token)
 	return args.Error(0)
 }
 
 // TriggerAccessClient
 
-func (m *ApiMock) TriggerPermissionsList(ctx context.Context, token, triggerID string) (types.Permission, []string, error) {
+func (m *APIMock) TriggerPermissionsList(ctx context.Context, token, triggerID string) (types.Permission, []string, error) {
 	args := m.Called(ctx, token, triggerID)
 	return args.Get(0).(types.Permission), args.Get(1).([]string), args.Error(2)
 }
 
-func (m *ApiMock) TriggerPermissionsSet(ctx context.Context, token, triggerID, entities string, distributionType types.Permission, entityType string) ([]string, error) {
+func (m *APIMock) TriggerPermissionsSet(ctx context.Context, token, triggerID, entities string, distributionType types.Permission, entityType string) ([]string, error) {
 	args := m.Called(ctx, token, triggerID, entities, distributionType, entityType)
 	return args.Get(0).([]string), args.Error(1)
 }
 
-func (m *ApiMock) TriggerPermissionsAddEntities(ctx context.Context, token, triggerID, entities string, entityType string) error {
+func (m *APIMock) TriggerPermissionsAddEntities(ctx context.Context, token, triggerID, entities string, entityType string) error {
 	args := m.Called(ctx, token, triggerID, entities, entityType)
 	return args.Error(0)
 }
 
-func (m *ApiMock) TriggerPermissionsRemoveEntities(ctx context.Context, token, triggerID, entities string, entityType string) error {
+func (m *APIMock) TriggerPermissionsRemoveEntities(ctx context.Context, token, triggerID, entities string, entityType string) error {
 	args := m.Called(ctx, token, triggerID, entities, entityType)
 	return args.Error(0)
 }
 
 // Collaborator management
 
-func (m *ApiMock) AddCollaborator(ctx context.Context, token, appID string, slackUser types.SlackUser) error {
+func (m *APIMock) AddCollaborator(ctx context.Context, token, appID string, slackUser types.SlackUser) error {
 	args := m.Called(ctx, token, appID, slackUser)
 	return args.Error(0)
 }
 
-func (m *ApiMock) ListCollaborators(ctx context.Context, token, appID string) ([]types.SlackUser, error) {
+func (m *APIMock) ListCollaborators(ctx context.Context, token, appID string) ([]types.SlackUser, error) {
 	args := m.Called(ctx, token, appID)
 	return args.Get(0).([]types.SlackUser), args.Error(1)
 }
 
-func (m *ApiMock) RemoveCollaborator(ctx context.Context, token, appID string, slackUser types.SlackUser) (slackerror.Warnings, error) {
+func (m *APIMock) RemoveCollaborator(ctx context.Context, token, appID string, slackUser types.SlackUser) (slackerror.Warnings, error) {
 	args := m.Called(ctx, token, appID, slackUser)
 	return nil, args.Error(0)
 }
 
-func (m *ApiMock) UpdateCollaborator(ctx context.Context, token, appID string, slackUser types.SlackUser) error {
+func (m *APIMock) UpdateCollaborator(ctx context.Context, token, appID string, slackUser types.SlackUser) error {
 	args := m.Called(ctx, token, appID, slackUser)
 	return args.Error(0)
 }
 
 // ActivityClient
 
-func (m *ApiMock) Activity(ctx context.Context, token string, activityRequest types.ActivityRequest) (ActivityResult, error) {
+func (m *APIMock) Activity(ctx context.Context, token string, activityRequest types.ActivityRequest) (ActivityResult, error) {
 	args := m.Called(ctx, token, activityRequest)
 	return args.Get(0).(ActivityResult), args.Error(1)
 }
 
 // AuthClient
 
-func (m *ApiMock) ExchangeAuthTicket(ctx context.Context, ticket string, challenge string, cliVersion string) (ExchangeAuthTicketResult, error) {
+func (m *APIMock) ExchangeAuthTicket(ctx context.Context, ticket string, challenge string, cliVersion string) (ExchangeAuthTicketResult, error) {
 	args := m.Called(ctx, ticket, challenge, cliVersion)
 	return args.Get(0).(ExchangeAuthTicketResult), args.Error(1)
 }
 
-func (m *ApiMock) GenerateAuthTicket(ctx context.Context, cliVersion string, serviceTokenFlag bool) (GenerateAuthTicketResult, error) {
+func (m *APIMock) GenerateAuthTicket(ctx context.Context, cliVersion string, serviceTokenFlag bool) (GenerateAuthTicketResult, error) {
 	args := m.Called(ctx, cliVersion, serviceTokenFlag)
 	return args.Get(0).(GenerateAuthTicketResult), args.Error(1)
 }
 
-func (m *ApiMock) RotateToken(ctx context.Context, auth types.SlackAuth) (RotateTokenResult, error) {
+func (m *APIMock) RotateToken(ctx context.Context, auth types.SlackAuth) (RotateTokenResult, error) {
 	args := m.Called(ctx, auth)
 	return args.Get(0).(RotateTokenResult), args.Error(1)
 }
 
 // UserClient
 
-func (m *ApiMock) UsersInfo(ctx context.Context, token, userID string) (*types.UserInfo, error) {
+func (m *APIMock) UsersInfo(ctx context.Context, token, userID string) (*types.UserInfo, error) {
 	args := m.Called(ctx, token, userID)
 	return args.Get(0).(*types.UserInfo), args.Error(1)
 }
 
 // ChannelClient
 
-func (m *ApiMock) ChannelsInfo(ctx context.Context, token, channelID string) (*types.ChannelInfo, error) {
+func (m *APIMock) ChannelsInfo(ctx context.Context, token, channelID string) (*types.ChannelInfo, error) {
 	args := m.Called(ctx, token, channelID)
 	return args.Get(0).(*types.ChannelInfo), args.Error(1)
 }
 
 // TeamClient (team and organization share the same client)
 
-func (m *ApiMock) TeamsInfo(ctx context.Context, token, teamID string) (*types.TeamInfo, error) {
+func (m *APIMock) TeamsInfo(ctx context.Context, token, teamID string) (*types.TeamInfo, error) {
 	args := m.Called(ctx, token, teamID)
 	return args.Get(0).(*types.TeamInfo), args.Error(1)
 }
 
-func (m *ApiMock) AuthTeamsList(ctx context.Context, token string, limit int) ([]types.TeamInfo, string, error) {
+func (m *APIMock) AuthTeamsList(ctx context.Context, token string, limit int) ([]types.TeamInfo, string, error) {
 	args := m.Called(ctx, token)
 	return args.Get(0).([]types.TeamInfo), args.String(1), args.Error(2)
 }
 
 // ExternalAuthClient
 
-func (m *ApiMock) AppsAuthExternalStart(ctx context.Context, token, appID, providerKey string) (string, error) {
+func (m *APIMock) AppsAuthExternalStart(ctx context.Context, token, appID, providerKey string) (string, error) {
 	args := m.Called(ctx, token, appID, providerKey)
 	return args.Get(0).(string), args.Error(1)
 }
 
-func (m *ApiMock) AppsAuthExternalDelete(ctx context.Context, token, appID, providerKey string, externalTokenId string) error {
-	args := m.Called(ctx, token, appID, providerKey, externalTokenId)
+func (m *APIMock) AppsAuthExternalDelete(ctx context.Context, token, appID, providerKey string, externalTokenID string) error {
+	args := m.Called(ctx, token, appID, providerKey, externalTokenID)
 	return args.Error(0)
 }
 
-func (m *ApiMock) AppsAuthExternalList(ctx context.Context, token, appID string, includeWorkflows bool) (types.ExternalAuthorizationInfoLists, error) {
+func (m *APIMock) AppsAuthExternalList(ctx context.Context, token, appID string, includeWorkflows bool) (types.ExternalAuthorizationInfoLists, error) {
 	args := m.Called(ctx, token, appID)
 	return args.Get(0).(types.ExternalAuthorizationInfoLists), args.Error(1)
 }
 
-func (m *ApiMock) AppsAuthExternalClientSecretAdd(ctx context.Context, token, appID, providerKey, clientSecret string) error {
+func (m *APIMock) AppsAuthExternalClientSecretAdd(ctx context.Context, token, appID, providerKey, clientSecret string) error {
 	args := m.Called(ctx, token, appID, providerKey, clientSecret)
 	return args.Error(0)
 }
 
-func (m *ApiMock) AppsAuthExternalSelectAuth(ctx context.Context, token, appID, providerKey, workflowId, externalTokenId string) error {
-	args := m.Called(ctx, token, appID, providerKey, workflowId, externalTokenId)
+func (m *APIMock) AppsAuthExternalSelectAuth(ctx context.Context, token, appID, providerKey, workflowID, externalTokenID string) error {
+	args := m.Called(ctx, token, appID, providerKey, workflowID, externalTokenID)
 	return args.Error(0)
 }
 
 // FunctionDistributionClient
 
-func (m *ApiMock) FunctionDistributionList(ctx context.Context, callbackID, appID string) (types.Permission, []types.FunctionDistributionUser, error) {
+func (m *APIMock) FunctionDistributionList(ctx context.Context, callbackID, appID string) (types.Permission, []types.FunctionDistributionUser, error) {
 	args := m.Called(ctx, callbackID, appID)
 	return args.Get(0).(types.Permission), args.Get(1).([]types.FunctionDistributionUser), args.Error(2)
 }
 
-func (m *ApiMock) FunctionDistributionSet(ctx context.Context, callbackID, appID string, distributionType types.Permission, users string) ([]types.FunctionDistributionUser, error) {
+func (m *APIMock) FunctionDistributionSet(ctx context.Context, callbackID, appID string, distributionType types.Permission, users string) ([]types.FunctionDistributionUser, error) {
 	args := m.Called(ctx, callbackID, appID, distributionType, users)
 	return args.Get(0).([]types.FunctionDistributionUser), args.Error(1)
 }
 
-func (m *ApiMock) FunctionDistributionAddUsers(ctx context.Context, callbackID, appID, users string) error {
+func (m *APIMock) FunctionDistributionAddUsers(ctx context.Context, callbackID, appID, users string) error {
 	args := m.Called(ctx, callbackID, appID, users)
 	return args.Error(0)
 }
 
-func (m *ApiMock) FunctionDistributionRemoveUsers(ctx context.Context, callbackID, appID, users string) error {
+func (m *APIMock) FunctionDistributionRemoveUsers(ctx context.Context, callbackID, appID, users string) error {
 	args := m.Called(ctx, callbackID, appID, users)
 	return args.Error(0)
 }
 
 // DatastoresClient
 
-func (m *ApiMock) AppsDatastorePut(ctx context.Context, token string, request types.AppDatastorePut) (types.AppDatastorePutResult, error) {
+func (m *APIMock) AppsDatastorePut(ctx context.Context, token string, request types.AppDatastorePut) (types.AppDatastorePutResult, error) {
 	args := m.Called(ctx, token, request)
 	return args.Get(0).(types.AppDatastorePutResult), args.Error(1)
 }
 
-func (m *ApiMock) AppsDatastoreBulkPut(ctx context.Context, token string, request types.AppDatastoreBulkPut) (types.AppDatastoreBulkPutResult, error) {
+func (m *APIMock) AppsDatastoreBulkPut(ctx context.Context, token string, request types.AppDatastoreBulkPut) (types.AppDatastoreBulkPutResult, error) {
 	args := m.Called(ctx, token, request)
 	return args.Get(0).(types.AppDatastoreBulkPutResult), args.Error(1)
 }
 
-func (m *ApiMock) AppsDatastoreUpdate(ctx context.Context, token string, request types.AppDatastoreUpdate) (types.AppDatastoreUpdateResult, error) {
+func (m *APIMock) AppsDatastoreUpdate(ctx context.Context, token string, request types.AppDatastoreUpdate) (types.AppDatastoreUpdateResult, error) {
 	args := m.Called(ctx, token, request)
 	return args.Get(0).(types.AppDatastoreUpdateResult), args.Error(1)
 }
 
-func (m *ApiMock) AppsDatastoreGet(ctx context.Context, token string, request types.AppDatastoreGet) (types.AppDatastoreGetResult, error) {
+func (m *APIMock) AppsDatastoreGet(ctx context.Context, token string, request types.AppDatastoreGet) (types.AppDatastoreGetResult, error) {
 	args := m.Called(ctx, token, request)
 	return args.Get(0).(types.AppDatastoreGetResult), args.Error(1)
 }
 
-func (m *ApiMock) AppsDatastoreBulkGet(ctx context.Context, token string, request types.AppDatastoreBulkGet) (types.AppDatastoreBulkGetResult, error) {
+func (m *APIMock) AppsDatastoreBulkGet(ctx context.Context, token string, request types.AppDatastoreBulkGet) (types.AppDatastoreBulkGetResult, error) {
 	args := m.Called(ctx, token, request)
 	return args.Get(0).(types.AppDatastoreBulkGetResult), args.Error(1)
 }
 
-func (m *ApiMock) AppsDatastoreDelete(ctx context.Context, token string, request types.AppDatastoreDelete) (types.AppDatastoreDeleteResult, error) {
+func (m *APIMock) AppsDatastoreDelete(ctx context.Context, token string, request types.AppDatastoreDelete) (types.AppDatastoreDeleteResult, error) {
 	args := m.Called(ctx, token, request)
 	return args.Get(0).(types.AppDatastoreDeleteResult), args.Error(1)
 }
 
-func (m *ApiMock) AppsDatastoreBulkDelete(ctx context.Context, token string, request types.AppDatastoreBulkDelete) (types.AppDatastoreBulkDeleteResult, error) {
+func (m *APIMock) AppsDatastoreBulkDelete(ctx context.Context, token string, request types.AppDatastoreBulkDelete) (types.AppDatastoreBulkDeleteResult, error) {
 	args := m.Called(ctx, token, request)
 	return args.Get(0).(types.AppDatastoreBulkDeleteResult), args.Error(1)
 }
 
-func (m *ApiMock) AppsDatastoreQuery(ctx context.Context, token string, query types.AppDatastoreQuery) (types.AppDatastoreQueryResult, error) {
+func (m *APIMock) AppsDatastoreQuery(ctx context.Context, token string, query types.AppDatastoreQuery) (types.AppDatastoreQueryResult, error) {
 	args := m.Called(ctx, token, query)
 	return args.Get(0).(types.AppDatastoreQueryResult), args.Error(1)
 }
 
-func (m *ApiMock) AppsDatastoreCount(ctx context.Context, token string, query types.AppDatastoreCount) (types.AppDatastoreCountResult, error) {
+func (m *APIMock) AppsDatastoreCount(ctx context.Context, token string, query types.AppDatastoreCount) (types.AppDatastoreCountResult, error) {
 	args := m.Called(ctx, token, query)
 	return args.Get(0).(types.AppDatastoreCountResult), args.Error(1)
 }
 
 // StepsClient
 
-func (m *ApiMock) StepsList(ctx context.Context, token string, workflow string, appId string) ([]StepVersion, error) {
-	args := m.Called(ctx, token, workflow, appId)
+func (m *APIMock) StepsList(ctx context.Context, token string, workflow string, appID string) ([]StepVersion, error) {
+	args := m.Called(ctx, token, workflow, appID)
 	return args.Get(0).([]StepVersion), args.Error(1)
 }
 
-func (m *ApiMock) StepsResponsesExport(ctx context.Context, token string, workflow string, appId string, stepId string) error {
-	args := m.Called(ctx, token, workflow, appId, stepId)
+func (m *APIMock) StepsResponsesExport(ctx context.Context, token string, workflow string, appID string, stepID string) error {
+	args := m.Called(ctx, token, workflow, appID, stepID)
 	return args.Error(0)
 }
 
 // AppsClient
 
-func (m *ApiMock) DeleteApp(ctx context.Context, token string, appID string) error {
+func (m *APIMock) DeleteApp(ctx context.Context, token string, appID string) error {
 	args := m.Called(ctx, token, appID)
 	return args.Error(0)
 }
 
-func (m *ApiMock) UninstallApp(ctx context.Context, token string, appID, teamID string) error {
+func (m *APIMock) UninstallApp(ctx context.Context, token string, appID, teamID string) error {
 	args := m.Called(ctx, token, appID, teamID)
 	return args.Error(0)
 }
 
-func (m *ApiMock) GetAppStatus(ctx context.Context, token string, appIDs []string, teamID string) (GetAppStatusResult, error) {
+func (m *APIMock) GetAppStatus(ctx context.Context, token string, appIDs []string, teamID string) (GetAppStatusResult, error) {
 	args := m.Called(ctx, token, appIDs, teamID)
 	return args.Get(0).(GetAppStatusResult), args.Error(1)
 }
 
-func (m *ApiMock) SetHost(host string) {
+func (m *APIMock) SetHost(host string) {
 	m.Called(host)
 }
 
-func (m *ApiMock) CertifiedAppInstall(ctx context.Context, token string, certifiedAppId string) (CertifiedInstallResult, error) {
-	args := m.Called(ctx, token, certifiedAppId)
+func (m *APIMock) CertifiedAppInstall(ctx context.Context, token string, certifiedAppID string) (CertifiedInstallResult, error) {
+	args := m.Called(ctx, token, certifiedAppID)
 	return args.Get(0).(CertifiedInstallResult), args.Error(1)
 }
 
-func (m *ApiMock) RequestAppApproval(ctx context.Context, token string, appID string, teamID string, reason string, scopes string, outgoingDomains []string) (AppsApprovalsRequestsCreateResult, error) {
+func (m *APIMock) RequestAppApproval(ctx context.Context, token string, appID string, teamID string, reason string, scopes string, outgoingDomains []string) (AppsApprovalsRequestsCreateResult, error) {
 	args := m.Called(ctx, token, appID, teamID, reason, scopes, outgoingDomains)
 	return args.Get(0).(AppsApprovalsRequestsCreateResult), args.Error(1)
 }
 
 // VariablesClient
 
-func (m *ApiMock) AddVariable(ctx context.Context, token, appID, name, value string) error {
+func (m *APIMock) AddVariable(ctx context.Context, token, appID, name, value string) error {
 	args := m.Called(ctx, token, appID, name, value)
 	return args.Error(0)
 }
 
-func (m *ApiMock) ListVariables(ctx context.Context, token, appID string) ([]string, error) {
+func (m *APIMock) ListVariables(ctx context.Context, token, appID string) ([]string, error) {
 	args := m.Called(ctx, token, appID)
 	return args.Get(0).([]string), args.Error(1)
 }
 
-func (m *ApiMock) RemoveVariable(ctx context.Context, token string, appID string, variableName string) error {
+func (m *APIMock) RemoveVariable(ctx context.Context, token string, appID string, variableName string) error {
 	args := m.Called(ctx, token, appID, variableName)
 	return args.Error(0)
 }
 
-func (m *ApiMock) Host() string {
+func (m *APIMock) Host() string {
 	args := m.Called()
 	return args.Get(0).(string)
 }
 
-func (m *ApiMock) ConnectionsOpen(ctx context.Context, token string) (AppsConnectionsOpenResult, error) {
+func (m *APIMock) ConnectionsOpen(ctx context.Context, token string) (AppsConnectionsOpenResult, error) {
 	args := m.Called(ctx, token)
 	return args.Get(0).(AppsConnectionsOpenResult), args.Error(1)
 }
 
-func (m *ApiMock) ExportAppManifest(ctx context.Context, token string, appId string) (ExportAppResult, error) {
-	args := m.Called(ctx, token, appId)
+func (m *APIMock) ExportAppManifest(ctx context.Context, token string, appID string) (ExportAppResult, error) {
+	args := m.Called(ctx, token, appID)
 	return args.Get(0).(ExportAppResult), args.Error(1)
 }
 
-func (m *ApiMock) ValidateAppManifest(ctx context.Context, token string, manifest types.AppManifest, appId string) (ValidateAppManifestResult, error) {
-	args := m.Called(ctx, token, manifest, appId)
+func (m *APIMock) ValidateAppManifest(ctx context.Context, token string, manifest types.AppManifest, appID string) (ValidateAppManifestResult, error) {
+	args := m.Called(ctx, token, manifest, appID)
 	return args.Get(0).(ValidateAppManifestResult), args.Error(1)
 }
 
-func (m *ApiMock) CreateApp(ctx context.Context, token string, manifest types.AppManifest, enableDistribution bool) (CreateAppResult, error) {
+func (m *APIMock) CreateApp(ctx context.Context, token string, manifest types.AppManifest, enableDistribution bool) (CreateAppResult, error) {
 	args := m.Called(ctx, token, manifest, enableDistribution)
 	return args.Get(0).(CreateAppResult), args.Error(1)
 }
 
-func (m *ApiMock) UpdateApp(ctx context.Context, token string, appID string, manifest types.AppManifest, forceUpdate bool, continueWithBreakingChanges bool) (UpdateAppResult, error) {
+func (m *APIMock) UpdateApp(ctx context.Context, token string, appID string, manifest types.AppManifest, forceUpdate bool, continueWithBreakingChanges bool) (UpdateAppResult, error) {
 	args := m.Called(ctx, token, appID, manifest, forceUpdate, continueWithBreakingChanges)
 	return args.Get(0).(UpdateAppResult), args.Error(1)
 }
 
-func (m *ApiMock) GetPresignedS3PostParams(ctx context.Context, token string, appID string) (GenerateS3PresignedPostResult, error) {
+func (m *APIMock) GetPresignedS3PostParams(ctx context.Context, token string, appID string) (GenerateS3PresignedPostResult, error) {
 	args := m.Called(ctx, token, appID)
 	return args.Get(0).(GenerateS3PresignedPostResult), args.Error(1)
 }
 
-func (m *ApiMock) UploadApp(ctx context.Context, token, runtime, appID string, fileName string) error {
+func (m *APIMock) UploadApp(ctx context.Context, token, runtime, appID string, fileName string) error {
 	args := m.Called(ctx, token, runtime, appID, fileName)
 	return args.Error(0)
 }
 
-func (m *ApiMock) DeveloperAppInstall(ctx context.Context, IO iostreams.IOStreamer, token string, app types.App, botScopes []string, outgoingDomains []string, orgGrantWorkspaceID string, autoAAARequest bool) (DeveloperAppInstallResult, types.InstallState, error) {
+func (m *APIMock) DeveloperAppInstall(ctx context.Context, IO iostreams.IOStreamer, token string, app types.App, botScopes []string, outgoingDomains []string, orgGrantWorkspaceID string, autoAAARequest bool) (DeveloperAppInstallResult, types.InstallState, error) {
 	args := m.Called(ctx, IO, token, app, botScopes, outgoingDomains, orgGrantWorkspaceID, autoAAARequest)
 	return args.Get(0).(DeveloperAppInstallResult), args.Get(1).(types.InstallState), args.Error(2)
 }

--- a/internal/api/app.go
+++ b/internal/api/app.go
@@ -94,14 +94,14 @@ func (c *Client) CertifiedAppInstall(ctx context.Context, token string, certifie
 	}
 	b, err := c.postJSON(ctx, appCertifiedInstallMethod, token, "", body)
 	if err != nil {
-		return CertifiedInstallResult{}, errHttpRequestFailed.WithRootCause(err)
+		return CertifiedInstallResult{}, errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	resp := certifiedInstallResponse{}
 	err = goutils.JsonUnmarshal(b, &resp)
 
 	if err != nil {
-		return CertifiedInstallResult{}, errHttpResponseInvalid.WithRootCause(err).AddApiMethod(appCertifiedInstallMethod)
+		return CertifiedInstallResult{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appCertifiedInstallMethod)
 	}
 
 	if !resp.Ok {
@@ -170,14 +170,14 @@ func (c *Client) CreateApp(ctx context.Context, token string, manifest types.App
 
 	b, err := c.postJSON(ctx, appManifestCreateMethod, token, "", body)
 	if err != nil {
-		return CreateAppResult{}, errHttpRequestFailed.WithRootCause(err)
+		return CreateAppResult{}, errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	resp := createAppResponse{}
 	err = goutils.JsonUnmarshal(b, &resp)
 
 	if err != nil {
-		return CreateAppResult{}, errHttpResponseInvalid.WithRootCause(err).AddApiMethod(appManifestCreateMethod)
+		return CreateAppResult{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appManifestCreateMethod)
 	}
 
 	if !resp.Ok {
@@ -215,14 +215,14 @@ func (c *Client) ExportAppManifest(ctx context.Context, token, appID string) (Ex
 	}
 	b, err := c.postJSON(ctx, appManifestExportMethod, token, "", body)
 	if err != nil {
-		return ExportAppResult{}, errHttpRequestFailed.WithRootCause(err)
+		return ExportAppResult{}, errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	resp := ExportAppResponse{}
 	err = goutils.JsonUnmarshal(b, &resp)
 
 	if err != nil {
-		return ExportAppResult{}, errHttpResponseInvalid.WithRootCause(err).AddApiMethod(appManifestExportMethod)
+		return ExportAppResult{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appManifestExportMethod)
 	}
 	if !resp.Ok {
 		return ExportAppResult{}, slackerror.NewApiError(resp.Error, resp.Description, resp.Errors, appManifestExportMethod)
@@ -263,7 +263,7 @@ func (c *Client) ValidateAppManifest(ctx context.Context, token string, manifest
 
 	if err != nil {
 		return ValidateAppManifestResult{slackerror.Warnings{}},
-			errHttpRequestFailed.WithRootCause(err)
+			errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	resp := extendedBaseResponse{}
@@ -271,7 +271,7 @@ func (c *Client) ValidateAppManifest(ctx context.Context, token string, manifest
 
 	if err != nil {
 		return ValidateAppManifestResult{slackerror.Warnings{}},
-			errHttpResponseInvalid.WithRootCause(err).AddApiMethod(appManifestValidateMethod)
+			errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appManifestValidateMethod)
 	}
 
 	if resp.Ok && len(resp.Errors) == 0 {
@@ -320,14 +320,14 @@ func (c *Client) UpdateApp(ctx context.Context, token string, appID string, mani
 
 	b, err := c.postJSON(ctx, appManifestUpdateMethod, token, "", body)
 	if err != nil {
-		return UpdateAppResult{}, errHttpRequestFailed.WithRootCause(err)
+		return UpdateAppResult{}, errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	resp := updateAppResponse{}
 	err = goutils.JsonUnmarshal(b, &resp)
 
 	if err != nil {
-		return UpdateAppResult{}, errHttpResponseInvalid.WithRootCause(err).AddApiMethod(appManifestUpdateMethod)
+		return UpdateAppResult{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appManifestUpdateMethod)
 	}
 
 	if !resp.Ok {
@@ -367,14 +367,14 @@ func (c *Client) GetPresignedS3PostParams(ctx context.Context, token string, app
 
 	b, err := c.postJSON(ctx, appGeneratePresignedPostMethod, token, "", body)
 	if err != nil {
-		return GenerateS3PresignedPostResult{}, errHttpRequestFailed.WithRootCause(err)
+		return GenerateS3PresignedPostResult{}, errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	resp := generateS3PresignedPostResponse{}
 	err = goutils.JsonUnmarshal(b, &resp)
 
 	if err != nil {
-		return GenerateS3PresignedPostResult{}, errHttpResponseInvalid.WithRootCause(err).AddApiMethod(appGeneratePresignedPostMethod)
+		return GenerateS3PresignedPostResult{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appGeneratePresignedPostMethod)
 	}
 
 	if !resp.Ok {
@@ -417,14 +417,14 @@ func (c *Client) UploadApp(ctx context.Context, token, runtime, appID string, fi
 
 	b, err := c.postJSON(ctx, appUploadMethod, token, "", body)
 	if err != nil {
-		return errHttpRequestFailed.WithRootCause(err)
+		return errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	resp := uploadAppResponse{}
 	err = goutils.JsonUnmarshal(b, &resp)
 
 	if err != nil {
-		return errHttpResponseInvalid.WithRootCause(err).AddApiMethod(appUploadMethod)
+		return errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appUploadMethod)
 	}
 
 	if !resp.Ok {
@@ -457,14 +457,14 @@ func (c *Client) DeleteApp(ctx context.Context, token string, appID string) erro
 
 	b, err := c.postJSON(ctx, appDeleteMethod, token, "", body)
 	if err != nil {
-		return errHttpRequestFailed.WithRootCause(err)
+		return errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	resp := deleteAppResponse{}
 	err = goutils.JsonUnmarshal(b, &resp)
 
 	if err != nil {
-		return errHttpResponseInvalid.WithRootCause(err).AddApiMethod(appDeleteMethod)
+		return errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appDeleteMethod)
 	}
 
 	if !resp.Ok {
@@ -495,7 +495,7 @@ func (c *Client) UninstallApp(ctx context.Context, token string, appID, teamID s
 
 	b, err := c.postJSON(ctx, appDeveloperUninstallMethod, token, "", body)
 	if err != nil {
-		return errHttpRequestFailed.WithRootCause(err)
+		return errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	resp := struct {
@@ -504,7 +504,7 @@ func (c *Client) UninstallApp(ctx context.Context, token string, appID, teamID s
 	err = goutils.JsonUnmarshal(b, &resp)
 
 	if err != nil {
-		return errHttpResponseInvalid.WithRootCause(err).AddApiMethod(appDeveloperUninstallMethod)
+		return errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appDeveloperUninstallMethod)
 	}
 
 	if !resp.Ok {
@@ -556,14 +556,14 @@ func (c *Client) GetAppStatus(ctx context.Context, token string, appIDs []string
 
 	b, err := c.postJSON(ctx, appStatusMethod, token, "", body)
 	if err != nil {
-		return GetAppStatusResult{}, errHttpRequestFailed.WithRootCause(err)
+		return GetAppStatusResult{}, errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	var resp GetAppStatusResponse
 	err = goutils.JsonUnmarshal(b, &resp)
 
 	if err != nil {
-		return GetAppStatusResult{}, errHttpResponseInvalid.WithRootCause(err).AddApiMethod(appStatusMethod)
+		return GetAppStatusResult{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appStatusMethod)
 	}
 
 	if !resp.Ok {
@@ -605,14 +605,14 @@ func (c *Client) ConnectionsOpen(ctx context.Context, token string) (AppsConnect
 
 	b, err := c.postJSON(ctx, appConnectionsOpenMethod, token, "", body)
 	if err != nil {
-		return AppsConnectionsOpenResult{}, errHttpRequestFailed.WithRootCause(err)
+		return AppsConnectionsOpenResult{}, errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	resp := appsConnectionsOpenResponse{}
 	err = goutils.JsonUnmarshal(b, &resp)
 
 	if err != nil {
-		return AppsConnectionsOpenResult{}, errHttpResponseInvalid.WithRootCause(err).AddApiMethod(appConnectionsOpenMethod)
+		return AppsConnectionsOpenResult{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appConnectionsOpenMethod)
 	}
 
 	if !resp.Ok {
@@ -672,14 +672,14 @@ func (c *Client) DeveloperAppInstall(ctx context.Context, IO iostreams.IOStreame
 
 	b, err := c.postJSON(ctx, appDeveloperInstallMethod, token, "", body)
 	if err != nil {
-		return DeveloperAppInstallResult{}, "", errHttpRequestFailed.WithRootCause(err)
+		return DeveloperAppInstallResult{}, "", errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	var resp developerAppInstallResponse
 	err = goutils.JsonUnmarshal(b, &resp)
 
 	if err != nil {
-		return DeveloperAppInstallResult{}, "", errHttpResponseInvalid.WithRootCause(err).AddApiMethod(appDeveloperInstallMethod)
+		return DeveloperAppInstallResult{}, "", errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appDeveloperInstallMethod)
 	}
 
 	if !resp.Ok {
@@ -818,13 +818,13 @@ func (c *Client) handleAppRequestPendingState(ctx context.Context, IO iostreams.
 
 		b, err := c.postJSON(ctx, appApprovalRequestCancelMethod, token, "", body)
 		if err != nil {
-			return "", errHttpRequestFailed.WithRootCause(err)
+			return "", errHTTPRequestFailed.WithRootCause(err)
 		}
 
 		appsApprovalsRequestsCancelResp := appsApprovalsRequestsCancelResponse{}
 		err = goutils.JsonUnmarshal(b, &appsApprovalsRequestsCancelResp)
 		if err != nil {
-			return "", errHttpResponseInvalid.WithRootCause(err).AddApiMethod(appApprovalRequestCancelMethod)
+			return "", errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appApprovalRequestCancelMethod)
 		}
 
 		if !appsApprovalsRequestsCancelResp.Ok {
@@ -879,13 +879,13 @@ func (c *Client) RequestAppApproval(ctx context.Context, token string, appID str
 
 	b, err := c.postJSON(ctx, appApprovalRequestCreateMethod, token, "", body)
 	if err != nil {
-		return AppsApprovalsRequestsCreateResult{}, errHttpRequestFailed.WithRootCause(err)
+		return AppsApprovalsRequestsCreateResult{}, errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	resp := appsApprovalsRequestsCreateResponse{}
 	err = goutils.JsonUnmarshal(b, &resp)
 	if err != nil {
-		return AppsApprovalsRequestsCreateResult{}, errHttpResponseInvalid.WithRootCause(err).AddApiMethod(appApprovalRequestCreateMethod)
+		return AppsApprovalsRequestsCreateResult{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appApprovalRequestCreateMethod)
 	}
 
 	if !resp.Ok {

--- a/internal/api/app.go
+++ b/internal/api/app.go
@@ -697,7 +697,7 @@ func (c *Client) DeveloperAppInstall(ctx context.Context, IO iostreams.IOStreame
 		return DeveloperAppInstallResult{}, "", slackerror.NewAPIError(resp.Error, resp.Description, resp.Errors, appDeveloperInstallMethod)
 	}
 
-	return resp.DeveloperAppInstallResult, types.SUCCESS, nil
+	return resp.DeveloperAppInstallResult, types.InstallSuccess, nil
 }
 
 // handleAppApprovalStates handles responses from the developerInstall API when admin apps approval (AAA) is on
@@ -773,9 +773,9 @@ func (c *Client) handleAppRequestEligibleState(ctx context.Context, IO iostreams
 		}
 
 		IO.PrintTrace(ctx, slacktrace.AdminAppApprovalRequestPending)
-		return types.REQUEST_PENDING, nil
+		return types.InstallRequestPending, nil
 	} else {
-		return types.REQUEST_NOT_SENT, nil
+		return types.InstallRequestNotSent, nil
 	}
 }
 
@@ -842,13 +842,13 @@ func (c *Client) handleAppRequestPendingState(ctx context.Context, IO iostreams.
 			return "", err
 		}
 
-		if installState != types.REQUEST_PENDING {
-			return types.REQUEST_CANCELLED, nil
+		if installState != types.InstallRequestPending {
+			return types.InstallRequestCancelled, nil
 		} else {
 			return installState, nil
 		}
 	} else {
-		return types.REQUEST_PENDING, nil
+		return types.InstallRequestPending, nil
 	}
 }
 

--- a/internal/api/app.go
+++ b/internal/api/app.go
@@ -49,12 +49,12 @@ const (
 
 // AppsClient is the interface for app-related API calls
 type AppsClient interface {
-	CertifiedAppInstall(ctx context.Context, token string, certifiedAppId string) (CertifiedInstallResult, error)
+	CertifiedAppInstall(ctx context.Context, token string, certifiedAppID string) (CertifiedInstallResult, error)
 	ConnectionsOpen(ctx context.Context, token string) (AppsConnectionsOpenResult, error)
 	CreateApp(ctx context.Context, token string, manifest types.AppManifest, enableDistribution bool) (CreateAppResult, error)
 	DeleteApp(ctx context.Context, token string, appID string) error
 	DeveloperAppInstall(ctx context.Context, IO iostreams.IOStreamer, token string, app types.App, botScopes []string, outgoingDomains []string, orgGrantWorkspaceID string, autoRequestAAA bool) (DeveloperAppInstallResult, types.InstallState, error)
-	ExportAppManifest(ctx context.Context, token string, appId string) (ExportAppResult, error)
+	ExportAppManifest(ctx context.Context, token string, appID string) (ExportAppResult, error)
 	GetAppStatus(ctx context.Context, token string, appIDs []string, teamID string) (GetAppStatusResult, error)
 	GetPresignedS3PostParams(ctx context.Context, token string, appID string) (GenerateS3PresignedPostResult, error)
 	Host() string
@@ -65,7 +65,7 @@ type AppsClient interface {
 	UpdateApp(ctx context.Context, token string, appID string, manifest types.AppManifest, forceUpdate bool, continueWithBreakingChanges bool) (UpdateAppResult, error)
 	UploadApp(ctx context.Context, token, runtime, appID string, fileName string) error
 	UploadPackageToS3(ctx context.Context, fs afero.Fs, appID string, uploadParams GenerateS3PresignedPostResult, archiveFilePath string) (string, error)
-	ValidateAppManifest(ctx context.Context, token string, manifest types.AppManifest, appId string) (ValidateAppManifestResult, error)
+	ValidateAppManifest(ctx context.Context, token string, manifest types.AppManifest, appID string) (ValidateAppManifestResult, error)
 }
 
 // This API returns null
@@ -77,15 +77,15 @@ type certifiedInstallResponse struct {
 }
 
 // CertifiedAppInstall requests the installation of a certified app in order for its connectors to be usable
-func (c *Client) CertifiedAppInstall(ctx context.Context, token string, certifiedAppId string) (CertifiedInstallResult, error) {
+func (c *Client) CertifiedAppInstall(ctx context.Context, token string, certifiedAppID string) (CertifiedInstallResult, error) {
 	var span opentracing.Span
 	span, ctx = opentracing.StartSpanFromContext(ctx, "apiclient.CertifiedAppInstall")
 	defer span.Finish()
 
 	args := struct {
-		AppId string `json:"app_id,omitempty"` // the app id of the certified app
+		AppID string `json:"app_id,omitempty"` // the app id of the certified app
 	}{
-		certifiedAppId,
+		certifiedAppID,
 	}
 
 	body, err := json.Marshal(args)
@@ -98,14 +98,14 @@ func (c *Client) CertifiedAppInstall(ctx context.Context, token string, certifie
 	}
 
 	resp := certifiedInstallResponse{}
-	err = goutils.JsonUnmarshal(b, &resp)
+	err = goutils.JSONUnmarshal(b, &resp)
 
 	if err != nil {
-		return CertifiedInstallResult{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appCertifiedInstallMethod)
+		return CertifiedInstallResult{}, errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(appCertifiedInstallMethod)
 	}
 
 	if !resp.Ok {
-		return CertifiedInstallResult{}, slackerror.NewApiError(resp.Error, resp.Description, resp.Errors, appCertifiedInstallMethod)
+		return CertifiedInstallResult{}, slackerror.NewAPIError(resp.Error, resp.Description, resp.Errors, appCertifiedInstallMethod)
 	}
 
 	return resp.CertifiedInstallResult, nil
@@ -135,7 +135,7 @@ type PresignedPostFields struct {
 type CreateAppResult struct {
 	AppID             string      `json:"app_id,omitempty"`
 	Credentials       Credentials `json:"credentials,omitempty"`
-	OAuthAuthorizeUrl string      `json:"oauth_authorize_url,omitempty"`
+	OAuthAuthorizeURL string      `json:"oauth_authorize_url,omitempty"`
 }
 
 type createAppResponse struct {
@@ -174,14 +174,14 @@ func (c *Client) CreateApp(ctx context.Context, token string, manifest types.App
 	}
 
 	resp := createAppResponse{}
-	err = goutils.JsonUnmarshal(b, &resp)
+	err = goutils.JSONUnmarshal(b, &resp)
 
 	if err != nil {
-		return CreateAppResult{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appManifestCreateMethod)
+		return CreateAppResult{}, errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(appManifestCreateMethod)
 	}
 
 	if !resp.Ok {
-		return CreateAppResult{}, slackerror.NewApiError(resp.Error, resp.Description, resp.Errors, appManifestCreateMethod)
+		return CreateAppResult{}, slackerror.NewAPIError(resp.Error, resp.Description, resp.Errors, appManifestCreateMethod)
 	}
 
 	return resp.CreateAppResult, nil
@@ -219,13 +219,13 @@ func (c *Client) ExportAppManifest(ctx context.Context, token, appID string) (Ex
 	}
 
 	resp := ExportAppResponse{}
-	err = goutils.JsonUnmarshal(b, &resp)
+	err = goutils.JSONUnmarshal(b, &resp)
 
 	if err != nil {
-		return ExportAppResult{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appManifestExportMethod)
+		return ExportAppResult{}, errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(appManifestExportMethod)
 	}
 	if !resp.Ok {
-		return ExportAppResult{}, slackerror.NewApiError(resp.Error, resp.Description, resp.Errors, appManifestExportMethod)
+		return ExportAppResult{}, slackerror.NewAPIError(resp.Error, resp.Description, resp.Errors, appManifestExportMethod)
 	}
 	return resp.ExportAppResult, nil
 }
@@ -235,7 +235,7 @@ type ValidateAppManifestResult struct {
 }
 
 // ValidateAppManifest validates a new Slack app
-func (c *Client) ValidateAppManifest(ctx context.Context, token string, manifest types.AppManifest, appId string) (ValidateAppManifestResult, error) {
+func (c *Client) ValidateAppManifest(ctx context.Context, token string, manifest types.AppManifest, appID string) (ValidateAppManifestResult, error) {
 	var span opentracing.Span
 	span, ctx = opentracing.StartSpanFromContext(ctx, "apiclient.ValidateAppManifest")
 	defer span.Finish()
@@ -246,10 +246,10 @@ func (c *Client) ValidateAppManifest(ctx context.Context, token string, manifest
 	// deployed (slack deploy), but cannot check against apps installed only locally (slack run)
 	args := struct {
 		Manifest types.AppManifest `json:"manifest,omitempty"`
-		AppId    string            `json:"app_id,omitempty"`
+		AppID    string            `json:"app_id,omitempty"`
 	}{
 		manifest,
-		appId,
+		appID,
 	}
 
 	body, err := json.Marshal(args)
@@ -267,11 +267,11 @@ func (c *Client) ValidateAppManifest(ctx context.Context, token string, manifest
 	}
 
 	resp := extendedBaseResponse{}
-	err = goutils.JsonUnmarshal(b, &resp)
+	err = goutils.JSONUnmarshal(b, &resp)
 
 	if err != nil {
 		return ValidateAppManifestResult{slackerror.Warnings{}},
-			errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appManifestValidateMethod)
+			errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(appManifestValidateMethod)
 	}
 
 	if resp.Ok && len(resp.Errors) == 0 {
@@ -279,7 +279,7 @@ func (c *Client) ValidateAppManifest(ctx context.Context, token string, manifest
 	}
 
 	return ValidateAppManifestResult{resp.Warnings},
-		slackerror.NewApiError(resp.Error, resp.Description, resp.Errors, appManifestValidateMethod)
+		slackerror.NewAPIError(resp.Error, resp.Description, resp.Errors, appManifestValidateMethod)
 }
 
 // UpdateAppResult details returned
@@ -324,14 +324,14 @@ func (c *Client) UpdateApp(ctx context.Context, token string, appID string, mani
 	}
 
 	resp := updateAppResponse{}
-	err = goutils.JsonUnmarshal(b, &resp)
+	err = goutils.JSONUnmarshal(b, &resp)
 
 	if err != nil {
-		return UpdateAppResult{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appManifestUpdateMethod)
+		return UpdateAppResult{}, errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(appManifestUpdateMethod)
 	}
 
 	if !resp.Ok {
-		return UpdateAppResult{}, slackerror.NewApiError(resp.Error, resp.Description, resp.Errors, appManifestUpdateMethod)
+		return UpdateAppResult{}, slackerror.NewAPIError(resp.Error, resp.Description, resp.Errors, appManifestUpdateMethod)
 	}
 
 	return resp.UpdateAppResult, nil
@@ -339,7 +339,7 @@ func (c *Client) UpdateApp(ctx context.Context, token string, appID string, mani
 
 // GenerateS3PresignedPost details to be saved
 type GenerateS3PresignedPostResult struct {
-	Url      string              `json:"url"`
+	URL      string              `json:"url"`
 	FileName string              `json:"file_name"`
 	Fields   PresignedPostFields `json:"fields"`
 }
@@ -371,14 +371,14 @@ func (c *Client) GetPresignedS3PostParams(ctx context.Context, token string, app
 	}
 
 	resp := generateS3PresignedPostResponse{}
-	err = goutils.JsonUnmarshal(b, &resp)
+	err = goutils.JSONUnmarshal(b, &resp)
 
 	if err != nil {
-		return GenerateS3PresignedPostResult{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appGeneratePresignedPostMethod)
+		return GenerateS3PresignedPostResult{}, errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(appGeneratePresignedPostMethod)
 	}
 
 	if !resp.Ok {
-		return GenerateS3PresignedPostResult{}, slackerror.NewApiError(resp.Error, resp.Description, resp.Errors, appGeneratePresignedPostMethod)
+		return GenerateS3PresignedPostResult{}, slackerror.NewAPIError(resp.Error, resp.Description, resp.Errors, appGeneratePresignedPostMethod)
 	}
 
 	return resp.GenerateS3PresignedPostResult, nil
@@ -421,14 +421,14 @@ func (c *Client) UploadApp(ctx context.Context, token, runtime, appID string, fi
 	}
 
 	resp := uploadAppResponse{}
-	err = goutils.JsonUnmarshal(b, &resp)
+	err = goutils.JSONUnmarshal(b, &resp)
 
 	if err != nil {
-		return errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appUploadMethod)
+		return errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(appUploadMethod)
 	}
 
 	if !resp.Ok {
-		return slackerror.NewApiError(resp.Error, resp.Description, resp.Errors, appUploadMethod)
+		return slackerror.NewAPIError(resp.Error, resp.Description, resp.Errors, appUploadMethod)
 	}
 
 	return nil
@@ -461,14 +461,14 @@ func (c *Client) DeleteApp(ctx context.Context, token string, appID string) erro
 	}
 
 	resp := deleteAppResponse{}
-	err = goutils.JsonUnmarshal(b, &resp)
+	err = goutils.JSONUnmarshal(b, &resp)
 
 	if err != nil {
-		return errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appDeleteMethod)
+		return errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(appDeleteMethod)
 	}
 
 	if !resp.Ok {
-		return slackerror.NewApiError(resp.Error, resp.Description, resp.Errors, appDeleteMethod)
+		return slackerror.NewAPIError(resp.Error, resp.Description, resp.Errors, appDeleteMethod)
 	}
 
 	return nil
@@ -501,14 +501,14 @@ func (c *Client) UninstallApp(ctx context.Context, token string, appID, teamID s
 	resp := struct {
 		baseResponse
 	}{}
-	err = goutils.JsonUnmarshal(b, &resp)
+	err = goutils.JSONUnmarshal(b, &resp)
 
 	if err != nil {
-		return errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appDeveloperUninstallMethod)
+		return errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(appDeveloperUninstallMethod)
 	}
 
 	if !resp.Ok {
-		return slackerror.NewApiError(resp.Error, resp.Description, nil, appDeveloperUninstallMethod)
+		return slackerror.NewAPIError(resp.Error, resp.Description, nil, appDeveloperUninstallMethod)
 	}
 
 	return nil
@@ -560,14 +560,14 @@ func (c *Client) GetAppStatus(ctx context.Context, token string, appIDs []string
 	}
 
 	var resp GetAppStatusResponse
-	err = goutils.JsonUnmarshal(b, &resp)
+	err = goutils.JSONUnmarshal(b, &resp)
 
 	if err != nil {
-		return GetAppStatusResult{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appStatusMethod)
+		return GetAppStatusResult{}, errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(appStatusMethod)
 	}
 
 	if !resp.Ok {
-		return GetAppStatusResult{}, slackerror.NewApiError(resp.Error, resp.Description, nil, appStatusMethod)
+		return GetAppStatusResult{}, slackerror.NewAPIError(resp.Error, resp.Description, nil, appStatusMethod)
 	}
 
 	return resp.GetAppStatusResult, nil
@@ -588,7 +588,7 @@ type appsApprovalsRequestsCancelResponse struct {
 
 // GenerateS3PresignedPost details to be saved
 type AppsConnectionsOpenResult struct {
-	Url string `json:"url"`
+	URL string `json:"url"`
 }
 type appsConnectionsOpenResponse struct {
 	extendedBaseResponse
@@ -609,14 +609,14 @@ func (c *Client) ConnectionsOpen(ctx context.Context, token string) (AppsConnect
 	}
 
 	resp := appsConnectionsOpenResponse{}
-	err = goutils.JsonUnmarshal(b, &resp)
+	err = goutils.JSONUnmarshal(b, &resp)
 
 	if err != nil {
-		return AppsConnectionsOpenResult{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appConnectionsOpenMethod)
+		return AppsConnectionsOpenResult{}, errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(appConnectionsOpenMethod)
 	}
 
 	if !resp.Ok {
-		return AppsConnectionsOpenResult{}, slackerror.NewApiError(resp.Error, resp.Description, resp.Errors, appConnectionsOpenMethod)
+		return AppsConnectionsOpenResult{}, slackerror.NewAPIError(resp.Error, resp.Description, resp.Errors, appConnectionsOpenMethod)
 	}
 
 	return resp.AppsConnectionsOpenResult, nil
@@ -676,10 +676,10 @@ func (c *Client) DeveloperAppInstall(ctx context.Context, IO iostreams.IOStreame
 	}
 
 	var resp developerAppInstallResponse
-	err = goutils.JsonUnmarshal(b, &resp)
+	err = goutils.JSONUnmarshal(b, &resp)
 
 	if err != nil {
-		return DeveloperAppInstallResult{}, "", errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appDeveloperInstallMethod)
+		return DeveloperAppInstallResult{}, "", errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(appDeveloperInstallMethod)
 	}
 
 	if !resp.Ok {
@@ -694,7 +694,7 @@ func (c *Client) DeveloperAppInstall(ctx context.Context, IO iostreams.IOStreame
 			return DeveloperAppInstallResult{}, installState, err
 		}
 
-		return DeveloperAppInstallResult{}, "", slackerror.NewApiError(resp.Error, resp.Description, resp.Errors, appDeveloperInstallMethod)
+		return DeveloperAppInstallResult{}, "", slackerror.NewAPIError(resp.Error, resp.Description, resp.Errors, appDeveloperInstallMethod)
 	}
 
 	return resp.DeveloperAppInstallResult, types.SUCCESS, nil
@@ -822,13 +822,13 @@ func (c *Client) handleAppRequestPendingState(ctx context.Context, IO iostreams.
 		}
 
 		appsApprovalsRequestsCancelResp := appsApprovalsRequestsCancelResponse{}
-		err = goutils.JsonUnmarshal(b, &appsApprovalsRequestsCancelResp)
+		err = goutils.JSONUnmarshal(b, &appsApprovalsRequestsCancelResp)
 		if err != nil {
-			return "", errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appApprovalRequestCancelMethod)
+			return "", errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(appApprovalRequestCancelMethod)
 		}
 
 		if !appsApprovalsRequestsCancelResp.Ok {
-			return "", slackerror.NewApiError(
+			return "", slackerror.NewAPIError(
 				appsApprovalsRequestsCancelResp.Error,
 				appsApprovalsRequestsCancelResp.Description,
 				appsApprovalsRequestsCancelResp.Errors,
@@ -883,13 +883,13 @@ func (c *Client) RequestAppApproval(ctx context.Context, token string, appID str
 	}
 
 	resp := appsApprovalsRequestsCreateResponse{}
-	err = goutils.JsonUnmarshal(b, &resp)
+	err = goutils.JSONUnmarshal(b, &resp)
 	if err != nil {
-		return AppsApprovalsRequestsCreateResult{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appApprovalRequestCreateMethod)
+		return AppsApprovalsRequestsCreateResult{}, errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(appApprovalRequestCreateMethod)
 	}
 
 	if !resp.Ok {
-		return AppsApprovalsRequestsCreateResult{}, slackerror.NewApiError(
+		return AppsApprovalsRequestsCreateResult{}, slackerror.NewAPIError(
 			resp.Error,
 			resp.Description,
 			resp.Errors,

--- a/internal/api/app_test.go
+++ b/internal/api/app_test.go
@@ -196,7 +196,7 @@ func TestClient_ValidateAppManifest(t *testing.T) {
 			},
 			want:       ValidateAppManifestResult{nil},
 			wantErr:    true,
-			wantErrVal: slackerror.NewApiError(errInvalidManifestCode, errInvalidManifestDesc, errorDetails, appManifestValidateMethod),
+			wantErrVal: slackerror.NewAPIError(errInvalidManifestCode, errInvalidManifestDesc, errorDetails, appManifestValidateMethod),
 		},
 		{
 			name: "returns warning with breaking_change",
@@ -233,7 +233,7 @@ func TestClient_ValidateAppManifest(t *testing.T) {
 			},
 			want:       ValidateAppManifestResult{nil},
 			wantErr:    true,
-			wantErrVal: slackerror.NewApiError(errInvalidManifestCode, errInvalidManifestDesc, errorDetails, appManifestValidateMethod),
+			wantErrVal: slackerror.NewAPIError(errInvalidManifestCode, errInvalidManifestDesc, errorDetails, appManifestValidateMethod),
 		},
 		{
 			name: "returns an error invalid_manifest when error detail is due to connector not being installed",
@@ -250,7 +250,7 @@ func TestClient_ValidateAppManifest(t *testing.T) {
 			},
 			want:       ValidateAppManifestResult{nil},
 			wantErr:    true,
-			wantErrVal: slackerror.NewApiError(errInvalidManifestCode, "", errorDetails2, appManifestValidateMethod),
+			wantErrVal: slackerror.NewAPIError(errInvalidManifestCode, "", errorDetails2, appManifestValidateMethod),
 		},
 	}
 	for _, tt := range tests {
@@ -284,7 +284,7 @@ func TestClient_GetPresignedS3PostParams_Ok(t *testing.T) {
 	result, err := c.GetPresignedS3PostParams(ctx, "token", "A123")
 	require.NoError(t, err)
 	require.Equal(t, "foo.tar.gz", result.FileName)
-	require.Equal(t, "example.com/upload", result.Url)
+	require.Equal(t, "example.com/upload", result.URL)
 	require.Equal(t, "cred", result.Fields.AmzCredentials)
 }
 
@@ -299,13 +299,13 @@ func TestClient_GetPresignedS3PostParams_CommonErrors(t *testing.T) {
 func TestClient_CertifiedAppInstall(t *testing.T) {
 	tests := []struct {
 		name       string
-		resultJson string
+		resultJSON string
 		wantErr    bool
 		err        string
 	}{
 		{
 			name:       "OK result",
-			resultJson: `{"ok":true}`,
+			resultJSON: `{"ok":true}`,
 		},
 	}
 	for _, tt := range tests {
@@ -315,11 +315,11 @@ func TestClient_CertifiedAppInstall(t *testing.T) {
 			// prepare
 			handlerFunc := func(w http.ResponseWriter, r *http.Request) {
 				require.Contains(t, r.URL.Path, appCertifiedInstallMethod)
-				expectedJson := `{"app_id":"A123"}`
+				expectedJSON := `{"app_id":"A123"}`
 				payload, err := io.ReadAll(r.Body)
 				require.NoError(t, err)
-				require.Equal(t, expectedJson, string(payload))
-				result := tt.resultJson
+				require.Equal(t, expectedJSON, string(payload))
+				result := tt.resultJSON
 				_, err = fmt.Fprintln(w, result)
 				require.NoError(t, err)
 			}
@@ -327,9 +327,9 @@ func TestClient_CertifiedAppInstall(t *testing.T) {
 			defer ts.Close()
 			c := NewClient(&http.Client{}, ts.URL, nil)
 
-			mockAppId := "A123"
+			mockAppID := "A123"
 			// execute
-			_, err := c.CertifiedAppInstall(ctx, "token", mockAppId)
+			_, err := c.CertifiedAppInstall(ctx, "token", mockAppID)
 
 			// check
 			if (err != nil) != tt.wantErr {
@@ -363,16 +363,16 @@ func TestClient_InstallApp(t *testing.T) {
 
 	tests := []struct {
 		name       string
-		resultJson string
+		resultJSON string
 		wantErr    bool
 		err        string
 	}{
 		{
 			name:       "OK result",
-			resultJson: `{"ok":true}`,
+			resultJSON: `{"ok":true}`,
 		}, {
 			name:       "Error result",
-			resultJson: `{"ok":false,"error":"invalid_app_id"}`,
+			resultJSON: `{"ok":false,"error":"invalid_app_id"}`,
 			wantErr:    true,
 			err:        "invalid_app_id",
 		},
@@ -386,11 +386,11 @@ func TestClient_InstallApp(t *testing.T) {
 			// prepare
 			handlerFunc := func(w http.ResponseWriter, r *http.Request) {
 				require.Contains(t, r.URL.Path, appDeveloperInstallMethod)
-				expectedJson := `{"app_id":"A123"}`
+				expectedJSON := `{"app_id":"A123"}`
 				payload, err := io.ReadAll(r.Body)
 				require.NoError(t, err)
-				require.Equal(t, expectedJson, string(payload))
-				result := tt.resultJson
+				require.Equal(t, expectedJSON, string(payload))
+				result := tt.resultJSON
 				_, err = fmt.Fprintln(w, result)
 				require.NoError(t, err)
 			}
@@ -426,17 +426,17 @@ func TestClient_InstallApp(t *testing.T) {
 func TestClient_UninstallApp(t *testing.T) {
 	tests := []struct {
 		name       string
-		resultJson string
+		resultJSON string
 		wantErr    bool
 		errMessage string
 	}{
 		{
 			name:       "OK result",
-			resultJson: `{"ok":true}`,
+			resultJSON: `{"ok":true}`,
 		},
 		{
 			name:       "Error result",
-			resultJson: `{"ok":false,"error":"invalid_app_id"}`,
+			resultJSON: `{"ok":false,"error":"invalid_app_id"}`,
 			wantErr:    true,
 			errMessage: "invalid_app_id",
 		},
@@ -448,11 +448,11 @@ func TestClient_UninstallApp(t *testing.T) {
 			// prepare
 			handlerFunc := func(w http.ResponseWriter, r *http.Request) {
 				require.Contains(t, r.URL.Path, appDeveloperUninstallMethod)
-				expectedJson := `{"app_id":"A123","team_id":"T123"}`
+				expectedJSON := `{"app_id":"A123","team_id":"T123"}`
 				payload, err := io.ReadAll(r.Body)
 				require.NoError(t, err)
-				require.Equal(t, expectedJson, string(payload))
-				result := tt.resultJson
+				require.Equal(t, expectedJSON, string(payload))
+				result := tt.resultJSON
 				_, err = fmt.Fprintln(w, result)
 				require.NoError(t, err)
 			}
@@ -483,17 +483,17 @@ func TestClient_UninstallApp(t *testing.T) {
 func TestClient_DeleteApp(t *testing.T) {
 	tests := []struct {
 		name       string
-		resultJson string
+		resultJSON string
 		wantErr    bool
 		errMessage string
 	}{
 		{
 			name:       "OK result",
-			resultJson: `{"ok":true}`,
+			resultJSON: `{"ok":true}`,
 		},
 		{
 			name:       "Error result",
-			resultJson: `{"ok":false,"error":"invalid_app_id"}`,
+			resultJSON: `{"ok":false,"error":"invalid_app_id"}`,
 			wantErr:    true,
 			errMessage: "invalid_app_id",
 		},
@@ -505,11 +505,11 @@ func TestClient_DeleteApp(t *testing.T) {
 			// prepare
 			handlerFunc := func(w http.ResponseWriter, r *http.Request) {
 				require.Contains(t, r.URL.Path, appDeleteMethod)
-				expectedJson := `{"app_id":"A123"}`
+				expectedJSON := `{"app_id":"A123"}`
 				payload, err := io.ReadAll(r.Body)
 				require.NoError(t, err)
-				require.Equal(t, expectedJson, string(payload))
-				result := tt.resultJson
+				require.Equal(t, expectedJSON, string(payload))
+				result := tt.resultJSON
 				_, err = fmt.Fprintln(w, result)
 				require.NoError(t, err)
 			}
@@ -590,10 +590,10 @@ func TestClient_DeveloperAppInstall_RequestAppApproval(t *testing.T) {
 				}
 
 				if strings.Contains(r.URL.Path, appApprovalRequestCreateMethod) {
-					expectedJson := tt.requestJSON
+					expectedJSON := tt.requestJSON
 					payload, err := io.ReadAll(r.Body)
 					require.NoError(t, err)
-					require.Equal(t, expectedJson, string(payload))
+					require.Equal(t, expectedJSON, string(payload))
 					_, err = fmt.Fprintln(w, `{"ok":true}`)
 					require.NoError(t, err)
 				}

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -99,14 +99,14 @@ func (c *Client) ExchangeAuthTicket(ctx context.Context, ticket string, challeng
 	}
 
 	resp := exchangeAuthTicketMethodResponse{}
-	err = goutils.JsonUnmarshal(b, &resp)
+	err = goutils.JSONUnmarshal(b, &resp)
 
 	if err != nil {
-		return ExchangeAuthTicketResult{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(exchangeAuthTicketMethod)
+		return ExchangeAuthTicketResult{}, errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(exchangeAuthTicketMethod)
 	}
 
 	if !resp.Ok {
-		return ExchangeAuthTicketResult{}, slackerror.NewApiError(resp.Error, resp.Description, resp.Errors, exchangeAuthTicketMethod)
+		return ExchangeAuthTicketResult{}, slackerror.NewAPIError(resp.Error, resp.Description, resp.Errors, exchangeAuthTicketMethod)
 	}
 
 	// ExchangeAuthTicketResult must have a token to be valid
@@ -135,13 +135,13 @@ func (c *Client) GenerateAuthTicket(ctx context.Context, cliVersion string, serv
 	}
 
 	resp := generateAuthTicketResponse{}
-	err = goutils.JsonUnmarshal(b, &resp)
+	err = goutils.JSONUnmarshal(b, &resp)
 	if err != nil {
-		return GenerateAuthTicketResult{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(generateAuthTicketMethod)
+		return GenerateAuthTicketResult{}, errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(generateAuthTicketMethod)
 	}
 
 	if !resp.Ok {
-		return GenerateAuthTicketResult{}, slackerror.NewApiError(resp.Error, resp.Description, resp.Errors, generateAuthTicketMethod)
+		return GenerateAuthTicketResult{}, slackerror.NewAPIError(resp.Error, resp.Description, resp.Errors, generateAuthTicketMethod)
 	}
 
 	return resp.GenerateAuthTicketResult, nil
@@ -179,13 +179,13 @@ func (c *Client) RotateToken(ctx context.Context, auth types.SlackAuth) (RotateT
 	}
 
 	resp := rotateTokenMethodResponse{}
-	err = goutils.JsonUnmarshal(b, &resp)
+	err = goutils.JSONUnmarshal(b, &resp)
 	if err != nil {
-		return RotateTokenResult{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(rotateTokenMethod)
+		return RotateTokenResult{}, errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(rotateTokenMethod)
 	}
 
 	if !resp.Ok {
-		return RotateTokenResult{}, slackerror.NewApiError(resp.Error, resp.Description, resp.Errors, rotateTokenMethod)
+		return RotateTokenResult{}, slackerror.NewAPIError(resp.Error, resp.Description, resp.Errors, rotateTokenMethod)
 	}
 
 	return resp.RotateTokenResult, nil

--- a/internal/api/auth.go
+++ b/internal/api/auth.go
@@ -91,18 +91,18 @@ func (c *Client) ExchangeAuthTicket(ctx context.Context, ticket string, challeng
 
 	b, err := c.postForm(ctx, exchangeAuthTicketMethod, values)
 	if err != nil {
-		return ExchangeAuthTicketResult{}, errHttpRequestFailed.WithRootCause(err)
+		return ExchangeAuthTicketResult{}, errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	if b == nil {
-		return ExchangeAuthTicketResult{}, errHttpResponseInvalid.WithRootCause(slackerror.New("empty body"))
+		return ExchangeAuthTicketResult{}, errHTTPResponseInvalid.WithRootCause(slackerror.New("empty body"))
 	}
 
 	resp := exchangeAuthTicketMethodResponse{}
 	err = goutils.JsonUnmarshal(b, &resp)
 
 	if err != nil {
-		return ExchangeAuthTicketResult{}, errHttpResponseInvalid.WithRootCause(err).AddApiMethod(exchangeAuthTicketMethod)
+		return ExchangeAuthTicketResult{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(exchangeAuthTicketMethod)
 	}
 
 	if !resp.Ok {
@@ -127,17 +127,17 @@ func (c *Client) GenerateAuthTicket(ctx context.Context, cliVersion string, serv
 
 	b, err := c.postForm(ctx, generateAuthTicketMethod, values)
 	if err != nil {
-		return GenerateAuthTicketResult{}, errHttpRequestFailed.WithRootCause(err)
+		return GenerateAuthTicketResult{}, errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	if b == nil {
-		return GenerateAuthTicketResult{}, errHttpResponseInvalid.WithRootCause(slackerror.New("empty body"))
+		return GenerateAuthTicketResult{}, errHTTPResponseInvalid.WithRootCause(slackerror.New("empty body"))
 	}
 
 	resp := generateAuthTicketResponse{}
 	err = goutils.JsonUnmarshal(b, &resp)
 	if err != nil {
-		return GenerateAuthTicketResult{}, errHttpResponseInvalid.WithRootCause(err).AddApiMethod(generateAuthTicketMethod)
+		return GenerateAuthTicketResult{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(generateAuthTicketMethod)
 	}
 
 	if !resp.Ok {
@@ -171,17 +171,17 @@ func (c *Client) RotateToken(ctx context.Context, auth types.SlackAuth) (RotateT
 
 	b, err := c.postForm(ctx, rotateTokenMethod, values)
 	if err != nil {
-		return RotateTokenResult{}, errHttpRequestFailed.WithRootCause(err)
+		return RotateTokenResult{}, errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	if b == nil {
-		return RotateTokenResult{}, errHttpResponseInvalid.WithRootCause(slackerror.New("empty body"))
+		return RotateTokenResult{}, errHTTPResponseInvalid.WithRootCause(slackerror.New("empty body"))
 	}
 
 	resp := rotateTokenMethodResponse{}
 	err = goutils.JsonUnmarshal(b, &resp)
 	if err != nil {
-		return RotateTokenResult{}, errHttpResponseInvalid.WithRootCause(err).AddApiMethod(rotateTokenMethod)
+		return RotateTokenResult{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(rotateTokenMethod)
 	}
 
 	if !resp.Ok {

--- a/internal/api/auth_test.go
+++ b/internal/api/auth_test.go
@@ -123,7 +123,7 @@ func TestClient_RotateToken_OkDevHostRestoreTimeout(t *testing.T) {
 	c.host = devHost
 	c.httpClient.Timeout = 24 * time.Second
 	_, err := c.RotateToken(ctx, types.SlackAuth{
-		ApiHost:      &devHost,
+		APIHost:      &devHost,
 		Token:        `valid-token`,
 		RefreshToken: `valid-refresh-token`,
 	})

--- a/internal/api/channels.go
+++ b/internal/api/channels.go
@@ -49,18 +49,18 @@ func (c *Client) ChannelsInfo(ctx context.Context, token, channelID string) (*ty
 
 	b, err := c.postForm(ctx, channelsInfoMethod, values)
 	if err != nil {
-		return nil, errHttpRequestFailed.WithRootCause(err)
+		return nil, errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	if b == nil {
-		return nil, errHttpResponseInvalid.WithRootCause(slackerror.New("empty body"))
+		return nil, errHTTPResponseInvalid.WithRootCause(slackerror.New("empty body"))
 	}
 
 	resp := ChannelInfoResponse{}
 	err = goutils.JsonUnmarshal(b, &resp)
 
 	if err != nil {
-		return nil, errHttpResponseInvalid.WithRootCause(err).AddApiMethod(workflowsTriggersPermissionsListMethod)
+		return nil, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(workflowsTriggersPermissionsListMethod)
 	}
 
 	if !resp.Ok {

--- a/internal/api/channels.go
+++ b/internal/api/channels.go
@@ -57,14 +57,14 @@ func (c *Client) ChannelsInfo(ctx context.Context, token, channelID string) (*ty
 	}
 
 	resp := ChannelInfoResponse{}
-	err = goutils.JsonUnmarshal(b, &resp)
+	err = goutils.JSONUnmarshal(b, &resp)
 
 	if err != nil {
-		return nil, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(workflowsTriggersPermissionsListMethod)
+		return nil, errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(workflowsTriggersPermissionsListMethod)
 	}
 
 	if !resp.Ok {
-		return nil, slackerror.NewApiError(resp.Error, resp.Description, resp.Errors, workflowsTriggersPermissionsListMethod)
+		return nil, slackerror.NewAPIError(resp.Error, resp.Description, resp.Errors, workflowsTriggersPermissionsListMethod)
 	}
 
 	return &resp.Channel, nil

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -70,7 +70,7 @@ type responseMetadata struct {
 
 var (
 	errInvalidArguments    = slackerror.New(slackerror.ErrInvalidArguments)
-	errHttpResponseInvalid = slackerror.New(slackerror.ErrHttpResponseInvalid)
+	errHttpResponseInvalid = slackerror.New(slackerror.ErrHTTPResponseInvalid)
 	errHttpRequestFailed   = slackerror.New(slackerror.ErrHttpRequestFailed)
 )
 

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -70,15 +70,15 @@ type responseMetadata struct {
 
 var (
 	errInvalidArguments    = slackerror.New(slackerror.ErrInvalidArguments)
-	errHttpResponseInvalid = slackerror.New(slackerror.ErrHTTPResponseInvalid)
-	errHttpRequestFailed   = slackerror.New(slackerror.ErrHttpRequestFailed)
+	errHTTPResponseInvalid = slackerror.New(slackerror.ErrHTTPResponseInvalid)
+	errHTTPRequestFailed   = slackerror.New(slackerror.ErrHTTPRequestFailed)
 )
 
 // NewClient accepts an httpClient to facilitate making http requests to Slack.
 // Client does not attempt to evaluate the response body, leaving that to the caller.
 func NewClient(client *http.Client, host string, io iostreams.IOStreamer) *Client {
 	if client == nil {
-		client = NewHttpClient(HttpClientOptions{TotalTimeOut: 60 * time.Second})
+		client = NewHTTPClient(HTTPClientOptions{TotalTimeOut: 60 * time.Second})
 	}
 	if io == nil {
 		fs := slackdeps.NewFs()
@@ -317,7 +317,7 @@ func (c *Client) DoWithRetry(ctx context.Context, request *http.Request, span op
 	}
 
 	if bytes == nil {
-		return nil, errHttpResponseInvalid.WithRootCause(slackerror.New("empty body"))
+		return nil, errHTTPResponseInvalid.WithRootCause(slackerror.New("empty body"))
 	}
 
 	return bytes, err

--- a/internal/api/collaborators.go
+++ b/internal/api/collaborators.go
@@ -64,14 +64,14 @@ func (c *Client) AddCollaborator(ctx context.Context, token, appID string, slack
 	}
 
 	resp := extendedBaseResponse{}
-	err = goutils.JsonUnmarshal(b, &resp)
+	err = goutils.JSONUnmarshal(b, &resp)
 
 	if err != nil {
-		return errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(collaboratorsAddMethod)
+		return errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(collaboratorsAddMethod)
 	}
 
 	if !resp.Ok {
-		return slackerror.NewApiError(resp.Error, resp.Description, resp.Errors, collaboratorsAddMethod)
+		return slackerror.NewAPIError(resp.Error, resp.Description, resp.Errors, collaboratorsAddMethod)
 	}
 
 	return nil
@@ -102,14 +102,14 @@ func (c *Client) ListCollaborators(ctx context.Context, token, appID string) ([]
 	}
 
 	resp := listCollaboratorsResponse{}
-	err = goutils.JsonUnmarshal(b, &resp)
+	err = goutils.JSONUnmarshal(b, &resp)
 
 	if err != nil {
-		return []types.SlackUser{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(collaboratorsListMethod)
+		return []types.SlackUser{}, errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(collaboratorsListMethod)
 	}
 
 	if !resp.Ok {
-		return []types.SlackUser{}, slackerror.NewApiError(resp.Error, resp.Description, resp.Errors, collaboratorsListMethod)
+		return []types.SlackUser{}, slackerror.NewAPIError(resp.Error, resp.Description, resp.Errors, collaboratorsListMethod)
 	}
 
 	return resp.Owners, nil
@@ -140,14 +140,14 @@ func (c *Client) RemoveCollaborator(ctx context.Context, token, appID string, sl
 	}
 
 	resp := extendedBaseResponse{}
-	err = goutils.JsonUnmarshal(b, &resp)
+	err = goutils.JSONUnmarshal(b, &resp)
 
 	if err != nil {
-		return resp.Warnings, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(collaboratorsRemoveMethod)
+		return resp.Warnings, errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(collaboratorsRemoveMethod)
 	}
 
 	if !resp.Ok {
-		return resp.Warnings, slackerror.NewApiError(resp.Error, resp.Description, resp.Errors, collaboratorsRemoveMethod)
+		return resp.Warnings, slackerror.NewAPIError(resp.Error, resp.Description, resp.Errors, collaboratorsRemoveMethod)
 	}
 
 	return resp.Warnings, nil
@@ -179,14 +179,14 @@ func (c *Client) UpdateCollaborator(ctx context.Context, token, appID string, sl
 	}
 
 	resp := extendedBaseResponse{}
-	err = goutils.JsonUnmarshal(b, &resp)
+	err = goutils.JSONUnmarshal(b, &resp)
 
 	if err != nil {
-		return errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(collaboratorsUpdateMethod)
+		return errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(collaboratorsUpdateMethod)
 	}
 
 	if !resp.Ok {
-		return slackerror.NewApiError(resp.Error, resp.Description, resp.Errors, collaboratorsUpdateMethod)
+		return slackerror.NewAPIError(resp.Error, resp.Description, resp.Errors, collaboratorsUpdateMethod)
 	}
 
 	return nil

--- a/internal/api/collaborators.go
+++ b/internal/api/collaborators.go
@@ -56,18 +56,18 @@ func (c *Client) AddCollaborator(ctx context.Context, token, appID string, slack
 
 	b, err := c.postForm(ctx, collaboratorsAddMethod, values)
 	if err != nil {
-		return errHttpRequestFailed.WithRootCause(err)
+		return errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	if b == nil {
-		return errHttpResponseInvalid.WithRootCause(slackerror.New("empty body"))
+		return errHTTPResponseInvalid.WithRootCause(slackerror.New("empty body"))
 	}
 
 	resp := extendedBaseResponse{}
 	err = goutils.JsonUnmarshal(b, &resp)
 
 	if err != nil {
-		return errHttpResponseInvalid.WithRootCause(err).AddApiMethod(collaboratorsAddMethod)
+		return errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(collaboratorsAddMethod)
 	}
 
 	if !resp.Ok {
@@ -94,18 +94,18 @@ func (c *Client) ListCollaborators(ctx context.Context, token, appID string) ([]
 
 	b, err := c.postForm(ctx, collaboratorsListMethod, values)
 	if err != nil {
-		return []types.SlackUser{}, errHttpRequestFailed.WithRootCause(err)
+		return []types.SlackUser{}, errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	if b == nil {
-		return []types.SlackUser{}, errHttpResponseInvalid.WithRootCause(slackerror.New("empty body"))
+		return []types.SlackUser{}, errHTTPResponseInvalid.WithRootCause(slackerror.New("empty body"))
 	}
 
 	resp := listCollaboratorsResponse{}
 	err = goutils.JsonUnmarshal(b, &resp)
 
 	if err != nil {
-		return []types.SlackUser{}, errHttpResponseInvalid.WithRootCause(err).AddApiMethod(collaboratorsListMethod)
+		return []types.SlackUser{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(collaboratorsListMethod)
 	}
 
 	if !resp.Ok {
@@ -132,18 +132,18 @@ func (c *Client) RemoveCollaborator(ctx context.Context, token, appID string, sl
 
 	b, err := c.postForm(ctx, collaboratorsRemoveMethod, values)
 	if err != nil {
-		return nil, errHttpRequestFailed.WithRootCause(err)
+		return nil, errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	if b == nil {
-		return nil, errHttpResponseInvalid.WithRootCause(slackerror.New("empty body"))
+		return nil, errHTTPResponseInvalid.WithRootCause(slackerror.New("empty body"))
 	}
 
 	resp := extendedBaseResponse{}
 	err = goutils.JsonUnmarshal(b, &resp)
 
 	if err != nil {
-		return resp.Warnings, errHttpResponseInvalid.WithRootCause(err).AddApiMethod(collaboratorsRemoveMethod)
+		return resp.Warnings, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(collaboratorsRemoveMethod)
 	}
 
 	if !resp.Ok {
@@ -171,18 +171,18 @@ func (c *Client) UpdateCollaborator(ctx context.Context, token, appID string, sl
 
 	b, err := c.postForm(ctx, collaboratorsUpdateMethod, values)
 	if err != nil {
-		return errHttpRequestFailed.WithRootCause(err)
+		return errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	if b == nil {
-		return errHttpResponseInvalid.WithRootCause(slackerror.New("empty body"))
+		return errHTTPResponseInvalid.WithRootCause(slackerror.New("empty body"))
 	}
 
 	resp := extendedBaseResponse{}
 	err = goutils.JsonUnmarshal(b, &resp)
 
 	if err != nil {
-		return errHttpResponseInvalid.WithRootCause(err).AddApiMethod(collaboratorsUpdateMethod)
+		return errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(collaboratorsUpdateMethod)
 	}
 
 	if !resp.Ok {

--- a/internal/api/datastore.go
+++ b/internal/api/datastore.go
@@ -76,7 +76,7 @@ func (c *Client) AppsDatastorePut(ctx context.Context, token string, request typ
 
 	b, err := c.postJSON(ctx, appDatastorePutMethod, token, "", body)
 	if err != nil {
-		return types.AppDatastorePutResult{}, errHttpRequestFailed.WithRootCause(err)
+		return types.AppDatastorePutResult{}, errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	type responseWrapper struct {
@@ -86,7 +86,7 @@ func (c *Client) AppsDatastorePut(ctx context.Context, token string, request typ
 	resp := responseWrapper{}
 	err = goutils.JsonUnmarshal(b, &resp)
 	if err != nil {
-		return types.AppDatastorePutResult{}, errHttpResponseInvalid.WithRootCause(err).AddApiMethod(appDatastorePutMethod)
+		return types.AppDatastorePutResult{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appDatastorePutMethod)
 	}
 
 	if !resp.Ok {
@@ -119,7 +119,7 @@ func (c *Client) AppsDatastoreBulkPut(ctx context.Context, token string, request
 
 	b, err := c.postJSON(ctx, appDatastoreBulkPutMethod, token, "", body)
 	if err != nil {
-		return types.AppDatastoreBulkPutResult{}, errHttpRequestFailed.WithRootCause(err)
+		return types.AppDatastoreBulkPutResult{}, errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	type responseWrapper struct {
@@ -129,7 +129,7 @@ func (c *Client) AppsDatastoreBulkPut(ctx context.Context, token string, request
 	resp := responseWrapper{}
 	err = goutils.JsonUnmarshal(b, &resp)
 	if err != nil {
-		return types.AppDatastoreBulkPutResult{}, errHttpResponseInvalid.WithRootCause(err).AddApiMethod(appDatastoreBulkPutMethod)
+		return types.AppDatastoreBulkPutResult{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appDatastoreBulkPutMethod)
 	}
 
 	if !resp.Ok && len(resp.FailedItems) == 0 {
@@ -166,7 +166,7 @@ func (c *Client) AppsDatastoreUpdate(ctx context.Context, token string, request 
 
 	b, err := c.postJSON(ctx, appDatastoreUpdateMethod, token, "", body)
 	if err != nil {
-		return types.AppDatastoreUpdateResult{}, errHttpRequestFailed.WithRootCause(err)
+		return types.AppDatastoreUpdateResult{}, errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	type responseWrapper struct {
@@ -176,7 +176,7 @@ func (c *Client) AppsDatastoreUpdate(ctx context.Context, token string, request 
 	resp := responseWrapper{}
 	err = goutils.JsonUnmarshal(b, &resp)
 	if err != nil {
-		return types.AppDatastoreUpdateResult{}, errHttpResponseInvalid.WithRootCause(err).AddApiMethod(appDatastoreUpdateMethod)
+		return types.AppDatastoreUpdateResult{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appDatastoreUpdateMethod)
 	}
 
 	if !resp.Ok {
@@ -217,7 +217,7 @@ func (c *Client) AppsDatastoreQuery(ctx context.Context, token string, query typ
 
 	b, err := c.postJSON(ctx, appDatastoreQueryMethod, token, "", body)
 	if err != nil {
-		return types.AppDatastoreQueryResult{}, errHttpRequestFailed.WithRootCause(err)
+		return types.AppDatastoreQueryResult{}, errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	type responseWrapper struct {
@@ -227,7 +227,7 @@ func (c *Client) AppsDatastoreQuery(ctx context.Context, token string, query typ
 	resp := responseWrapper{}
 	err = goutils.JsonUnmarshal(b, &resp)
 	if err != nil {
-		return types.AppDatastoreQueryResult{}, errHttpResponseInvalid.WithRootCause(err).AddApiMethod(appDatastoreQueryMethod)
+		return types.AppDatastoreQueryResult{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appDatastoreQueryMethod)
 	}
 
 	if !resp.Ok {
@@ -266,7 +266,7 @@ func (c *Client) AppsDatastoreCount(ctx context.Context, token string, count typ
 
 	b, err := c.postJSON(ctx, appDatastoreCountMethod, token, "", body)
 	if err != nil {
-		return types.AppDatastoreCountResult{}, errHttpRequestFailed.WithRootCause(err)
+		return types.AppDatastoreCountResult{}, errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	type responseWrapper struct {
@@ -276,7 +276,7 @@ func (c *Client) AppsDatastoreCount(ctx context.Context, token string, count typ
 	resp := responseWrapper{}
 	err = goutils.JsonUnmarshal(b, &resp)
 	if err != nil {
-		return types.AppDatastoreCountResult{}, errHttpResponseInvalid.WithRootCause(err).AddApiMethod(appDatastoreCountMethod)
+		return types.AppDatastoreCountResult{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appDatastoreCountMethod)
 	}
 
 	if !resp.Ok {
@@ -309,7 +309,7 @@ func (c *Client) AppsDatastoreDelete(ctx context.Context, token string, request 
 
 	b, err := c.postJSON(ctx, appDatastoreDeleteMethod, token, "", body)
 	if err != nil {
-		return types.AppDatastoreDeleteResult{}, errHttpRequestFailed.WithRootCause(err)
+		return types.AppDatastoreDeleteResult{}, errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	type responseWrapper struct {
@@ -319,7 +319,7 @@ func (c *Client) AppsDatastoreDelete(ctx context.Context, token string, request 
 	resp := responseWrapper{}
 	err = goutils.JsonUnmarshal(b, &resp)
 	if err != nil {
-		return types.AppDatastoreDeleteResult{}, errHttpResponseInvalid.WithRootCause(err).AddApiMethod(appDatastoreDeleteMethod)
+		return types.AppDatastoreDeleteResult{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appDatastoreDeleteMethod)
 	}
 
 	if !resp.Ok {
@@ -360,7 +360,7 @@ func (c *Client) AppsDatastoreBulkDelete(ctx context.Context, token string, requ
 
 	b, err := c.postJSON(ctx, appDatastoreBulkDeleteMethod, token, "", body)
 	if err != nil {
-		return types.AppDatastoreBulkDeleteResult{}, errHttpRequestFailed.WithRootCause(err)
+		return types.AppDatastoreBulkDeleteResult{}, errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	type responseWrapper struct {
@@ -370,7 +370,7 @@ func (c *Client) AppsDatastoreBulkDelete(ctx context.Context, token string, requ
 	resp := responseWrapper{}
 	err = goutils.JsonUnmarshal(b, &resp)
 	if err != nil {
-		return types.AppDatastoreBulkDeleteResult{}, errHttpResponseInvalid.WithRootCause(err).AddApiMethod(appDatastoreBulkDeleteMethod)
+		return types.AppDatastoreBulkDeleteResult{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appDatastoreBulkDeleteMethod)
 	}
 
 	if !resp.Ok && len(resp.FailedItems) == 0 {
@@ -407,7 +407,7 @@ func (c *Client) AppsDatastoreGet(ctx context.Context, token string, request typ
 
 	b, err := c.postJSON(ctx, appDatastoreGetMethod, token, "", body)
 	if err != nil {
-		return types.AppDatastoreGetResult{}, errHttpRequestFailed.WithRootCause(err)
+		return types.AppDatastoreGetResult{}, errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	type responseWrapper struct {
@@ -417,7 +417,7 @@ func (c *Client) AppsDatastoreGet(ctx context.Context, token string, request typ
 	resp := responseWrapper{}
 	err = goutils.JsonUnmarshal(b, &resp)
 	if err != nil {
-		return types.AppDatastoreGetResult{}, errHttpResponseInvalid.WithRootCause(err).AddApiMethod(appDatastoreGetMethod)
+		return types.AppDatastoreGetResult{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appDatastoreGetMethod)
 	}
 
 	if !resp.Ok {
@@ -450,7 +450,7 @@ func (c *Client) AppsDatastoreBulkGet(ctx context.Context, token string, request
 
 	b, err := c.postJSON(ctx, appDatastoreBulkGetMethod, token, "", body)
 	if err != nil {
-		return types.AppDatastoreBulkGetResult{}, errHttpRequestFailed.WithRootCause(err)
+		return types.AppDatastoreBulkGetResult{}, errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	type responseWrapper struct {
@@ -460,7 +460,7 @@ func (c *Client) AppsDatastoreBulkGet(ctx context.Context, token string, request
 	resp := responseWrapper{}
 	err = goutils.JsonUnmarshal(b, &resp)
 	if err != nil {
-		return types.AppDatastoreBulkGetResult{}, errHttpResponseInvalid.WithRootCause(err).AddApiMethod(appDatastoreBulkGetMethod)
+		return types.AppDatastoreBulkGetResult{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appDatastoreBulkGetMethod)
 	}
 
 	if !resp.Ok && len(resp.FailedItems) == 0 {

--- a/internal/api/datastore.go
+++ b/internal/api/datastore.go
@@ -84,13 +84,13 @@ func (c *Client) AppsDatastorePut(ctx context.Context, token string, request typ
 		types.AppDatastorePutResult
 	}
 	resp := responseWrapper{}
-	err = goutils.JsonUnmarshal(b, &resp)
+	err = goutils.JSONUnmarshal(b, &resp)
 	if err != nil {
-		return types.AppDatastorePutResult{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appDatastorePutMethod)
+		return types.AppDatastorePutResult{}, errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(appDatastorePutMethod)
 	}
 
 	if !resp.Ok {
-		return types.AppDatastorePutResult{}, slackerror.NewApiError(resp.Error, resp.Description, resp.Errors, appDatastorePutMethod)
+		return types.AppDatastorePutResult{}, slackerror.NewAPIError(resp.Error, resp.Description, resp.Errors, appDatastorePutMethod)
 	}
 
 	return resp.AppDatastorePutResult, nil
@@ -127,13 +127,13 @@ func (c *Client) AppsDatastoreBulkPut(ctx context.Context, token string, request
 		types.AppDatastoreBulkPutResult
 	}
 	resp := responseWrapper{}
-	err = goutils.JsonUnmarshal(b, &resp)
+	err = goutils.JSONUnmarshal(b, &resp)
 	if err != nil {
-		return types.AppDatastoreBulkPutResult{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appDatastoreBulkPutMethod)
+		return types.AppDatastoreBulkPutResult{}, errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(appDatastoreBulkPutMethod)
 	}
 
 	if !resp.Ok && len(resp.FailedItems) == 0 {
-		return types.AppDatastoreBulkPutResult{}, slackerror.NewApiError(resp.Error, resp.Description, resp.Errors, appDatastoreBulkPutMethod)
+		return types.AppDatastoreBulkPutResult{}, slackerror.NewAPIError(resp.Error, resp.Description, resp.Errors, appDatastoreBulkPutMethod)
 	}
 
 	if resp.AppDatastoreBulkPutResult.Datastore == "" {
@@ -174,13 +174,13 @@ func (c *Client) AppsDatastoreUpdate(ctx context.Context, token string, request 
 		types.AppDatastoreUpdateResult
 	}
 	resp := responseWrapper{}
-	err = goutils.JsonUnmarshal(b, &resp)
+	err = goutils.JSONUnmarshal(b, &resp)
 	if err != nil {
-		return types.AppDatastoreUpdateResult{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appDatastoreUpdateMethod)
+		return types.AppDatastoreUpdateResult{}, errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(appDatastoreUpdateMethod)
 	}
 
 	if !resp.Ok {
-		return types.AppDatastoreUpdateResult{}, slackerror.NewApiError(resp.Error, resp.Description, resp.Errors, appDatastoreUpdateMethod)
+		return types.AppDatastoreUpdateResult{}, slackerror.NewAPIError(resp.Error, resp.Description, resp.Errors, appDatastoreUpdateMethod)
 	}
 
 	return resp.AppDatastoreUpdateResult, nil
@@ -225,13 +225,13 @@ func (c *Client) AppsDatastoreQuery(ctx context.Context, token string, query typ
 		types.AppDatastoreQueryResult
 	}
 	resp := responseWrapper{}
-	err = goutils.JsonUnmarshal(b, &resp)
+	err = goutils.JSONUnmarshal(b, &resp)
 	if err != nil {
-		return types.AppDatastoreQueryResult{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appDatastoreQueryMethod)
+		return types.AppDatastoreQueryResult{}, errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(appDatastoreQueryMethod)
 	}
 
 	if !resp.Ok {
-		return types.AppDatastoreQueryResult{}, slackerror.NewApiError(resp.Error, resp.Description, resp.Errors, appDatastoreQueryMethod)
+		return types.AppDatastoreQueryResult{}, slackerror.NewAPIError(resp.Error, resp.Description, resp.Errors, appDatastoreQueryMethod)
 	}
 
 	resp.AppDatastoreQueryResult.NextCursor = resp.baseResponse.ResponseMetadata.NextCursor
@@ -274,13 +274,13 @@ func (c *Client) AppsDatastoreCount(ctx context.Context, token string, count typ
 		types.AppDatastoreCountResult
 	}
 	resp := responseWrapper{}
-	err = goutils.JsonUnmarshal(b, &resp)
+	err = goutils.JSONUnmarshal(b, &resp)
 	if err != nil {
-		return types.AppDatastoreCountResult{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appDatastoreCountMethod)
+		return types.AppDatastoreCountResult{}, errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(appDatastoreCountMethod)
 	}
 
 	if !resp.Ok {
-		return types.AppDatastoreCountResult{}, slackerror.NewApiError(resp.Error, resp.Description, resp.Errors, appDatastoreCountMethod)
+		return types.AppDatastoreCountResult{}, slackerror.NewAPIError(resp.Error, resp.Description, resp.Errors, appDatastoreCountMethod)
 	}
 
 	return resp.AppDatastoreCountResult, nil
@@ -317,13 +317,13 @@ func (c *Client) AppsDatastoreDelete(ctx context.Context, token string, request 
 		types.AppDatastoreDeleteResult
 	}
 	resp := responseWrapper{}
-	err = goutils.JsonUnmarshal(b, &resp)
+	err = goutils.JSONUnmarshal(b, &resp)
 	if err != nil {
-		return types.AppDatastoreDeleteResult{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appDatastoreDeleteMethod)
+		return types.AppDatastoreDeleteResult{}, errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(appDatastoreDeleteMethod)
 	}
 
 	if !resp.Ok {
-		return types.AppDatastoreDeleteResult{}, slackerror.NewApiError(resp.Error, resp.Description, resp.Errors, appDatastoreDeleteMethod)
+		return types.AppDatastoreDeleteResult{}, slackerror.NewAPIError(resp.Error, resp.Description, resp.Errors, appDatastoreDeleteMethod)
 	}
 
 	// the delete API doesn't return id or datastore (yet) so set it if empty
@@ -368,13 +368,13 @@ func (c *Client) AppsDatastoreBulkDelete(ctx context.Context, token string, requ
 		types.AppDatastoreBulkDeleteResult
 	}
 	resp := responseWrapper{}
-	err = goutils.JsonUnmarshal(b, &resp)
+	err = goutils.JSONUnmarshal(b, &resp)
 	if err != nil {
-		return types.AppDatastoreBulkDeleteResult{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appDatastoreBulkDeleteMethod)
+		return types.AppDatastoreBulkDeleteResult{}, errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(appDatastoreBulkDeleteMethod)
 	}
 
 	if !resp.Ok && len(resp.FailedItems) == 0 {
-		return types.AppDatastoreBulkDeleteResult{}, slackerror.NewApiError(resp.Error, resp.Description, resp.Errors, appDatastoreBulkDeleteMethod)
+		return types.AppDatastoreBulkDeleteResult{}, slackerror.NewAPIError(resp.Error, resp.Description, resp.Errors, appDatastoreBulkDeleteMethod)
 	}
 
 	if resp.AppDatastoreBulkDeleteResult.Datastore == "" {
@@ -415,13 +415,13 @@ func (c *Client) AppsDatastoreGet(ctx context.Context, token string, request typ
 		types.AppDatastoreGetResult
 	}
 	resp := responseWrapper{}
-	err = goutils.JsonUnmarshal(b, &resp)
+	err = goutils.JSONUnmarshal(b, &resp)
 	if err != nil {
-		return types.AppDatastoreGetResult{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appDatastoreGetMethod)
+		return types.AppDatastoreGetResult{}, errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(appDatastoreGetMethod)
 	}
 
 	if !resp.Ok {
-		return types.AppDatastoreGetResult{}, slackerror.NewApiError(resp.Error, resp.Description, resp.Errors, appDatastoreGetMethod)
+		return types.AppDatastoreGetResult{}, slackerror.NewAPIError(resp.Error, resp.Description, resp.Errors, appDatastoreGetMethod)
 	}
 
 	return resp.AppDatastoreGetResult, nil
@@ -458,13 +458,13 @@ func (c *Client) AppsDatastoreBulkGet(ctx context.Context, token string, request
 		types.AppDatastoreBulkGetResult
 	}
 	resp := responseWrapper{}
-	err = goutils.JsonUnmarshal(b, &resp)
+	err = goutils.JSONUnmarshal(b, &resp)
 	if err != nil {
-		return types.AppDatastoreBulkGetResult{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appDatastoreBulkGetMethod)
+		return types.AppDatastoreBulkGetResult{}, errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(appDatastoreBulkGetMethod)
 	}
 
 	if !resp.Ok && len(resp.FailedItems) == 0 {
-		return types.AppDatastoreBulkGetResult{}, slackerror.NewApiError(resp.Error, resp.Description, resp.Errors, appDatastoreBulkGetMethod)
+		return types.AppDatastoreBulkGetResult{}, slackerror.NewAPIError(resp.Error, resp.Description, resp.Errors, appDatastoreBulkGetMethod)
 	}
 
 	if resp.AppDatastoreBulkGetResult.Datastore == "" {

--- a/internal/api/datastore_test.go
+++ b/internal/api/datastore_test.go
@@ -102,7 +102,7 @@ func TestClient_AppsDatastorePut(t *testing.T) {
 				},
 			},
 			wantErr:    true,
-			errMessage: slackerror.ErrHttpResponseInvalid,
+			errMessage: slackerror.ErrHTTPResponseInvalid,
 		},
 		{
 			name: "api_error",
@@ -225,7 +225,7 @@ func TestClient_AppsDatastoreUpdate(t *testing.T) {
 				},
 			},
 			wantErr:    true,
-			errMessage: slackerror.ErrHttpResponseInvalid,
+			errMessage: slackerror.ErrHTTPResponseInvalid,
 		},
 		{
 			name: "api_error",
@@ -340,7 +340,7 @@ func TestClient_AppsDatastoreQuery(t *testing.T) {
 				},
 			},
 			wantErr:    true,
-			errMessage: slackerror.ErrHttpResponseInvalid,
+			errMessage: slackerror.ErrHTTPResponseInvalid,
 		},
 		{
 			name: "api_error",
@@ -451,7 +451,7 @@ func TestClient_AppsDatastoreDelete(t *testing.T) {
 				},
 			},
 			wantErr:    true,
-			errMessage: slackerror.ErrHttpResponseInvalid,
+			errMessage: slackerror.ErrHTTPResponseInvalid,
 		},
 		{
 			name: "api_error",
@@ -565,7 +565,7 @@ func TestClient_AppsDatastoreGet(t *testing.T) {
 				},
 			},
 			wantErr:    true,
-			errMessage: slackerror.ErrHttpResponseInvalid,
+			errMessage: slackerror.ErrHTTPResponseInvalid,
 		},
 		{
 			name: "api_error",

--- a/internal/api/datastore_test.go
+++ b/internal/api/datastore_test.go
@@ -82,7 +82,7 @@ func TestClient_AppsDatastorePut(t *testing.T) {
 				},
 			},
 			wantErr:    true,
-			errMessage: slackerror.ErrHttpRequestFailed,
+			errMessage: slackerror.ErrHTTPRequestFailed,
 		},
 		{
 			name: "response_unmarshal_error",
@@ -205,7 +205,7 @@ func TestClient_AppsDatastoreUpdate(t *testing.T) {
 				},
 			},
 			wantErr:    true,
-			errMessage: slackerror.ErrHttpRequestFailed,
+			errMessage: slackerror.ErrHTTPRequestFailed,
 		},
 		{
 			name: "response_unmarshal_error",
@@ -323,7 +323,7 @@ func TestClient_AppsDatastoreQuery(t *testing.T) {
 				},
 			},
 			wantErr:    true,
-			errMessage: slackerror.ErrHttpRequestFailed,
+			errMessage: slackerror.ErrHTTPRequestFailed,
 		},
 		{
 			name: "response_unmarshal_error",
@@ -433,7 +433,7 @@ func TestClient_AppsDatastoreDelete(t *testing.T) {
 				},
 			},
 			wantErr:    true,
-			errMessage: slackerror.ErrHttpRequestFailed,
+			errMessage: slackerror.ErrHTTPRequestFailed,
 		},
 		{
 			name: "response_unmarshal_error",
@@ -547,7 +547,7 @@ func TestClient_AppsDatastoreGet(t *testing.T) {
 				},
 			},
 			wantErr:    true,
-			errMessage: slackerror.ErrHttpRequestFailed,
+			errMessage: slackerror.ErrHTTPRequestFailed,
 		},
 		{
 			name: "response_unmarshal_error",

--- a/internal/api/externalauth.go
+++ b/internal/api/externalauth.go
@@ -43,7 +43,7 @@ const (
 
 type appsAuthExternalStartResponse struct {
 	extendedBaseResponse
-	AuthorizationUrl string `json:"authorization_url"`
+	AuthorizationURL string `json:"authorization_url"`
 }
 
 type appsAuthExternalDeleteResponse struct {
@@ -92,30 +92,30 @@ func (c *Client) AppsAuthExternalStart(ctx context.Context, token, appID, provid
 	}
 
 	var resp appsAuthExternalStartResponse
-	err = goutils.JsonUnmarshal(b, &resp)
+	err = goutils.JSONUnmarshal(b, &resp)
 	if err != nil {
-		return "", errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appsAuthExternalStartMethod)
+		return "", errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(appsAuthExternalStartMethod)
 	}
 
 	if !resp.Ok {
-		return "", slackerror.NewApiError(resp.Error, resp.Description, resp.Errors, appsAuthExternalStartMethod)
+		return "", slackerror.NewAPIError(resp.Error, resp.Description, resp.Errors, appsAuthExternalStartMethod)
 	}
 
-	return resp.AuthorizationUrl, nil
+	return resp.AuthorizationURL, nil
 }
 
-func (c *Client) AppsAuthExternalDelete(ctx context.Context, token, appID, providerKey string, externalTokenId string) error {
+func (c *Client) AppsAuthExternalDelete(ctx context.Context, token, appID, providerKey string, externalTokenID string) error {
 	var span opentracing.Span
 	span, ctx = opentracing.StartSpanFromContext(ctx, "apiclient.AppsAuthExternalDelete")
 	defer span.Finish()
 
 	var body []byte
 	var err error
-	if externalTokenId != "" {
+	if externalTokenID != "" {
 		args := struct {
 			ExternalTokenID string `json:"external_token_id,omitempty"`
 		}{
-			externalTokenId,
+			externalTokenID,
 		}
 		body, err = json.Marshal(args)
 	} else if providerKey == "" {
@@ -146,13 +146,13 @@ func (c *Client) AppsAuthExternalDelete(ctx context.Context, token, appID, provi
 	}
 
 	var resp appsAuthExternalDeleteResponse
-	err = goutils.JsonUnmarshal(b, &resp)
+	err = goutils.JSONUnmarshal(b, &resp)
 	if err != nil {
-		return errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appsAuthExternalDeleteMethod)
+		return errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(appsAuthExternalDeleteMethod)
 	}
 
 	if !resp.Ok {
-		return slackerror.NewApiError(resp.Error, resp.Description, resp.Errors, appsAuthExternalDeleteMethod)
+		return slackerror.NewAPIError(resp.Error, resp.Description, resp.Errors, appsAuthExternalDeleteMethod)
 	}
 
 	return nil
@@ -186,13 +186,13 @@ func (c *Client) AppsAuthExternalClientSecretAdd(ctx context.Context, token, app
 	}
 
 	var resp appsAuthExternalClientSecretAddResponse
-	err = goutils.JsonUnmarshal(b, &resp)
+	err = goutils.JSONUnmarshal(b, &resp)
 	if err != nil {
-		return errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appsAuthExternalClientSecretAddMethod)
+		return errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(appsAuthExternalClientSecretAddMethod)
 	}
 
 	if !resp.Ok {
-		return slackerror.NewApiError(resp.Error, resp.Description, resp.Errors, appsAuthExternalClientSecretAddMethod)
+		return slackerror.NewAPIError(resp.Error, resp.Description, resp.Errors, appsAuthExternalClientSecretAddMethod)
 	}
 
 	return nil
@@ -227,19 +227,19 @@ func (c *Client) AppsAuthExternalList(ctx context.Context, token, appID string, 
 	}
 
 	var resp appsAuthExternalListResponse
-	err = goutils.JsonUnmarshal(b, &resp)
+	err = goutils.JSONUnmarshal(b, &resp)
 	if err != nil {
-		return types.ExternalAuthorizationInfoLists{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appsAuthExternalListMethod)
+		return types.ExternalAuthorizationInfoLists{}, errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(appsAuthExternalListMethod)
 	}
 
 	if !resp.Ok {
-		return types.ExternalAuthorizationInfoLists{}, slackerror.NewApiError(resp.Error, resp.Description, resp.Errors, appsAuthExternalListMethod)
+		return types.ExternalAuthorizationInfoLists{}, slackerror.NewAPIError(resp.Error, resp.Description, resp.Errors, appsAuthExternalListMethod)
 	}
 
 	return types.ExternalAuthorizationInfoLists(resp.appsAuthExternalListResult), nil
 }
 
-func (c *Client) AppsAuthExternalSelectAuth(ctx context.Context, token, appID, providerKey, workflowId, externalTokenId string) error {
+func (c *Client) AppsAuthExternalSelectAuth(ctx context.Context, token, appID, providerKey, workflowID, externalTokenID string) error {
 	var span opentracing.Span
 	span, ctx = opentracing.StartSpanFromContext(ctx, "apiclient.AppsAuthExternalSelectAuth")
 	defer span.Finish()
@@ -249,14 +249,14 @@ func (c *Client) AppsAuthExternalSelectAuth(ctx context.Context, token, appID, p
 	args := struct {
 		AppID            string `json:"app_id,omitempty"`
 		ProviderKey      string `json:"provider_key,omitempty"`
-		WorkflowId       string `json:"workflow_id,omitempty"`
+		WorkflowID       string `json:"workflow_id,omitempty"`
 		ExternalTokenID  string `json:"external_token_id,omitempty"`
 		MappingOwnerType string `json:"mapping_owner_type,omitempty"`
 	}{
 		appID,
 		providerKey,
-		workflowId,
-		externalTokenId,
+		workflowID,
+		externalTokenID,
 		"DEVELOPER",
 	}
 	body, err = json.Marshal(args)
@@ -271,13 +271,13 @@ func (c *Client) AppsAuthExternalSelectAuth(ctx context.Context, token, appID, p
 	}
 
 	var resp appsAuthExternalSelectAuthResponse
-	err = goutils.JsonUnmarshal(b, &resp)
+	err = goutils.JSONUnmarshal(b, &resp)
 	if err != nil {
-		return errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appsAuthExternalSelectAuthMethod)
+		return errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(appsAuthExternalSelectAuthMethod)
 	}
 
 	if !resp.Ok {
-		return slackerror.NewApiError(resp.Error, resp.Description, resp.Errors, appsAuthExternalSelectAuthMethod)
+		return slackerror.NewAPIError(resp.Error, resp.Description, resp.Errors, appsAuthExternalSelectAuthMethod)
 	}
 
 	return nil

--- a/internal/api/externalauth.go
+++ b/internal/api/externalauth.go
@@ -88,13 +88,13 @@ func (c *Client) AppsAuthExternalStart(ctx context.Context, token, appID, provid
 
 	b, err := c.postJSON(ctx, appsAuthExternalStartMethod, token, "", body)
 	if err != nil {
-		return "", errHttpRequestFailed.WithRootCause(err)
+		return "", errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	var resp appsAuthExternalStartResponse
 	err = goutils.JsonUnmarshal(b, &resp)
 	if err != nil {
-		return "", errHttpResponseInvalid.WithRootCause(err).AddApiMethod(appsAuthExternalStartMethod)
+		return "", errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appsAuthExternalStartMethod)
 	}
 
 	if !resp.Ok {
@@ -142,13 +142,13 @@ func (c *Client) AppsAuthExternalDelete(ctx context.Context, token, appID, provi
 
 	b, err := c.postJSON(ctx, appsAuthExternalDeleteMethod, token, "", body)
 	if err != nil {
-		return errHttpRequestFailed.WithRootCause(err)
+		return errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	var resp appsAuthExternalDeleteResponse
 	err = goutils.JsonUnmarshal(b, &resp)
 	if err != nil {
-		return errHttpResponseInvalid.WithRootCause(err).AddApiMethod(appsAuthExternalDeleteMethod)
+		return errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appsAuthExternalDeleteMethod)
 	}
 
 	if !resp.Ok {
@@ -182,13 +182,13 @@ func (c *Client) AppsAuthExternalClientSecretAdd(ctx context.Context, token, app
 
 	b, err := c.postJSON(ctx, appsAuthExternalClientSecretAddMethod, token, "", body)
 	if err != nil {
-		return errHttpRequestFailed.WithRootCause(err)
+		return errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	var resp appsAuthExternalClientSecretAddResponse
 	err = goutils.JsonUnmarshal(b, &resp)
 	if err != nil {
-		return errHttpResponseInvalid.WithRootCause(err).AddApiMethod(appsAuthExternalClientSecretAddMethod)
+		return errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appsAuthExternalClientSecretAddMethod)
 	}
 
 	if !resp.Ok {
@@ -223,13 +223,13 @@ func (c *Client) AppsAuthExternalList(ctx context.Context, token, appID string, 
 
 	b, err := c.postJSON(ctx, appsAuthExternalListMethod, token, "", body)
 	if err != nil {
-		return types.ExternalAuthorizationInfoLists{}, errHttpRequestFailed.WithRootCause(err)
+		return types.ExternalAuthorizationInfoLists{}, errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	var resp appsAuthExternalListResponse
 	err = goutils.JsonUnmarshal(b, &resp)
 	if err != nil {
-		return types.ExternalAuthorizationInfoLists{}, errHttpResponseInvalid.WithRootCause(err).AddApiMethod(appsAuthExternalListMethod)
+		return types.ExternalAuthorizationInfoLists{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appsAuthExternalListMethod)
 	}
 
 	if !resp.Ok {
@@ -267,13 +267,13 @@ func (c *Client) AppsAuthExternalSelectAuth(ctx context.Context, token, appID, p
 
 	b, err := c.postJSON(ctx, appsAuthExternalSelectAuthMethod, token, "", body)
 	if err != nil {
-		return errHttpRequestFailed.WithRootCause(err)
+		return errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	var resp appsAuthExternalSelectAuthResponse
 	err = goutils.JsonUnmarshal(b, &resp)
 	if err != nil {
-		return errHttpResponseInvalid.WithRootCause(err).AddApiMethod(appsAuthExternalSelectAuthMethod)
+		return errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(appsAuthExternalSelectAuthMethod)
 	}
 
 	if !resp.Ok {

--- a/internal/api/externalauth.go
+++ b/internal/api/externalauth.go
@@ -250,7 +250,7 @@ func (c *Client) AppsAuthExternalSelectAuth(ctx context.Context, token, appID, p
 		AppID            string `json:"app_id,omitempty"`
 		ProviderKey      string `json:"provider_key,omitempty"`
 		WorkflowId       string `json:"workflow_id,omitempty"`
-		ExternalTokenId  string `json:"external_token_id,omitempty"`
+		ExternalTokenID  string `json:"external_token_id,omitempty"`
 		MappingOwnerType string `json:"mapping_owner_type,omitempty"`
 	}{
 		appID,

--- a/internal/api/externalauth_test.go
+++ b/internal/api/externalauth_test.go
@@ -60,7 +60,7 @@ func Test_API_AppsAuthExternalStart(t *testing.T) {
 			argsProviderKey:          "provider-key",
 			httpResponseJSON:         `this is not valid json {"ok": true, "authorization_url": "http://slack.com/authorization/url"}`,
 			expectedAuthorizationURL: "",
-			expectedErrorContains:    errHttpResponseInvalid.Code,
+			expectedErrorContains:    errHTTPResponseInvalid.Code,
 		},
 	}
 
@@ -123,7 +123,7 @@ func Test_API_AppsAuthExternalRemove(t *testing.T) {
 			argsAppID:             "A0123",
 			argsProviderKey:       "provider-key",
 			httpResponseJSON:      `this is not valid json {"ok": true}`,
-			expectedErrorContains: errHttpResponseInvalid.Code,
+			expectedErrorContains: errHTTPResponseInvalid.Code,
 		},
 	}
 
@@ -188,7 +188,7 @@ func Test_API_AppsAuthExternalClientSecretAdd(t *testing.T) {
 			argsAppID:             "A0123",
 			argsProviderKey:       "provider-key",
 			httpResponseJSON:      `this is not valid json {"ok": true}`,
-			expectedErrorContains: errHttpResponseInvalid.Code,
+			expectedErrorContains: errHTTPResponseInvalid.Code,
 		},
 	}
 
@@ -367,7 +367,7 @@ func Test_API_AppsAuthExternalList(t *testing.T) {
 			argsToken:             "xoxp-123",
 			argsAppID:             "A0123",
 			httpResponseJSON:      `this is not valid json {"ok": true}`,
-			expectedErrorContains: errHttpResponseInvalid.Code,
+			expectedErrorContains: errHTTPResponseInvalid.Code,
 		},
 	}
 

--- a/internal/api/externalauth_test.go
+++ b/internal/api/externalauth_test.go
@@ -274,10 +274,10 @@ func Test_API_AppsAuthExternalList(t *testing.T) {
 						ClientId:           "xxxxx",
 						ClientSecretExists: true,
 						ValidTokenExists:   true,
-						ExternalTokenIds:   []string{"Et0548LYDWCT"},
+						ExternalTokenIDs:   []string{"Et0548LYDWCT"},
 						ExternalTokens: []types.ExternalTokenInfo{
 							{
-								ExternalTokenId: "Et0548LABCDE",
+								ExternalTokenID: "Et0548LABCDE",
 								ExternalUserId:  "xyz@salesforce.com",
 								DateUpdated:     1682021142,
 							},
@@ -330,10 +330,10 @@ func Test_API_AppsAuthExternalList(t *testing.T) {
 						ClientId:           "xxxxx",
 						ClientSecretExists: true,
 						ValidTokenExists:   true,
-						ExternalTokenIds:   []string{"Et0548LYDWCT"},
+						ExternalTokenIDs:   []string{"Et0548LYDWCT"},
 						ExternalTokens: []types.ExternalTokenInfo{
 							{
-								ExternalTokenId: "Et0548LABCDE",
+								ExternalTokenID: "Et0548LABCDE",
 								ExternalUserId:  "xyz@salesforce.com",
 								DateUpdated:     1682021142,
 							},
@@ -405,7 +405,7 @@ func Test_API_AppsAuthExternalSelectAuth(t *testing.T) {
 		argsAppID             string
 		argsProviderKey       string
 		argsWorkflowId        string
-		argsExternalTokenId   string
+		argsExternalTokenID   string
 		argsMappingOwnerType  string
 		httpResponseJSON      string
 		expectedErrorContains string
@@ -416,7 +416,7 @@ func Test_API_AppsAuthExternalSelectAuth(t *testing.T) {
 			argsAppID:             "A0123",
 			argsProviderKey:       "provider-key",
 			argsWorkflowId:        "WABCD12",
-			argsExternalTokenId:   "ET1234AB",
+			argsExternalTokenID:   "ET1234AB",
 			argsMappingOwnerType:  "DEVELOPER",
 			httpResponseJSON:      `{"ok": true}`,
 			expectedErrorContains: "",
@@ -427,7 +427,7 @@ func Test_API_AppsAuthExternalSelectAuth(t *testing.T) {
 			argsAppID:             "A0123",
 			argsProviderKey:       "provider-key",
 			argsWorkflowId:        "WABCD12",
-			argsExternalTokenId:   "",
+			argsExternalTokenID:   "",
 			argsMappingOwnerType:  "DEVELOPER",
 			httpResponseJSON:      `{"ok":false,"error":"token id cannot be empty"}`,
 			expectedErrorContains: "token id cannot be empty",
@@ -438,7 +438,7 @@ func Test_API_AppsAuthExternalSelectAuth(t *testing.T) {
 			argsAppID:             "A0123",
 			argsProviderKey:       "provider-key",
 			argsWorkflowId:        "WABCD12",
-			argsExternalTokenId:   "",
+			argsExternalTokenID:   "",
 			httpResponseJSON:      `{"ok":false,"error":"this is not valid json"}`,
 			expectedErrorContains: "this is not valid json",
 		},
@@ -459,7 +459,7 @@ func Test_API_AppsAuthExternalSelectAuth(t *testing.T) {
 			apiClient := NewClient(&http.Client{}, ts.URL, nil)
 
 			// Execute test
-			err := apiClient.AppsAuthExternalSelectAuth(ctx, tt.argsToken, tt.argsAppID, tt.argsProviderKey, tt.argsWorkflowId, tt.argsExternalTokenId)
+			err := apiClient.AppsAuthExternalSelectAuth(ctx, tt.argsToken, tt.argsAppID, tt.argsProviderKey, tt.argsWorkflowId, tt.argsExternalTokenID)
 
 			// Assertions
 			if tt.expectedErrorContains == "" {

--- a/internal/api/externalauth_test.go
+++ b/internal/api/externalauth_test.go
@@ -238,7 +238,7 @@ func Test_API_AppsAuthExternalList(t *testing.T) {
 					{
 						ProviderName:       "Google",
 						ProviderKey:        "google",
-						ClientId:           "xxxxx",
+						ClientID:           "xxxxx",
 						ClientSecretExists: true,
 						ValidTokenExists:   true,
 					},
@@ -271,14 +271,14 @@ func Test_API_AppsAuthExternalList(t *testing.T) {
 					{
 						ProviderName:       "Google",
 						ProviderKey:        "google",
-						ClientId:           "xxxxx",
+						ClientID:           "xxxxx",
 						ClientSecretExists: true,
 						ValidTokenExists:   true,
 						ExternalTokenIDs:   []string{"Et0548LYDWCT"},
 						ExternalTokens: []types.ExternalTokenInfo{
 							{
 								ExternalTokenID: "Et0548LABCDE",
-								ExternalUserId:  "xyz@salesforce.com",
+								ExternalUserID:  "xyz@salesforce.com",
 								DateUpdated:     1682021142,
 							},
 						},
@@ -327,14 +327,14 @@ func Test_API_AppsAuthExternalList(t *testing.T) {
 					{
 						ProviderName:       "Google",
 						ProviderKey:        "google",
-						ClientId:           "xxxxx",
+						ClientID:           "xxxxx",
 						ClientSecretExists: true,
 						ValidTokenExists:   true,
 						ExternalTokenIDs:   []string{"Et0548LYDWCT"},
 						ExternalTokens: []types.ExternalTokenInfo{
 							{
 								ExternalTokenID: "Et0548LABCDE",
-								ExternalUserId:  "xyz@salesforce.com",
+								ExternalUserID:  "xyz@salesforce.com",
 								DateUpdated:     1682021142,
 							},
 						},
@@ -342,8 +342,8 @@ func Test_API_AppsAuthExternalList(t *testing.T) {
 				},
 				Workflows: []types.WorkflowsInfo{
 					{
-						WorkflowId: "Wf04QXGCK3FF",
-						CallBackId: "external_auth_demo_workflow",
+						WorkflowID: "Wf04QXGCK3FF",
+						CallBackID: "external_auth_demo_workflow",
 						Providers: []types.ProvidersInfo{
 							{
 								ProviderName: "Google",
@@ -404,7 +404,7 @@ func Test_API_AppsAuthExternalSelectAuth(t *testing.T) {
 		argsToken             string
 		argsAppID             string
 		argsProviderKey       string
-		argsWorkflowId        string
+		argsWorkflowID        string
 		argsExternalTokenID   string
 		argsMappingOwnerType  string
 		httpResponseJSON      string
@@ -415,7 +415,7 @@ func Test_API_AppsAuthExternalSelectAuth(t *testing.T) {
 			argsToken:             "xoxp-123",
 			argsAppID:             "A0123",
 			argsProviderKey:       "provider-key",
-			argsWorkflowId:        "WABCD12",
+			argsWorkflowID:        "WABCD12",
 			argsExternalTokenID:   "ET1234AB",
 			argsMappingOwnerType:  "DEVELOPER",
 			httpResponseJSON:      `{"ok": true}`,
@@ -426,7 +426,7 @@ func Test_API_AppsAuthExternalSelectAuth(t *testing.T) {
 			argsToken:             "xoxp-123",
 			argsAppID:             "A0123",
 			argsProviderKey:       "provider-key",
-			argsWorkflowId:        "WABCD12",
+			argsWorkflowID:        "WABCD12",
 			argsExternalTokenID:   "",
 			argsMappingOwnerType:  "DEVELOPER",
 			httpResponseJSON:      `{"ok":false,"error":"token id cannot be empty"}`,
@@ -437,7 +437,7 @@ func Test_API_AppsAuthExternalSelectAuth(t *testing.T) {
 			argsToken:             "xoxp-123",
 			argsAppID:             "A0123",
 			argsProviderKey:       "provider-key",
-			argsWorkflowId:        "WABCD12",
+			argsWorkflowID:        "WABCD12",
 			argsExternalTokenID:   "",
 			httpResponseJSON:      `{"ok":false,"error":"this is not valid json"}`,
 			expectedErrorContains: "this is not valid json",
@@ -459,7 +459,7 @@ func Test_API_AppsAuthExternalSelectAuth(t *testing.T) {
 			apiClient := NewClient(&http.Client{}, ts.URL, nil)
 
 			// Execute test
-			err := apiClient.AppsAuthExternalSelectAuth(ctx, tt.argsToken, tt.argsAppID, tt.argsProviderKey, tt.argsWorkflowId, tt.argsExternalTokenID)
+			err := apiClient.AppsAuthExternalSelectAuth(ctx, tt.argsToken, tt.argsAppID, tt.argsProviderKey, tt.argsWorkflowID, tt.argsExternalTokenID)
 
 			// Assertions
 			if tt.expectedErrorContains == "" {

--- a/internal/api/functiondistribution.go
+++ b/internal/api/functiondistribution.go
@@ -110,7 +110,7 @@ func (c *Client) FunctionDistributionSet(ctx context.Context, callbackID, appID 
 	values.Add("function_callback_id", callbackID)
 	values.Add("function_app_id", appID)
 	values.Add("distribution_type", string(distributionType))
-	if distributionType == types.NAMED_ENTITIES && len(users) > 0 {
+	if distributionType == types.PermissionNamedEntities && len(users) > 0 {
 		values.Add("user_ids", users)
 	}
 

--- a/internal/api/functiondistribution.go
+++ b/internal/api/functiondistribution.go
@@ -62,18 +62,18 @@ func (c *Client) FunctionDistributionList(ctx context.Context, callbackID, appID
 
 	b, err := c.postForm(ctx, functionDistributionsPermissionsListMethod, values)
 	if err != nil {
-		return "", []types.FunctionDistributionUser{}, errHttpRequestFailed.WithRootCause(err)
+		return "", []types.FunctionDistributionUser{}, errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	if b == nil {
-		return "", []types.FunctionDistributionUser{}, errHttpResponseInvalid.WithRootCause(slackerror.New("empty body"))
+		return "", []types.FunctionDistributionUser{}, errHTTPResponseInvalid.WithRootCause(slackerror.New("empty body"))
 	}
 
 	resp := FunctionDistributionListResponse{}
 	err = goutils.JsonUnmarshal(b, &resp)
 
 	if err != nil {
-		return "", []types.FunctionDistributionUser{}, errHttpResponseInvalid.WithRootCause(err).AddApiMethod(functionDistributionsPermissionsListMethod)
+		return "", []types.FunctionDistributionUser{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(functionDistributionsPermissionsListMethod)
 	}
 
 	if !resp.Ok {
@@ -116,18 +116,18 @@ func (c *Client) FunctionDistributionSet(ctx context.Context, callbackID, appID 
 
 	b, err := c.postForm(ctx, functionDistributionsPermissionsSetMethod, values)
 	if err != nil {
-		return []types.FunctionDistributionUser{}, errHttpRequestFailed.WithRootCause(err)
+		return []types.FunctionDistributionUser{}, errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	if b == nil {
-		return []types.FunctionDistributionUser{}, errHttpResponseInvalid.WithRootCause(slackerror.New("empty body"))
+		return []types.FunctionDistributionUser{}, errHTTPResponseInvalid.WithRootCause(slackerror.New("empty body"))
 	}
 
 	resp := FunctionDistributionSetResponse{}
 	err = goutils.JsonUnmarshal(b, &resp)
 
 	if err != nil {
-		return []types.FunctionDistributionUser{}, errHttpResponseInvalid.WithRootCause(err).AddApiMethod(functionDistributionsPermissionsSetMethod)
+		return []types.FunctionDistributionUser{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(functionDistributionsPermissionsSetMethod)
 	}
 
 	if !resp.Ok {
@@ -158,18 +158,18 @@ func (c *Client) FunctionDistributionAddUsers(ctx context.Context, callbackID, a
 
 	b, err := c.postForm(ctx, functionDistributionsPermissionsAddMethod, values)
 	if err != nil {
-		return errHttpRequestFailed.WithRootCause(err)
+		return errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	if b == nil {
-		return errHttpResponseInvalid.WithRootCause(slackerror.New("empty body"))
+		return errHTTPResponseInvalid.WithRootCause(slackerror.New("empty body"))
 	}
 
 	resp := FunctionDistributionAddUsersResponse{}
 	err = goutils.JsonUnmarshal(b, &resp)
 
 	if err != nil {
-		return errHttpResponseInvalid.WithRootCause(err).AddApiMethod(functionDistributionsPermissionsAddMethod)
+		return errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(functionDistributionsPermissionsAddMethod)
 	}
 
 	if !resp.Ok {
@@ -200,18 +200,18 @@ func (c *Client) FunctionDistributionRemoveUsers(ctx context.Context, callbackID
 
 	b, err := c.postForm(ctx, functionDistributionsPermissionsRemoveMethod, values)
 	if err != nil {
-		return errHttpRequestFailed.WithRootCause(err)
+		return errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	if b == nil {
-		return errHttpResponseInvalid.WithRootCause(slackerror.New("empty body"))
+		return errHTTPResponseInvalid.WithRootCause(slackerror.New("empty body"))
 	}
 
 	resp := FunctionDistributionRemoveUsersResponse{}
 	err = goutils.JsonUnmarshal(b, &resp)
 
 	if err != nil {
-		return errHttpResponseInvalid.WithRootCause(err).AddApiMethod(functionDistributionsPermissionsRemoveMethod)
+		return errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(functionDistributionsPermissionsRemoveMethod)
 	}
 
 	if !resp.Ok {

--- a/internal/api/functiondistribution.go
+++ b/internal/api/functiondistribution.go
@@ -70,20 +70,20 @@ func (c *Client) FunctionDistributionList(ctx context.Context, callbackID, appID
 	}
 
 	resp := FunctionDistributionListResponse{}
-	err = goutils.JsonUnmarshal(b, &resp)
+	err = goutils.JSONUnmarshal(b, &resp)
 
 	if err != nil {
-		return "", []types.FunctionDistributionUser{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(functionDistributionsPermissionsListMethod)
+		return "", []types.FunctionDistributionUser{}, errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(functionDistributionsPermissionsListMethod)
 	}
 
 	if !resp.Ok {
-		return "", []types.FunctionDistributionUser{}, slackerror.NewApiError(resp.Error, resp.Description, resp.Errors, functionDistributionsPermissionsListMethod)
+		return "", []types.FunctionDistributionUser{}, slackerror.NewAPIError(resp.Error, resp.Description, resp.Errors, functionDistributionsPermissionsListMethod)
 	}
 
 	dist := types.Permission(strings.ToLower(resp.DistributionType))
 	if !dist.IsValid() {
 		errStr := fmt.Sprintf("unrecognized access type %s", dist)
-		return "", []types.FunctionDistributionUser{}, slackerror.New(errStr).AddApiMethod(functionDistributionsPermissionsListMethod)
+		return "", []types.FunctionDistributionUser{}, slackerror.New(errStr).AddAPIMethod(functionDistributionsPermissionsListMethod)
 
 	}
 
@@ -124,14 +124,14 @@ func (c *Client) FunctionDistributionSet(ctx context.Context, callbackID, appID 
 	}
 
 	resp := FunctionDistributionSetResponse{}
-	err = goutils.JsonUnmarshal(b, &resp)
+	err = goutils.JSONUnmarshal(b, &resp)
 
 	if err != nil {
-		return []types.FunctionDistributionUser{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(functionDistributionsPermissionsSetMethod)
+		return []types.FunctionDistributionUser{}, errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(functionDistributionsPermissionsSetMethod)
 	}
 
 	if !resp.Ok {
-		return []types.FunctionDistributionUser{}, slackerror.NewApiError(resp.Error, resp.Description, resp.Errors, functionDistributionsPermissionsSetMethod)
+		return []types.FunctionDistributionUser{}, slackerror.NewAPIError(resp.Error, resp.Description, resp.Errors, functionDistributionsPermissionsSetMethod)
 	}
 
 	return resp.Users, nil
@@ -166,14 +166,14 @@ func (c *Client) FunctionDistributionAddUsers(ctx context.Context, callbackID, a
 	}
 
 	resp := FunctionDistributionAddUsersResponse{}
-	err = goutils.JsonUnmarshal(b, &resp)
+	err = goutils.JSONUnmarshal(b, &resp)
 
 	if err != nil {
-		return errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(functionDistributionsPermissionsAddMethod)
+		return errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(functionDistributionsPermissionsAddMethod)
 	}
 
 	if !resp.Ok {
-		return slackerror.NewApiError(resp.Error, resp.Description, resp.Errors, functionDistributionsPermissionsAddMethod)
+		return slackerror.NewAPIError(resp.Error, resp.Description, resp.Errors, functionDistributionsPermissionsAddMethod)
 	}
 
 	return nil
@@ -208,14 +208,14 @@ func (c *Client) FunctionDistributionRemoveUsers(ctx context.Context, callbackID
 	}
 
 	resp := FunctionDistributionRemoveUsersResponse{}
-	err = goutils.JsonUnmarshal(b, &resp)
+	err = goutils.JSONUnmarshal(b, &resp)
 
 	if err != nil {
-		return errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(functionDistributionsPermissionsRemoveMethod)
+		return errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(functionDistributionsPermissionsRemoveMethod)
 	}
 
 	if !resp.Ok {
-		return slackerror.NewApiError(resp.Error, resp.Description, resp.Errors, functionDistributionsPermissionsRemoveMethod)
+		return slackerror.NewAPIError(resp.Error, resp.Description, resp.Errors, functionDistributionsPermissionsRemoveMethod)
 	}
 
 	return nil

--- a/internal/api/functiondistribution_test.go
+++ b/internal/api/functiondistribution_test.go
@@ -29,7 +29,7 @@ func TestClient_AddRemoveSetAccess(t *testing.T) {
 	tests := []struct {
 		name         string
 		expectedPath string
-		resultJson   string
+		resultJSON   string
 		testFunc     func(t *testing.T, c *Client) error
 		want         string
 		wantErr      bool
@@ -37,7 +37,7 @@ func TestClient_AddRemoveSetAccess(t *testing.T) {
 	}{
 		{
 			name:       "Add user success",
-			resultJson: `{"ok": true, "distribution_type": "named_entities", "user_ids": ["user1", "user2"]}`,
+			resultJSON: `{"ok": true, "distribution_type": "named_entities", "user_ids": ["user1", "user2"]}`,
 			testFunc: func(t *testing.T, c *Client) error {
 				ctx := slackcontext.MockContext(t.Context())
 				return c.FunctionDistributionAddUsers(ctx, "valid_function", "app", "user1,user2")
@@ -45,7 +45,7 @@ func TestClient_AddRemoveSetAccess(t *testing.T) {
 		},
 		{
 			name:       "Add user: validation error",
-			resultJson: `{"ok": false, "error":"user_not_found"}`,
+			resultJSON: `{"ok": false, "error":"user_not_found"}`,
 			testFunc: func(t *testing.T, c *Client) error {
 				ctx := slackcontext.MockContext(t.Context())
 				return c.FunctionDistributionAddUsers(ctx, "valid_function", "app", "user1,user2")
@@ -55,7 +55,7 @@ func TestClient_AddRemoveSetAccess(t *testing.T) {
 		},
 		{
 			name:       "Remove user success",
-			resultJson: `{"ok": true, "distribution_type": "named_entities", "user_ids": []}`,
+			resultJSON: `{"ok": true, "distribution_type": "named_entities", "user_ids": []}`,
 			testFunc: func(t *testing.T, c *Client) error {
 				ctx := slackcontext.MockContext(t.Context())
 				return c.FunctionDistributionRemoveUsers(ctx, "valid_function", "app", "user1,user2")
@@ -63,7 +63,7 @@ func TestClient_AddRemoveSetAccess(t *testing.T) {
 		},
 		{
 			name:       "Remove user: distribution type not named_entitied",
-			resultJson: `{"ok":false,"error":"invalid_distribution_type"}`,
+			resultJSON: `{"ok":false,"error":"invalid_distribution_type"}`,
 			testFunc: func(t *testing.T, c *Client) error {
 				ctx := slackcontext.MockContext(t.Context())
 				return c.FunctionDistributionRemoveUsers(ctx, "valid_function", "app", "user1,user2")
@@ -73,7 +73,7 @@ func TestClient_AddRemoveSetAccess(t *testing.T) {
 		},
 		{
 			name:       "Set access type success",
-			resultJson: `{"ok": true, "distribution_type": "everyone", "user_ids": []}`,
+			resultJSON: `{"ok": true, "distribution_type": "everyone", "user_ids": []}`,
 			testFunc: func(t *testing.T, c *Client) error {
 				ctx := slackcontext.MockContext(t.Context())
 				_, err := c.FunctionDistributionSet(ctx, "valid_function", "app", types.EVERYONE, "")
@@ -82,7 +82,7 @@ func TestClient_AddRemoveSetAccess(t *testing.T) {
 		},
 		{
 			name:       "Set access type: access type not recognized by backend",
-			resultJson: `{"ok":false,"error":"invalid_arguments"}`,
+			resultJSON: `{"ok":false,"error":"invalid_arguments"}`,
 			testFunc: func(t *testing.T, c *Client) error {
 				ctx := slackcontext.MockContext(t.Context())
 				_, err := c.FunctionDistributionSet(ctx, "valid_function", "app", types.EVERYONE, "")
@@ -97,7 +97,7 @@ func TestClient_AddRemoveSetAccess(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// prepare
 			handlerFunc := func(w http.ResponseWriter, r *http.Request) {
-				result := tt.resultJson
+				result := tt.resultJSON
 				_, err := fmt.Fprintln(w, result)
 				require.NoError(t, err)
 			}

--- a/internal/api/functiondistribution_test.go
+++ b/internal/api/functiondistribution_test.go
@@ -76,7 +76,7 @@ func TestClient_AddRemoveSetAccess(t *testing.T) {
 			resultJSON: `{"ok": true, "distribution_type": "everyone", "user_ids": []}`,
 			testFunc: func(t *testing.T, c *Client) error {
 				ctx := slackcontext.MockContext(t.Context())
-				_, err := c.FunctionDistributionSet(ctx, "valid_function", "app", types.EVERYONE, "")
+				_, err := c.FunctionDistributionSet(ctx, "valid_function", "app", types.PermissionEveryone, "")
 				return err
 			},
 		},
@@ -85,7 +85,7 @@ func TestClient_AddRemoveSetAccess(t *testing.T) {
 			resultJSON: `{"ok":false,"error":"invalid_arguments"}`,
 			testFunc: func(t *testing.T, c *Client) error {
 				ctx := slackcontext.MockContext(t.Context())
-				_, err := c.FunctionDistributionSet(ctx, "valid_function", "app", types.EVERYONE, "")
+				_, err := c.FunctionDistributionSet(ctx, "valid_function", "app", types.PermissionEveryone, "")
 				return err
 			},
 			wantErr:    true,

--- a/internal/api/httpclient.go
+++ b/internal/api/httpclient.go
@@ -25,7 +25,7 @@ const (
 )
 
 // Options allows a user of this lib to customize their http Client.
-type HttpClientOptions struct {
+type HTTPClientOptions struct {
 	TotalTimeOut     time.Duration // total time for the life of the request.
 	SkipTLSVerify    bool
 	Retries          int            // how many times we should retry, if 0 no retry logic is added.
@@ -36,7 +36,7 @@ type HttpClientOptions struct {
 }
 
 // New returns an http.Client based on a given Options input.
-func NewHttpClient(opts HttpClientOptions) *http.Client {
+func NewHTTPClient(opts HTTPClientOptions) *http.Client {
 	var client http.Client
 
 	if opts.TotalTimeOut == 0 {

--- a/internal/api/icon_mock.go
+++ b/internal/api/icon_mock.go
@@ -20,7 +20,7 @@ import (
 	"github.com/spf13/afero"
 )
 
-func (m *ApiMock) Icon(ctx context.Context, fs afero.Fs, token, appID, iconFilePath string) (IconResult, error) {
+func (m *APIMock) Icon(ctx context.Context, fs afero.Fs, token, appID, iconFilePath string) (IconResult, error) {
 	args := m.Called(ctx, fs, token, iconFilePath)
 	return args.Get(0).(IconResult), args.Error(1)
 }

--- a/internal/api/s3_upload.go
+++ b/internal/api/s3_upload.go
@@ -100,7 +100,7 @@ func (c *Client) UploadPackageToS3(ctx context.Context, fs afero.Fs, appID strin
 	writer.Close()
 
 	var request *http.Request
-	request, err = http.NewRequestWithContext(ctx, "POST", uploadParams.Url, uploadbody)
+	request, err = http.NewRequestWithContext(ctx, "POST", uploadParams.URL, uploadbody)
 	if err != nil {
 		return fileName, err
 	}

--- a/internal/api/s3_upload_mock.go
+++ b/internal/api/s3_upload_mock.go
@@ -20,7 +20,7 @@ import (
 	"github.com/spf13/afero"
 )
 
-func (m *ApiMock) UploadPackageToS3(ctx context.Context, fs afero.Fs, appID string, uploadParams GenerateS3PresignedPostResult, archiveFilePath string) (string, error) {
+func (m *APIMock) UploadPackageToS3(ctx context.Context, fs afero.Fs, appID string, uploadParams GenerateS3PresignedPostResult, archiveFilePath string) (string, error) {
 	args := m.Called(ctx, fs, appID, uploadParams, archiveFilePath)
 	return args.String(0), args.Error(1)
 }

--- a/internal/api/s3_upload_test.go
+++ b/internal/api/s3_upload_test.go
@@ -76,7 +76,7 @@ func TestClient_UploadPackageToS3(t *testing.T) {
 	client := NewClient(&http.Client{}, server.URL, nil)
 
 	s3Params := GenerateS3PresignedPostResult{
-		Url:      server.URL + "/s3upload",
+		URL:      server.URL + "/s3upload",
 		FileName: "foo.txt",
 		Fields: PresignedPostFields{
 			AmzCredentials:    creds,

--- a/internal/api/session.go
+++ b/internal/api/session.go
@@ -47,17 +47,17 @@ func (c *Client) ValidateSession(ctx context.Context, token string) (AuthSession
 
 	b, err := c.postForm(ctx, sessionValidateMethod, url.Values{"token": []string{token}})
 	if err != nil {
-		return AuthSession{}, errHttpRequestFailed.WithRootCause(err)
+		return AuthSession{}, errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	if b == nil {
-		return AuthSession{}, errHttpResponseInvalid.WithRootCause(slackerror.New("empty body"))
+		return AuthSession{}, errHTTPResponseInvalid.WithRootCause(slackerror.New("empty body"))
 	}
 
 	var authResp authCheckResponse
 	err = goutils.JsonUnmarshal(b, &authResp)
 	if err != nil {
-		return AuthSession{}, errHttpResponseInvalid.WithRootCause(err).AddApiMethod(sessionValidateMethod)
+		return AuthSession{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(sessionValidateMethod)
 	}
 
 	if !authResp.Ok {
@@ -65,7 +65,7 @@ func (c *Client) ValidateSession(ctx context.Context, token string) (AuthSession
 	}
 
 	if authResp.UserID == nil {
-		return AuthSession{}, errHttpResponseInvalid.WithRootCause(slackerror.New("invalid user_id"))
+		return AuthSession{}, errHTTPResponseInvalid.WithRootCause(slackerror.New("invalid user_id"))
 	}
 
 	return authResp.AuthSession, nil
@@ -95,17 +95,17 @@ func (c *Client) RevokeToken(ctx context.Context, token string) error {
 
 	b, err := c.postForm(ctx, revokeTokenMethod, url.Values{"token": []string{token}})
 	if err != nil {
-		return errHttpRequestFailed.WithRootCause(err)
+		return errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	if b == nil {
-		return errHttpResponseInvalid.WithRootCause(slackerror.New("empty body"))
+		return errHTTPResponseInvalid.WithRootCause(slackerror.New("empty body"))
 	}
 
 	var revokeResp authRevokeResponse
 	err = goutils.JsonUnmarshal(b, &revokeResp)
 	if err != nil {
-		return errHttpResponseInvalid.WithRootCause(err).AddApiMethod(revokeTokenMethod)
+		return errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(revokeTokenMethod)
 	}
 
 	if !revokeResp.Ok {

--- a/internal/api/session.go
+++ b/internal/api/session.go
@@ -55,13 +55,13 @@ func (c *Client) ValidateSession(ctx context.Context, token string) (AuthSession
 	}
 
 	var authResp authCheckResponse
-	err = goutils.JsonUnmarshal(b, &authResp)
+	err = goutils.JSONUnmarshal(b, &authResp)
 	if err != nil {
-		return AuthSession{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(sessionValidateMethod)
+		return AuthSession{}, errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(sessionValidateMethod)
 	}
 
 	if !authResp.Ok {
-		return AuthSession{}, slackerror.NewApiError(authResp.Error, authResp.Description, authResp.Errors, sessionValidateMethod)
+		return AuthSession{}, slackerror.NewAPIError(authResp.Error, authResp.Description, authResp.Errors, sessionValidateMethod)
 	}
 
 	if authResp.UserID == nil {
@@ -103,13 +103,13 @@ func (c *Client) RevokeToken(ctx context.Context, token string) error {
 	}
 
 	var revokeResp authRevokeResponse
-	err = goutils.JsonUnmarshal(b, &revokeResp)
+	err = goutils.JSONUnmarshal(b, &revokeResp)
 	if err != nil {
-		return errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(revokeTokenMethod)
+		return errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(revokeTokenMethod)
 	}
 
 	if !revokeResp.Ok {
-		return slackerror.NewApiError(revokeResp.Error, revokeResp.Description, revokeResp.Errors, revokeTokenMethod)
+		return slackerror.NewAPIError(revokeResp.Error, revokeResp.Description, revokeResp.Errors, revokeTokenMethod)
 	}
 
 	return nil

--- a/internal/api/session_test.go
+++ b/internal/api/session_test.go
@@ -162,7 +162,7 @@ func TestClient_RevokeToken_NotOk_MappedErrorMsgs(t *testing.T) {
 	require.Contains(t, err.Error(), "token_expired")
 }
 
-func TestClient_RevokeToken_JsonUnmarshalFail(t *testing.T) {
+func TestClient_RevokeToken_JSONUnmarshalFail(t *testing.T) {
 	ctx := slackcontext.MockContext(t.Context())
 	c, teardown := NewFakeClient(t, FakeClientParams{
 		ExpectedMethod: revokeTokenMethod,

--- a/internal/api/steps.go
+++ b/internal/api/steps.go
@@ -69,13 +69,13 @@ func (c *Client) StepsList(ctx context.Context, token string, workflow string, a
 
 	b, err := c.postJSON(ctx, workflowsStepsListMethod, token, "", body)
 	if err != nil {
-		return []StepVersion{}, errHttpRequestFailed.WithRootCause(err)
+		return []StepVersion{}, errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	resp := stepsListResponse{}
 	err = goutils.JsonUnmarshal(b, &resp)
 	if err != nil {
-		return []StepVersion{}, errHttpResponseInvalid.WithRootCause(err).AddApiMethod(workflowsStepsListMethod)
+		return []StepVersion{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(workflowsStepsListMethod)
 	}
 
 	if !resp.Ok {
@@ -103,13 +103,13 @@ func (c *Client) StepsResponsesExport(ctx context.Context, token string, workflo
 
 	b, err := c.postJSON(ctx, workflowsStepsResponsesExportMethod, token, "", body)
 	if err != nil {
-		return errHttpRequestFailed.WithRootCause(err)
+		return errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	resp := exportResponse{}
 	err = goutils.JsonUnmarshal(b, &resp)
 	if err != nil {
-		return errHttpResponseInvalid.WithRootCause(err).AddApiMethod(workflowsStepsResponsesExportMethod)
+		return errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(workflowsStepsResponsesExportMethod)
 	}
 
 	if !resp.Ok {

--- a/internal/api/steps.go
+++ b/internal/api/steps.go
@@ -27,7 +27,7 @@ const (
 	workflowsStepsResponsesExportMethod = "functions.workflows.steps.responses.export"
 )
 
-const openFormFunctionId = "Fn010N"
+const openFormFunctionID = "Fn010N"
 
 type StepVersion struct {
 	Title                  string `json:"title"`
@@ -47,19 +47,19 @@ type exportResponse struct {
 }
 
 type StepsClient interface {
-	StepsList(ctx context.Context, token string, workflow string, appId string) ([]StepVersion, error)
-	StepsResponsesExport(ctx context.Context, token string, workflow string, appId string, stepId string) error
+	StepsList(ctx context.Context, token string, workflow string, appID string) ([]StepVersion, error)
+	StepsResponsesExport(ctx context.Context, token string, workflow string, appID string, stepID string) error
 }
 
-func (c *Client) StepsList(ctx context.Context, token string, workflow string, appId string) ([]StepVersion, error) {
+func (c *Client) StepsList(ctx context.Context, token string, workflow string, appID string) ([]StepVersion, error) {
 	args := struct {
-		WorkflowAppId string `json:"workflow_app_id"`
+		WorkflowAppID string `json:"workflow_app_id"`
 		Workflow      string `json:"workflow"`
-		FunctionId    string `json:"function_id"`
+		FunctionID    string `json:"function_id"`
 	}{
-		appId,
+		appID,
 		workflow,
-		openFormFunctionId,
+		openFormFunctionID,
 	}
 
 	body, err := json.Marshal(args)
@@ -73,27 +73,27 @@ func (c *Client) StepsList(ctx context.Context, token string, workflow string, a
 	}
 
 	resp := stepsListResponse{}
-	err = goutils.JsonUnmarshal(b, &resp)
+	err = goutils.JSONUnmarshal(b, &resp)
 	if err != nil {
-		return []StepVersion{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(workflowsStepsListMethod)
+		return []StepVersion{}, errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(workflowsStepsListMethod)
 	}
 
 	if !resp.Ok {
-		return []StepVersion{}, slackerror.NewApiError(resp.Error, resp.Description, resp.Errors, workflowsStepsListMethod)
+		return []StepVersion{}, slackerror.NewAPIError(resp.Error, resp.Description, resp.Errors, workflowsStepsListMethod)
 	}
 
 	return resp.StepVersions, nil
 }
 
-func (c *Client) StepsResponsesExport(ctx context.Context, token string, workflow string, appId string, stepId string) error {
+func (c *Client) StepsResponsesExport(ctx context.Context, token string, workflow string, appID string, stepID string) error {
 	args := struct {
-		WorkflowAppId string `json:"workflow_app_id"`
+		WorkflowAppID string `json:"workflow_app_id"`
 		Workflow      string `json:"workflow"`
-		StepId        string `json:"step_id"`
+		StepID        string `json:"step_id"`
 	}{
-		appId,
+		appID,
 		workflow,
-		stepId,
+		stepID,
 	}
 
 	body, err := json.Marshal(args)
@@ -107,13 +107,13 @@ func (c *Client) StepsResponsesExport(ctx context.Context, token string, workflo
 	}
 
 	resp := exportResponse{}
-	err = goutils.JsonUnmarshal(b, &resp)
+	err = goutils.JSONUnmarshal(b, &resp)
 	if err != nil {
-		return errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(workflowsStepsResponsesExportMethod)
+		return errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(workflowsStepsResponsesExportMethod)
 	}
 
 	if !resp.Ok {
-		return slackerror.NewApiError(resp.Error, resp.Description, resp.Errors, workflowsStepsResponsesExportMethod)
+		return slackerror.NewAPIError(resp.Error, resp.Description, resp.Errors, workflowsStepsResponsesExportMethod)
 	}
 
 	return nil

--- a/internal/api/teams.go
+++ b/internal/api/teams.go
@@ -61,14 +61,14 @@ func (c *Client) TeamsInfo(ctx context.Context, token, teamID string) (*types.Te
 	}
 
 	resp := TeamInfoResponse{}
-	err = goutils.JsonUnmarshal(b, &resp)
+	err = goutils.JSONUnmarshal(b, &resp)
 
 	if err != nil {
-		return nil, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(workflowsTriggersPermissionsListMethod)
+		return nil, errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(workflowsTriggersPermissionsListMethod)
 	}
 
 	if !resp.Ok {
-		return nil, slackerror.NewApiError(resp.Error, resp.Description, resp.Errors, workflowsTriggersPermissionsListMethod)
+		return nil, slackerror.NewAPIError(resp.Error, resp.Description, resp.Errors, workflowsTriggersPermissionsListMethod)
 	}
 
 	return &resp.Team, nil
@@ -108,14 +108,14 @@ func (c *Client) AuthTeamsList(ctx context.Context, token string, limit int) ([]
 	}
 
 	resp := AuthTeamsListResponse{}
-	err = goutils.JsonUnmarshal(b, &resp)
+	err = goutils.JSONUnmarshal(b, &resp)
 
 	if err != nil {
-		return nil, "", errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(authTeamsListMethod)
+		return nil, "", errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(authTeamsListMethod)
 	}
 
 	if !resp.Ok {
-		return nil, "", slackerror.NewApiError(resp.Error, resp.Description, resp.Errors, authTeamsListMethod)
+		return nil, "", slackerror.NewAPIError(resp.Error, resp.Description, resp.Errors, authTeamsListMethod)
 	}
 
 	sort.Slice(resp.Teams, func(i, j int) bool {

--- a/internal/api/teams.go
+++ b/internal/api/teams.go
@@ -53,18 +53,18 @@ func (c *Client) TeamsInfo(ctx context.Context, token, teamID string) (*types.Te
 
 	b, err := c.postForm(ctx, teamsInfoMethod, values)
 	if err != nil {
-		return nil, errHttpRequestFailed.WithRootCause(err)
+		return nil, errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	if b == nil {
-		return nil, errHttpResponseInvalid.WithRootCause(slackerror.New("empty body"))
+		return nil, errHTTPResponseInvalid.WithRootCause(slackerror.New("empty body"))
 	}
 
 	resp := TeamInfoResponse{}
 	err = goutils.JsonUnmarshal(b, &resp)
 
 	if err != nil {
-		return nil, errHttpResponseInvalid.WithRootCause(err).AddApiMethod(workflowsTriggersPermissionsListMethod)
+		return nil, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(workflowsTriggersPermissionsListMethod)
 	}
 
 	if !resp.Ok {
@@ -100,18 +100,18 @@ func (c *Client) AuthTeamsList(ctx context.Context, token string, limit int) ([]
 
 	b, err := c.postForm(ctx, authTeamsListMethod, values)
 	if err != nil {
-		return nil, "", errHttpRequestFailed.WithRootCause(err)
+		return nil, "", errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	if b == nil {
-		return nil, "", errHttpResponseInvalid.WithRootCause(slackerror.New("empty body"))
+		return nil, "", errHTTPResponseInvalid.WithRootCause(slackerror.New("empty body"))
 	}
 
 	resp := AuthTeamsListResponse{}
 	err = goutils.JsonUnmarshal(b, &resp)
 
 	if err != nil {
-		return nil, "", errHttpResponseInvalid.WithRootCause(err).AddApiMethod(authTeamsListMethod)
+		return nil, "", errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(authTeamsListMethod)
 	}
 
 	if !resp.Ok {

--- a/internal/api/teams_test.go
+++ b/internal/api/teams_test.go
@@ -57,7 +57,7 @@ func Test_API_TeamInfoResponse(t *testing.T) {
 			argsToken:             "xoxp-123",
 			argsTeamID:            "T0123",
 			httpResponseJSON:      `this is not valid json {"ok": true}`,
-			expectedErrorContains: errHttpResponseInvalid.Code,
+			expectedErrorContains: errHTTPResponseInvalid.Code,
 		},
 	}
 

--- a/internal/api/triggerpermissions.go
+++ b/internal/api/triggerpermissions.go
@@ -118,7 +118,7 @@ func (c *Client) TriggerPermissionsSet(ctx context.Context, token, triggerID, en
 	values.Add("token", token)
 	values.Add("trigger_id", triggerID)
 	values.Add("permission_type", string(permissionType))
-	if permissionType == types.NAMED_ENTITIES && len(entities) > 0 {
+	if permissionType == types.PermissionNamedEntities && len(entities) > 0 {
 		if entityType == "users" {
 			values.Add("user_ids", entities)
 		} else if entityType == "channels" {

--- a/internal/api/triggerpermissions.go
+++ b/internal/api/triggerpermissions.go
@@ -69,20 +69,20 @@ func (c *Client) TriggerPermissionsList(ctx context.Context, token, triggerID st
 	}
 
 	resp := TriggerPermissionsListResponse{}
-	err = goutils.JsonUnmarshal(b, &resp)
+	err = goutils.JSONUnmarshal(b, &resp)
 
 	if err != nil {
-		return "", []string{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(workflowsTriggersPermissionsListMethod)
+		return "", []string{}, errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(workflowsTriggersPermissionsListMethod)
 	}
 
 	if !resp.Ok {
-		return "", []string{}, slackerror.NewApiError(resp.Error, resp.Description, resp.Errors, workflowsTriggersPermissionsListMethod)
+		return "", []string{}, slackerror.NewAPIError(resp.Error, resp.Description, resp.Errors, workflowsTriggersPermissionsListMethod)
 	}
 
 	dist := types.Permission(strings.ToLower(resp.PermissionType))
 	if !dist.IsValid() {
 		errStr := fmt.Sprintf("unrecognized access type %s", dist)
-		return "", []string{}, slackerror.New(errStr).AddApiMethod(workflowsTriggersPermissionsListMethod)
+		return "", []string{}, slackerror.New(errStr).AddAPIMethod(workflowsTriggersPermissionsListMethod)
 	}
 	entitiesList := []string{}
 	namedEntitiesRespList := [][]string{
@@ -139,14 +139,14 @@ func (c *Client) TriggerPermissionsSet(ctx context.Context, token, triggerID, en
 	}
 
 	resp := TriggerPermissionsSetResponse{}
-	err = goutils.JsonUnmarshal(b, &resp)
+	err = goutils.JSONUnmarshal(b, &resp)
 
 	if err != nil {
-		return []string{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(workflowsTriggersPermissionsSetMethod)
+		return []string{}, errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(workflowsTriggersPermissionsSetMethod)
 	}
 
 	if !resp.Ok {
-		return []string{}, slackerror.NewApiError(resp.Error, resp.Description, resp.Errors, workflowsTriggersPermissionsSetMethod)
+		return []string{}, slackerror.NewAPIError(resp.Error, resp.Description, resp.Errors, workflowsTriggersPermissionsSetMethod)
 	}
 
 	entitiesList := append(resp.Users, resp.Channels...)
@@ -187,14 +187,14 @@ func (c *Client) TriggerPermissionsAddEntities(ctx context.Context, token, trigg
 	}
 
 	resp := TriggerPermissionsAddEntitiesResponse{}
-	err = goutils.JsonUnmarshal(b, &resp)
+	err = goutils.JSONUnmarshal(b, &resp)
 
 	if err != nil {
-		return errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(workflowsTriggersPermissionsAddMethod)
+		return errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(workflowsTriggersPermissionsAddMethod)
 	}
 
 	if !resp.Ok {
-		return slackerror.NewApiError(resp.Error, resp.Description, resp.Errors, workflowsTriggersPermissionsAddMethod)
+		return slackerror.NewAPIError(resp.Error, resp.Description, resp.Errors, workflowsTriggersPermissionsAddMethod)
 	}
 
 	return nil
@@ -234,14 +234,14 @@ func (c *Client) TriggerPermissionsRemoveEntities(ctx context.Context, token, tr
 	}
 
 	resp := TriggerPermissionsRemoveEntitiesResponse{}
-	err = goutils.JsonUnmarshal(b, &resp)
+	err = goutils.JSONUnmarshal(b, &resp)
 
 	if err != nil {
-		return errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(workflowsTriggersPermissionsRemoveMethod)
+		return errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(workflowsTriggersPermissionsRemoveMethod)
 	}
 
 	if !resp.Ok {
-		return slackerror.NewApiError(resp.Error, resp.Description, resp.Errors, workflowsTriggersPermissionsRemoveMethod)
+		return slackerror.NewAPIError(resp.Error, resp.Description, resp.Errors, workflowsTriggersPermissionsRemoveMethod)
 	}
 
 	return nil

--- a/internal/api/triggerpermissions.go
+++ b/internal/api/triggerpermissions.go
@@ -61,18 +61,18 @@ func (c *Client) TriggerPermissionsList(ctx context.Context, token, triggerID st
 
 	b, err := c.postForm(ctx, workflowsTriggersPermissionsListMethod, values)
 	if err != nil {
-		return "", []string{}, errHttpRequestFailed.WithRootCause(err)
+		return "", []string{}, errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	if b == nil {
-		return "", []string{}, errHttpResponseInvalid.WithRootCause(slackerror.New("empty body"))
+		return "", []string{}, errHTTPResponseInvalid.WithRootCause(slackerror.New("empty body"))
 	}
 
 	resp := TriggerPermissionsListResponse{}
 	err = goutils.JsonUnmarshal(b, &resp)
 
 	if err != nil {
-		return "", []string{}, errHttpResponseInvalid.WithRootCause(err).AddApiMethod(workflowsTriggersPermissionsListMethod)
+		return "", []string{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(workflowsTriggersPermissionsListMethod)
 	}
 
 	if !resp.Ok {
@@ -131,18 +131,18 @@ func (c *Client) TriggerPermissionsSet(ctx context.Context, token, triggerID, en
 	}
 	b, err := c.postForm(ctx, workflowsTriggersPermissionsSetMethod, values)
 	if err != nil {
-		return []string{}, errHttpRequestFailed.WithRootCause(err)
+		return []string{}, errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	if b == nil {
-		return []string{}, errHttpResponseInvalid.WithRootCause(slackerror.New("empty body"))
+		return []string{}, errHTTPResponseInvalid.WithRootCause(slackerror.New("empty body"))
 	}
 
 	resp := TriggerPermissionsSetResponse{}
 	err = goutils.JsonUnmarshal(b, &resp)
 
 	if err != nil {
-		return []string{}, errHttpResponseInvalid.WithRootCause(err).AddApiMethod(workflowsTriggersPermissionsSetMethod)
+		return []string{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(workflowsTriggersPermissionsSetMethod)
 	}
 
 	if !resp.Ok {
@@ -179,18 +179,18 @@ func (c *Client) TriggerPermissionsAddEntities(ctx context.Context, token, trigg
 
 	b, err := c.postForm(ctx, workflowsTriggersPermissionsAddMethod, values)
 	if err != nil {
-		return errHttpRequestFailed.WithRootCause(err)
+		return errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	if b == nil {
-		return errHttpResponseInvalid.WithRootCause(slackerror.New("empty body"))
+		return errHTTPResponseInvalid.WithRootCause(slackerror.New("empty body"))
 	}
 
 	resp := TriggerPermissionsAddEntitiesResponse{}
 	err = goutils.JsonUnmarshal(b, &resp)
 
 	if err != nil {
-		return errHttpResponseInvalid.WithRootCause(err).AddApiMethod(workflowsTriggersPermissionsAddMethod)
+		return errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(workflowsTriggersPermissionsAddMethod)
 	}
 
 	if !resp.Ok {
@@ -226,18 +226,18 @@ func (c *Client) TriggerPermissionsRemoveEntities(ctx context.Context, token, tr
 
 	b, err := c.postForm(ctx, workflowsTriggersPermissionsRemoveMethod, values)
 	if err != nil {
-		return errHttpRequestFailed.WithRootCause(err)
+		return errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	if b == nil {
-		return errHttpResponseInvalid.WithRootCause(slackerror.New("empty body"))
+		return errHTTPResponseInvalid.WithRootCause(slackerror.New("empty body"))
 	}
 
 	resp := TriggerPermissionsRemoveEntitiesResponse{}
 	err = goutils.JsonUnmarshal(b, &resp)
 
 	if err != nil {
-		return errHttpResponseInvalid.WithRootCause(err).AddApiMethod(workflowsTriggersPermissionsRemoveMethod)
+		return errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(workflowsTriggersPermissionsRemoveMethod)
 	}
 
 	if !resp.Ok {

--- a/internal/api/triggerpermissions_test.go
+++ b/internal/api/triggerpermissions_test.go
@@ -28,7 +28,7 @@ func TestClient_TriggerPermissionsSet(t *testing.T) {
 
 	tests := []struct {
 		name            string
-		resultJson      string
+		resultJSON      string
 		expectedRequest string
 		permissionType  types.Permission
 		users           string
@@ -43,46 +43,46 @@ func TestClient_TriggerPermissionsSet(t *testing.T) {
 			permissionType:  types.EVERYONE,
 			users:           "",
 			expectedRequest: `permission_type=everyone&token=xoxp-123&trigger_id=Ft123`,
-			resultJson:      `{"ok": true, "permission_type": "everyone"}`,
+			resultJSON:      `{"ok": true, "permission_type": "everyone"}`,
 		},
 		{
 			name:            "Set to collaborators",
 			permissionType:  types.APP_COLLABORATORS,
 			users:           "U0001",
 			expectedRequest: `permission_type=app_collaborators&token=xoxp-123&trigger_id=Ft123`,
-			resultJson:      `{"ok": true, "permission_type": "app_collaborators", "user_ids": [ "U0001" ]}`,
+			resultJSON:      `{"ok": true, "permission_type": "app_collaborators", "user_ids": [ "U0001" ]}`,
 		},
 		{
 			name:            "Set to named_entities (users)",
 			permissionType:  types.NAMED_ENTITIES,
 			users:           "U0001,U0002",
 			expectedRequest: `permission_type=named_entities&token=xoxp-123&trigger_id=Ft123&user_ids=U0001%2CU0002`,
-			resultJson:      `{"ok": true,"permission_type": "named_entities", "user_ids": [ "U0001", "U0002" ]}`,
+			resultJSON:      `{"ok": true,"permission_type": "named_entities", "user_ids": [ "U0001", "U0002" ]}`,
 		},
 		{
 			name:            "Set to named_entities (channels)",
 			permissionType:  types.NAMED_ENTITIES,
 			channels:        "C0001,C0002",
 			expectedRequest: `channel_ids=C0001%2CC0002&permission_type=named_entities&token=xoxp-123&trigger_id=Ft123`,
-			resultJson:      `{"ok": true,"permission_type": "named_entities", "channel_ids": [ "C0001", "C0002" ]}`,
+			resultJSON:      `{"ok": true,"permission_type": "named_entities", "channel_ids": [ "C0001", "C0002" ]}`,
 		},
 		{
 			name:            "Set to named_entities (workspaces)",
 			permissionType:  types.NAMED_ENTITIES,
 			workspaces:      "T0001,T0002",
 			expectedRequest: `permission_type=named_entities&team_ids=T0001%2CT0002&token=xoxp-123&trigger_id=Ft123`,
-			resultJson:      `{"ok": true,"permission_type": "named_entities", "teams_ids": [ "T0001", "T0002" ]}`,
+			resultJSON:      `{"ok": true,"permission_type": "named_entities", "teams_ids": [ "T0001", "T0002" ]}`,
 		},
 		{
 			name:            "Set to named_entities (organizations)",
 			permissionType:  types.NAMED_ENTITIES,
 			organizations:   "E0001,E0002",
 			expectedRequest: `org_ids=E0001%2CE0002&permission_type=named_entities&token=xoxp-123&trigger_id=Ft123`,
-			resultJson:      `{"ok": true,"permission_type": "named_entities", "org_ids": [ "E0001", "E0002" ]}`,
+			resultJSON:      `{"ok": true,"permission_type": "named_entities", "org_ids": [ "E0001", "E0002" ]}`,
 		},
 		{
 			name:       "Propagates errors",
-			resultJson: `{"ok": false, "error":"invalid_scopes"}`,
+			resultJSON: `{"ok": false, "error":"invalid_scopes"}`,
 			wantErr:    true,
 			errMessage: "invalid_scopes",
 		},
@@ -96,7 +96,7 @@ func TestClient_TriggerPermissionsSet(t *testing.T) {
 			c, teardown := NewFakeClient(t, FakeClientParams{
 				ExpectedMethod:  workflowsTriggersPermissionsSetMethod,
 				ExpectedRequest: tt.expectedRequest,
-				Response:        tt.resultJson,
+				Response:        tt.resultJSON,
 			})
 			defer teardown()
 
@@ -182,7 +182,7 @@ func TestClient_TriggerPermissionsAddEntities(t *testing.T) {
 
 	tests := []struct {
 		name            string
-		resultJson      string
+		resultJSON      string
 		expectedRequest string
 		users           string
 		channels        string
@@ -195,29 +195,29 @@ func TestClient_TriggerPermissionsAddEntities(t *testing.T) {
 			name:            "Add user successfully",
 			users:           "U0001",
 			expectedRequest: `token=xoxp-123&trigger_id=Ft123&user_ids=U0001`,
-			resultJson:      `{"ok": true,"permission_type": "named_entities", "user_ids": [ "U0001", "U0002" ]}`,
+			resultJSON:      `{"ok": true,"permission_type": "named_entities", "user_ids": [ "U0001", "U0002" ]}`,
 		},
 		{
 			name:            "Add channel successfully",
 			channels:        "C0001",
 			expectedRequest: `channel_ids=C0001&token=xoxp-123&trigger_id=Ft123`,
-			resultJson:      `{"ok": true,"permission_type": "named_entities", "channel_ids": [ "C0001", "C0002" ]}`,
+			resultJSON:      `{"ok": true,"permission_type": "named_entities", "channel_ids": [ "C0001", "C0002" ]}`,
 		},
 		{
 			name:            "Add workspace successfully",
 			workspaces:      "T0001",
 			expectedRequest: `team_ids=T0001&token=xoxp-123&trigger_id=Ft123`,
-			resultJson:      `{"ok": true,"permission_type": "named_entities", "team_ids": [ "T0001", "T0002" ]}`,
+			resultJSON:      `{"ok": true,"permission_type": "named_entities", "team_ids": [ "T0001", "T0002" ]}`,
 		},
 		{
 			name:            "Add organization successfully",
 			organizations:   "E0001",
 			expectedRequest: `org_ids=E0001&token=xoxp-123&trigger_id=Ft123`,
-			resultJson:      `{"ok": true,"permission_type": "named_entities", "org_ids": [ "E0001", "E0002" ]}`,
+			resultJSON:      `{"ok": true,"permission_type": "named_entities", "org_ids": [ "E0001", "E0002" ]}`,
 		},
 		{
 			name:       "Propagates errors",
-			resultJson: `{"ok": false, "error":"user_not_found"}`,
+			resultJSON: `{"ok": false, "error":"user_not_found"}`,
 			wantErr:    true,
 			errMessage: "user_not_found",
 		},
@@ -231,7 +231,7 @@ func TestClient_TriggerPermissionsAddEntities(t *testing.T) {
 			c, teardown := NewFakeClient(t, FakeClientParams{
 				ExpectedMethod:  workflowsTriggersPermissionsAddMethod,
 				ExpectedRequest: tt.expectedRequest,
-				Response:        tt.resultJson,
+				Response:        tt.resultJSON,
 			})
 			defer teardown()
 
@@ -313,7 +313,7 @@ func TestClient_TriggerPermissionsRemoveEntities(t *testing.T) {
 
 	tests := []struct {
 		name            string
-		resultJson      string
+		resultJSON      string
 		expectedRequest string
 		users           string
 		channels        string
@@ -326,29 +326,29 @@ func TestClient_TriggerPermissionsRemoveEntities(t *testing.T) {
 			name:            "Remove user successfully",
 			users:           "U0001",
 			expectedRequest: `token=xoxp-123&trigger_id=Ft123&user_ids=U0001`,
-			resultJson:      `{"ok": true,"permission_type": "named_entities", "user_ids": [ "U0002" ]}`,
+			resultJSON:      `{"ok": true,"permission_type": "named_entities", "user_ids": [ "U0002" ]}`,
 		},
 		{
 			name:            "Remove channel successfully",
 			channels:        "C0001",
 			expectedRequest: `channel_ids=C0001&token=xoxp-123&trigger_id=Ft123`,
-			resultJson:      `{"ok": true,"permission_type": "named_entities", "channel_ids": [ "C0002" ]}`,
+			resultJSON:      `{"ok": true,"permission_type": "named_entities", "channel_ids": [ "C0002" ]}`,
 		},
 		{
 			name:            "Remove workspace successfully",
 			workspaces:      "T0001",
 			expectedRequest: `team_ids=T0001&token=xoxp-123&trigger_id=Ft123`,
-			resultJson:      `{"ok": true,"permission_type": "named_entities", "team_ids": [ "T0002" ]}`,
+			resultJSON:      `{"ok": true,"permission_type": "named_entities", "team_ids": [ "T0002" ]}`,
 		},
 		{
 			name:            "Remove organization successfully",
 			organizations:   "E0001",
 			expectedRequest: `org_ids=E0001&token=xoxp-123&trigger_id=Ft123`,
-			resultJson:      `{"ok": true,"permission_type": "named_entities", "org_ids": [ "E0002" ]}`,
+			resultJSON:      `{"ok": true,"permission_type": "named_entities", "org_ids": [ "E0002" ]}`,
 		},
 		{
 			name:       "Propagates errors",
-			resultJson: `{"ok": false, "error":"user_not_found"}`,
+			resultJSON: `{"ok": false, "error":"user_not_found"}`,
 			wantErr:    true,
 			errMessage: "user_not_found",
 		},
@@ -362,7 +362,7 @@ func TestClient_TriggerPermissionsRemoveEntities(t *testing.T) {
 			c, teardown := NewFakeClient(t, FakeClientParams{
 				ExpectedMethod:  workflowsTriggersPermissionsRemoveMethod,
 				ExpectedRequest: tt.expectedRequest,
-				Response:        tt.resultJson,
+				Response:        tt.resultJSON,
 			})
 			defer teardown()
 
@@ -447,7 +447,7 @@ func TestClient_TriggerPermissionsList(t *testing.T) {
 
 	tests := []struct {
 		name                   string
-		resultJson             string
+		resultJSON             string
 		expectedRequest        string
 		expectedPermissionType types.Permission
 		expectedUsers          []string
@@ -462,46 +462,46 @@ func TestClient_TriggerPermissionsList(t *testing.T) {
 			expectedPermissionType: types.EVERYONE,
 			expectedUsers:          []string(nil),
 			expectedRequest:        `token=xoxp-123&trigger_id=Ft123`,
-			resultJson:             `{"ok": true, "permission_type": "everyone"}`,
+			resultJSON:             `{"ok": true, "permission_type": "everyone"}`,
 		},
 		{
 			name:                   "Access is collaborators",
 			expectedPermissionType: types.APP_COLLABORATORS,
 			expectedUsers:          []string{"U0001"},
 			expectedRequest:        `token=xoxp-123&trigger_id=Ft123`,
-			resultJson:             `{"ok": true, "permission_type": "app_collaborators", "user_ids": [ "U0001" ]}`,
+			resultJSON:             `{"ok": true, "permission_type": "app_collaborators", "user_ids": [ "U0001" ]}`,
 		},
 		{
 			name:                   "Set to named_entities (users)",
 			expectedPermissionType: types.NAMED_ENTITIES,
 			expectedUsers:          []string{"U0001", "U0002"},
 			expectedRequest:        `token=xoxp-123&trigger_id=Ft123`,
-			resultJson:             `{"ok": true,"permission_type": "named_entities", "user_ids": [ "U0001", "U0002" ]}`,
+			resultJSON:             `{"ok": true,"permission_type": "named_entities", "user_ids": [ "U0001", "U0002" ]}`,
 		},
 		{
 			name:                   "Set to named_entities (channels)",
 			expectedPermissionType: types.NAMED_ENTITIES,
 			expectedChannels:       []string{"C0001", "C0002"},
 			expectedRequest:        `token=xoxp-123&trigger_id=Ft123`,
-			resultJson:             `{"ok": true,"permission_type": "named_entities", "channel_ids": [ "C0001", "C0002" ]}`,
+			resultJSON:             `{"ok": true,"permission_type": "named_entities", "channel_ids": [ "C0001", "C0002" ]}`,
 		},
 		{
 			name:                   "Set to named_entities (workspaces)",
 			expectedPermissionType: types.NAMED_ENTITIES,
 			expectedWorkspaces:     []string{"T0001", "T0002"},
 			expectedRequest:        `token=xoxp-123&trigger_id=Ft123`,
-			resultJson:             `{"ok": true,"permission_type": "named_entities", "team_ids": [ "T0001", "T0002" ]}`,
+			resultJSON:             `{"ok": true,"permission_type": "named_entities", "team_ids": [ "T0001", "T0002" ]}`,
 		},
 		{
 			name:                   "Set to named_entities (organizations)",
 			expectedPermissionType: types.NAMED_ENTITIES,
 			expectedOrganizations:  []string{"E0001", "E0002"},
 			expectedRequest:        `token=xoxp-123&trigger_id=Ft123`,
-			resultJson:             `{"ok": true,"permission_type": "named_entities", "org_ids": [ "E0001", "E0002" ]}`,
+			resultJSON:             `{"ok": true,"permission_type": "named_entities", "org_ids": [ "E0001", "E0002" ]}`,
 		},
 		{
 			name:          "Propagates errors",
-			resultJson:    `{"ok": false, "error":"invalid_scopes"}`,
+			resultJSON:    `{"ok": false, "error":"invalid_scopes"}`,
 			wantErr:       true,
 			errMessage:    "invalid_scopes",
 			expectedUsers: []string{},
@@ -516,7 +516,7 @@ func TestClient_TriggerPermissionsList(t *testing.T) {
 			c, teardown := NewFakeClient(t, FakeClientParams{
 				ExpectedMethod:  workflowsTriggersPermissionsListMethod,
 				ExpectedRequest: tt.expectedRequest,
-				Response:        tt.resultJson,
+				Response:        tt.resultJSON,
 			})
 			defer teardown()
 

--- a/internal/api/triggerpermissions_test.go
+++ b/internal/api/triggerpermissions_test.go
@@ -40,42 +40,42 @@ func TestClient_TriggerPermissionsSet(t *testing.T) {
 	}{
 		{
 			name:            "Set to everyone",
-			permissionType:  types.EVERYONE,
+			permissionType:  types.PermissionEveryone,
 			users:           "",
 			expectedRequest: `permission_type=everyone&token=xoxp-123&trigger_id=Ft123`,
 			resultJSON:      `{"ok": true, "permission_type": "everyone"}`,
 		},
 		{
 			name:            "Set to collaborators",
-			permissionType:  types.APP_COLLABORATORS,
+			permissionType:  types.PermissionAppCollaborators,
 			users:           "U0001",
 			expectedRequest: `permission_type=app_collaborators&token=xoxp-123&trigger_id=Ft123`,
 			resultJSON:      `{"ok": true, "permission_type": "app_collaborators", "user_ids": [ "U0001" ]}`,
 		},
 		{
 			name:            "Set to named_entities (users)",
-			permissionType:  types.NAMED_ENTITIES,
+			permissionType:  types.PermissionNamedEntities,
 			users:           "U0001,U0002",
 			expectedRequest: `permission_type=named_entities&token=xoxp-123&trigger_id=Ft123&user_ids=U0001%2CU0002`,
 			resultJSON:      `{"ok": true,"permission_type": "named_entities", "user_ids": [ "U0001", "U0002" ]}`,
 		},
 		{
 			name:            "Set to named_entities (channels)",
-			permissionType:  types.NAMED_ENTITIES,
+			permissionType:  types.PermissionNamedEntities,
 			channels:        "C0001,C0002",
 			expectedRequest: `channel_ids=C0001%2CC0002&permission_type=named_entities&token=xoxp-123&trigger_id=Ft123`,
 			resultJSON:      `{"ok": true,"permission_type": "named_entities", "channel_ids": [ "C0001", "C0002" ]}`,
 		},
 		{
 			name:            "Set to named_entities (workspaces)",
-			permissionType:  types.NAMED_ENTITIES,
+			permissionType:  types.PermissionNamedEntities,
 			workspaces:      "T0001,T0002",
 			expectedRequest: `permission_type=named_entities&team_ids=T0001%2CT0002&token=xoxp-123&trigger_id=Ft123`,
 			resultJSON:      `{"ok": true,"permission_type": "named_entities", "teams_ids": [ "T0001", "T0002" ]}`,
 		},
 		{
 			name:            "Set to named_entities (organizations)",
-			permissionType:  types.NAMED_ENTITIES,
+			permissionType:  types.PermissionNamedEntities,
 			organizations:   "E0001,E0002",
 			expectedRequest: `org_ids=E0001%2CE0002&permission_type=named_entities&token=xoxp-123&trigger_id=Ft123`,
 			resultJSON:      `{"ok": true,"permission_type": "named_entities", "org_ids": [ "E0001", "E0002" ]}`,
@@ -171,7 +171,7 @@ func TestClient_TriggerPermissionsSet(t *testing.T) {
 
 	verifyCommonErrorCases(t, workflowsTriggersPermissionsSetMethod, func(c *Client) error {
 		ctx := slackcontext.MockContext(t.Context())
-		_, err := c.TriggerPermissionsSet(ctx, "xoxp-123", "Ft123", "user1", types.APP_COLLABORATORS, "users")
+		_, err := c.TriggerPermissionsSet(ctx, "xoxp-123", "Ft123", "user1", types.PermissionAppCollaborators, "users")
 		return err
 	})
 }
@@ -459,42 +459,42 @@ func TestClient_TriggerPermissionsList(t *testing.T) {
 	}{
 		{
 			name:                   "Access is everyone",
-			expectedPermissionType: types.EVERYONE,
+			expectedPermissionType: types.PermissionEveryone,
 			expectedUsers:          []string(nil),
 			expectedRequest:        `token=xoxp-123&trigger_id=Ft123`,
 			resultJSON:             `{"ok": true, "permission_type": "everyone"}`,
 		},
 		{
 			name:                   "Access is collaborators",
-			expectedPermissionType: types.APP_COLLABORATORS,
+			expectedPermissionType: types.PermissionAppCollaborators,
 			expectedUsers:          []string{"U0001"},
 			expectedRequest:        `token=xoxp-123&trigger_id=Ft123`,
 			resultJSON:             `{"ok": true, "permission_type": "app_collaborators", "user_ids": [ "U0001" ]}`,
 		},
 		{
 			name:                   "Set to named_entities (users)",
-			expectedPermissionType: types.NAMED_ENTITIES,
+			expectedPermissionType: types.PermissionNamedEntities,
 			expectedUsers:          []string{"U0001", "U0002"},
 			expectedRequest:        `token=xoxp-123&trigger_id=Ft123`,
 			resultJSON:             `{"ok": true,"permission_type": "named_entities", "user_ids": [ "U0001", "U0002" ]}`,
 		},
 		{
 			name:                   "Set to named_entities (channels)",
-			expectedPermissionType: types.NAMED_ENTITIES,
+			expectedPermissionType: types.PermissionNamedEntities,
 			expectedChannels:       []string{"C0001", "C0002"},
 			expectedRequest:        `token=xoxp-123&trigger_id=Ft123`,
 			resultJSON:             `{"ok": true,"permission_type": "named_entities", "channel_ids": [ "C0001", "C0002" ]}`,
 		},
 		{
 			name:                   "Set to named_entities (workspaces)",
-			expectedPermissionType: types.NAMED_ENTITIES,
+			expectedPermissionType: types.PermissionNamedEntities,
 			expectedWorkspaces:     []string{"T0001", "T0002"},
 			expectedRequest:        `token=xoxp-123&trigger_id=Ft123`,
 			resultJSON:             `{"ok": true,"permission_type": "named_entities", "team_ids": [ "T0001", "T0002" ]}`,
 		},
 		{
 			name:                   "Set to named_entities (organizations)",
-			expectedPermissionType: types.NAMED_ENTITIES,
+			expectedPermissionType: types.PermissionNamedEntities,
 			expectedOrganizations:  []string{"E0001", "E0002"},
 			expectedRequest:        `token=xoxp-123&trigger_id=Ft123`,
 			resultJSON:             `{"ok": true,"permission_type": "named_entities", "org_ids": [ "E0001", "E0002" ]}`,

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -19,7 +19,7 @@ package api
 // TODO: consider renaming interfaces from '*Client' to an -er verb such as '*Manager'
 //
 //	Ref: https://go.dev/doc/effective_go#interface-names
-type ApiInterface interface {
+type APIInterface interface {
 	ActivityClient
 	AppsClient
 	AuthClient

--- a/internal/api/users.go
+++ b/internal/api/users.go
@@ -49,18 +49,18 @@ func (c *Client) UsersInfo(ctx context.Context, token, userID string) (*types.Us
 
 	b, err := c.postForm(ctx, usersInfoMethod, values)
 	if err != nil {
-		return nil, errHttpRequestFailed.WithRootCause(err)
+		return nil, errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	if b == nil {
-		return nil, errHttpResponseInvalid.WithRootCause(slackerror.New("empty body"))
+		return nil, errHTTPResponseInvalid.WithRootCause(slackerror.New("empty body"))
 	}
 
 	resp := UserInfoResponse{}
 	err = goutils.JsonUnmarshal(b, &resp)
 
 	if err != nil {
-		return nil, errHttpResponseInvalid.WithRootCause(err).AddApiMethod(workflowsTriggersPermissionsListMethod)
+		return nil, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(workflowsTriggersPermissionsListMethod)
 	}
 
 	if !resp.Ok {

--- a/internal/api/users.go
+++ b/internal/api/users.go
@@ -57,14 +57,14 @@ func (c *Client) UsersInfo(ctx context.Context, token, userID string) (*types.Us
 	}
 
 	resp := UserInfoResponse{}
-	err = goutils.JsonUnmarshal(b, &resp)
+	err = goutils.JSONUnmarshal(b, &resp)
 
 	if err != nil {
-		return nil, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(workflowsTriggersPermissionsListMethod)
+		return nil, errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(workflowsTriggersPermissionsListMethod)
 	}
 
 	if !resp.Ok {
-		return nil, slackerror.NewApiError(resp.Error, resp.Description, resp.Errors, workflowsTriggersPermissionsListMethod)
+		return nil, slackerror.NewAPIError(resp.Error, resp.Description, resp.Errors, workflowsTriggersPermissionsListMethod)
 	}
 
 	return &resp.User, nil

--- a/internal/api/variables.go
+++ b/internal/api/variables.go
@@ -61,14 +61,14 @@ func (c *Client) AddVariable(ctx context.Context, token, appID, name, value stri
 	}
 
 	resp := extendedBaseResponse{}
-	err = goutils.JsonUnmarshal(b, &resp)
+	err = goutils.JSONUnmarshal(b, &resp)
 
 	if err != nil {
-		return errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(varAddMethod)
+		return errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(varAddMethod)
 	}
 
 	if !resp.Ok {
-		return slackerror.NewApiError(resp.Error, resp.Description, resp.Errors, varAddMethod)
+		return slackerror.NewAPIError(resp.Error, resp.Description, resp.Errors, varAddMethod)
 	}
 
 	return nil
@@ -102,14 +102,14 @@ func (c *Client) ListVariables(ctx context.Context, token, appID string) ([]stri
 	}
 
 	resp := listVariablesResponse{}
-	err = goutils.JsonUnmarshal(b, &resp)
+	err = goutils.JSONUnmarshal(b, &resp)
 
 	if err != nil {
-		return []string{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(varListMethod)
+		return []string{}, errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(varListMethod)
 	}
 
 	if !resp.Ok {
-		return []string{}, slackerror.NewApiError(resp.Error, resp.Description, resp.Errors, varListMethod)
+		return []string{}, slackerror.NewAPIError(resp.Error, resp.Description, resp.Errors, varListMethod)
 	}
 
 	return resp.VariableNames, nil
@@ -140,14 +140,14 @@ func (c *Client) RemoveVariable(ctx context.Context, token string, appID string,
 	}
 
 	resp := extendedBaseResponse{}
-	err = goutils.JsonUnmarshal(b, &resp)
+	err = goutils.JSONUnmarshal(b, &resp)
 
 	if err != nil {
-		return errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(varRemoveMethod)
+		return errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(varRemoveMethod)
 	}
 
 	if !resp.Ok {
-		return slackerror.NewApiError(resp.Error, resp.Description, resp.Errors, varRemoveMethod)
+		return slackerror.NewAPIError(resp.Error, resp.Description, resp.Errors, varRemoveMethod)
 	}
 
 	return nil

--- a/internal/api/variables.go
+++ b/internal/api/variables.go
@@ -57,14 +57,14 @@ func (c *Client) AddVariable(ctx context.Context, token, appID, name, value stri
 
 	b, err := c.postJSON(ctx, varAddMethod, token, "", body)
 	if err != nil {
-		return errHttpRequestFailed.WithRootCause(err)
+		return errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	resp := extendedBaseResponse{}
 	err = goutils.JsonUnmarshal(b, &resp)
 
 	if err != nil {
-		return errHttpResponseInvalid.WithRootCause(err).AddApiMethod(varAddMethod)
+		return errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(varAddMethod)
 	}
 
 	if !resp.Ok {
@@ -98,14 +98,14 @@ func (c *Client) ListVariables(ctx context.Context, token, appID string) ([]stri
 
 	b, err := c.postJSON(ctx, varListMethod, token, "", body)
 	if err != nil {
-		return []string{}, errHttpRequestFailed.WithRootCause(err)
+		return []string{}, errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	resp := listVariablesResponse{}
 	err = goutils.JsonUnmarshal(b, &resp)
 
 	if err != nil {
-		return []string{}, errHttpResponseInvalid.WithRootCause(err).AddApiMethod(varListMethod)
+		return []string{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(varListMethod)
 	}
 
 	if !resp.Ok {
@@ -136,14 +136,14 @@ func (c *Client) RemoveVariable(ctx context.Context, token string, appID string,
 
 	b, err := c.postJSON(ctx, varRemoveMethod, token, "", body)
 	if err != nil {
-		return errHttpRequestFailed.WithRootCause(err)
+		return errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	resp := extendedBaseResponse{}
 	err = goutils.JsonUnmarshal(b, &resp)
 
 	if err != nil {
-		return errHttpResponseInvalid.WithRootCause(err).AddApiMethod(varRemoveMethod)
+		return errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(varRemoveMethod)
 	}
 
 	if !resp.Ok {

--- a/internal/api/verify_errors.go
+++ b/internal/api/verify_errors.go
@@ -41,7 +41,7 @@ func verifyCommonErrorCases(t *testing.T, method string, callApi func(c *Client)
 		{
 			Name:          "invalid json response error",
 			Response:      `{`,
-			ExpectedError: slackerror.ErrHttpResponseInvalid,
+			ExpectedError: slackerror.ErrHTTPResponseInvalid,
 		},
 		{
 			Name:          "response not ok with error and errors",

--- a/internal/api/verify_errors.go
+++ b/internal/api/verify_errors.go
@@ -87,6 +87,6 @@ func verifyCommonErrorCases(t *testing.T, method string, callApi func(c *Client)
 		defer teardown()
 		err := callApi(c)
 		require.Error(t, err)
-		require.Contains(t, err.Error(), slackerror.ErrHttpRequestFailed)
+		require.Contains(t, err.Error(), slackerror.ErrHTTPRequestFailed)
 	})
 }

--- a/internal/api/verify_errors.go
+++ b/internal/api/verify_errors.go
@@ -23,9 +23,9 @@ import (
 )
 
 // verifyCommonErrorCases provides several invalid or error JSON representations as responses to the HTTP request
-// made by the callApi function, and verifies that they are handled correctly. All Client methods that call
+// made by the callAPI function, and verifies that they are handled correctly. All Client methods that call
 // HTTP API endpoints should pass these tests.
-func verifyCommonErrorCases(t *testing.T, method string, callApi func(c *Client) error) {
+func verifyCommonErrorCases(t *testing.T, method string, callAPI func(c *Client) error) {
 	type commonErrorTestArgs struct {
 		Name          string
 		Response      string
@@ -46,7 +46,7 @@ func verifyCommonErrorCases(t *testing.T, method string, callApi func(c *Client)
 		{
 			Name:          "response not ok with error and errors",
 			Response:      `{"ok": false, "error": "the error", "slack_cli_error_description": "the error", "errors": [{"message": "the errors"}]}`,
-			ExpectedError: slackerror.NewApiError("the error", "the error", slackerror.ErrorDetails{{Message: "the errors"}}, method).Error(),
+			ExpectedError: slackerror.NewAPIError("the error", "the error", slackerror.ErrorDetails{{Message: "the errors"}}, method).Error(),
 		},
 		{
 			Name:          "response not ok with error only",
@@ -72,7 +72,7 @@ func verifyCommonErrorCases(t *testing.T, method string, callApi func(c *Client)
 				Response:       args.Response,
 			})
 			defer teardown()
-			err := callApi(c)
+			err := callAPI(c)
 
 			require.Error(t, err)
 			require.Contains(t, err.Error(), args.ExpectedError)
@@ -85,7 +85,7 @@ func verifyCommonErrorCases(t *testing.T, method string, callApi func(c *Client)
 			StatusCode:     http.StatusInternalServerError,
 		})
 		defer teardown()
-		err := callApi(c)
+		err := callAPI(c)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), slackerror.ErrHTTPRequestFailed)
 	})

--- a/internal/api/workflows.go
+++ b/internal/api/workflows.go
@@ -168,13 +168,13 @@ func (c *Client) WorkflowsTriggersDelete(ctx context.Context, token string, trig
 
 	b, err := c.postJSON(ctx, workflowsTriggersDeleteMethod, token, "", body)
 	if err != nil {
-		return errHttpRequestFailed.WithRootCause(err)
+		return errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	resp := triggerDeleteResponse{}
 	err = goutils.JsonUnmarshal(b, &resp)
 	if err != nil {
-		return errHttpResponseInvalid.WithRootCause(err).AddApiMethod(workflowsTriggersDeleteMethod)
+		return errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(workflowsTriggersDeleteMethod)
 	}
 
 	if !resp.Ok {
@@ -187,13 +187,13 @@ func (c *Client) WorkflowsTriggersDelete(ctx context.Context, token string, trig
 func (c *Client) workflowsTriggerSave(ctx context.Context, token string, method string, body []byte) (types.DeployedTrigger, error) {
 	b, err := c.postJSON(ctx, method, token, "", body)
 	if err != nil {
-		return types.DeployedTrigger{}, errHttpRequestFailed.WithRootCause(err)
+		return types.DeployedTrigger{}, errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	resp := triggerCreateOrUpdateResponse{}
 	err = goutils.JsonUnmarshal(b, &resp)
 	if err != nil {
-		return types.DeployedTrigger{}, errHttpResponseInvalid.WithRootCause(err).AddApiMethod(method)
+		return types.DeployedTrigger{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(method)
 	}
 
 	if !resp.Ok {
@@ -239,7 +239,7 @@ func (c *Client) WorkflowsTriggersList(ctx context.Context, token string, listAr
 
 	b, err := c.postJSON(ctx, workflowsTriggersListMethod, token, "", body)
 	if err != nil {
-		return []types.DeployedTrigger{}, "", errHttpRequestFailed.WithRootCause(err)
+		return []types.DeployedTrigger{}, "", errHTTPRequestFailed.WithRootCause(err)
 	}
 
 	// workflowTriggersListResponse details to be saved
@@ -251,7 +251,7 @@ func (c *Client) WorkflowsTriggersList(ctx context.Context, token string, listAr
 	resp := workflowTriggersListResponse{}
 	err = goutils.JsonUnmarshal(b, &resp)
 	if err != nil {
-		return []types.DeployedTrigger{}, "", errHttpResponseInvalid.WithRootCause(err).AddApiMethod(workflowsTriggersListMethod)
+		return []types.DeployedTrigger{}, "", errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(workflowsTriggersListMethod)
 	}
 
 	if !resp.Ok {
@@ -274,13 +274,13 @@ func (c *Client) WorkflowsTriggersInfo(ctx context.Context, token, triggerId str
 
 	b, err := c.postJSON(ctx, workflowsTriggersInfoMethod, token, "", body)
 	if err != nil {
-		return types.DeployedTrigger{}, errors.WithStack(fmt.Errorf("%s: %s", errHttpRequestFailed, err))
+		return types.DeployedTrigger{}, errors.WithStack(fmt.Errorf("%s: %s", errHTTPRequestFailed, err))
 	}
 
 	resp := triggerInfoResponse{}
 	err = json.Unmarshal(b, &resp)
 	if err != nil {
-		return types.DeployedTrigger{}, errors.WithStack(fmt.Errorf("%s: %s", errHttpResponseInvalid, err))
+		return types.DeployedTrigger{}, errors.WithStack(fmt.Errorf("%s: %s", errHTTPResponseInvalid, err))
 	}
 
 	if !resp.Ok {

--- a/internal/api/workflows.go
+++ b/internal/api/workflows.go
@@ -172,13 +172,13 @@ func (c *Client) WorkflowsTriggersDelete(ctx context.Context, token string, trig
 	}
 
 	resp := triggerDeleteResponse{}
-	err = goutils.JsonUnmarshal(b, &resp)
+	err = goutils.JSONUnmarshal(b, &resp)
 	if err != nil {
-		return errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(workflowsTriggersDeleteMethod)
+		return errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(workflowsTriggersDeleteMethod)
 	}
 
 	if !resp.Ok {
-		return slackerror.NewApiError(resp.Error, resp.Description, resp.Errors, workflowsTriggersDeleteMethod)
+		return slackerror.NewAPIError(resp.Error, resp.Description, resp.Errors, workflowsTriggersDeleteMethod)
 	}
 
 	return nil
@@ -191,14 +191,14 @@ func (c *Client) workflowsTriggerSave(ctx context.Context, token string, method 
 	}
 
 	resp := triggerCreateOrUpdateResponse{}
-	err = goutils.JsonUnmarshal(b, &resp)
+	err = goutils.JSONUnmarshal(b, &resp)
 	if err != nil {
-		return types.DeployedTrigger{}, errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(method)
+		return types.DeployedTrigger{}, errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(method)
 	}
 
 	if !resp.Ok {
 		errorDetails, missingParamError := parseMissingParameterErrors(resp.Errors)
-		err = slackerror.NewApiError(resp.Error, resp.Description, errorDetails, method)
+		err = slackerror.NewAPIError(resp.Error, resp.Description, errorDetails, method)
 		if missingParamError != nil {
 			return types.DeployedTrigger{}, &TriggerCreateOrUpdateError{
 				Err: err, MissingParameterDetail: *missingParamError}
@@ -249,22 +249,22 @@ func (c *Client) WorkflowsTriggersList(ctx context.Context, token string, listAr
 	}
 
 	resp := workflowTriggersListResponse{}
-	err = goutils.JsonUnmarshal(b, &resp)
+	err = goutils.JSONUnmarshal(b, &resp)
 	if err != nil {
-		return []types.DeployedTrigger{}, "", errHTTPResponseInvalid.WithRootCause(err).AddApiMethod(workflowsTriggersListMethod)
+		return []types.DeployedTrigger{}, "", errHTTPResponseInvalid.WithRootCause(err).AddAPIMethod(workflowsTriggersListMethod)
 	}
 
 	if !resp.Ok {
-		return []types.DeployedTrigger{}, "", slackerror.NewApiError(resp.Error, resp.Description, resp.Errors, workflowsTriggersListMethod)
+		return []types.DeployedTrigger{}, "", slackerror.NewAPIError(resp.Error, resp.Description, resp.Errors, workflowsTriggersListMethod)
 	}
 
 	return resp.Triggers, resp.extendedBaseResponse.ResponseMetadata.NextCursor, nil
 }
 
 // WorkflowsTriggersInfo will retrieve information on an existing trigger
-func (c *Client) WorkflowsTriggersInfo(ctx context.Context, token, triggerId string) (types.DeployedTrigger, error) {
+func (c *Client) WorkflowsTriggersInfo(ctx context.Context, token, triggerID string) (types.DeployedTrigger, error) {
 	infoRequest := triggerInfoRequest{
-		TriggerID: triggerId,
+		TriggerID: triggerID,
 	}
 
 	body, err := json.Marshal(infoRequest)
@@ -284,7 +284,7 @@ func (c *Client) WorkflowsTriggersInfo(ctx context.Context, token, triggerId str
 	}
 
 	if !resp.Ok {
-		return types.DeployedTrigger{}, errors.WithStack(slackerror.NewApiError(resp.Error, resp.Description, resp.Errors, workflowsTriggersInfoMethod))
+		return types.DeployedTrigger{}, errors.WithStack(slackerror.NewAPIError(resp.Error, resp.Description, resp.Errors, workflowsTriggersInfoMethod))
 	}
 
 	return resp.Trigger, nil

--- a/internal/api/workflows.go
+++ b/internal/api/workflows.go
@@ -54,7 +54,7 @@ type TriggerRequest struct {
 	Description   string         `json:"description"`
 	Shortcut      *Shortcut      `json:"shortcut,omitempty"`
 	Workflow      string         `json:"workflow"`
-	WorkflowAppId string         `json:"workflow_app_id"`
+	WorkflowAppID string         `json:"workflow_app_id"`
 	Inputs        Inputs         `json:"inputs,omitempty"`
 	Event         *types.RawJSON `json:"event,omitempty"`
 	Schedule      *types.RawJSON `json:"schedule,omitempty"`
@@ -63,7 +63,7 @@ type TriggerRequest struct {
 }
 
 type triggerInfoRequest struct {
-	TriggerId string `json:"trigger_id"`
+	TriggerID string `json:"trigger_id"`
 }
 
 type triggerInfoResponse struct {
@@ -72,7 +72,7 @@ type triggerInfoResponse struct {
 }
 
 type triggerDeleteRequest struct {
-	TriggerId string `json:"trigger_id"`
+	TriggerID string `json:"trigger_id"`
 }
 
 type triggerDeleteResponse struct {
@@ -81,7 +81,7 @@ type triggerDeleteResponse struct {
 
 type TriggerUpdateRequest struct {
 	TriggerRequest
-	TriggerId string `json:"trigger_id"`
+	TriggerID string `json:"trigger_id"`
 }
 
 type triggerCreateOrUpdateErrorDetails []triggerCreateOrUpdateErrorDetail
@@ -117,7 +117,7 @@ func (e *TriggerCreateOrUpdateError) Error() string {
 }
 
 type TriggerListRequest struct {
-	AppId  string `json:"app_id,omitempty"`
+	AppID  string `json:"app_id,omitempty"`
 	Limit  int    `json:"limit,omitempty"`
 	Cursor string `json:"cursor,omitempty"`
 	Type   string `json:"type,omitempty"`
@@ -156,9 +156,9 @@ func (c *Client) WorkflowsTriggersUpdate(ctx context.Context, token string, trig
 }
 
 // WorkflowsTriggersDelete will delete an existing trigger using the method workflows.trigger.delete
-func (c *Client) WorkflowsTriggersDelete(ctx context.Context, token string, triggerId string) error {
+func (c *Client) WorkflowsTriggersDelete(ctx context.Context, token string, triggerID string) error {
 	deleteRequest := triggerDeleteRequest{
-		TriggerId: triggerId,
+		TriggerID: triggerID,
 	}
 
 	body, err := json.Marshal(deleteRequest)
@@ -264,7 +264,7 @@ func (c *Client) WorkflowsTriggersList(ctx context.Context, token string, listAr
 // WorkflowsTriggersInfo will retrieve information on an existing trigger
 func (c *Client) WorkflowsTriggersInfo(ctx context.Context, token, triggerId string) (types.DeployedTrigger, error) {
 	infoRequest := triggerInfoRequest{
-		TriggerId: triggerId,
+		TriggerID: triggerId,
 	}
 
 	body, err := json.Marshal(infoRequest)

--- a/internal/api/workflows_test.go
+++ b/internal/api/workflows_test.go
@@ -43,7 +43,7 @@ func TestClient_WorkflowsTriggerCreate(t *testing.T) {
 			inputTrigger: TriggerRequest{
 				Type:          types.TriggerTypeShortcut,
 				Workflow:      "#/workflows/test",
-				WorkflowAppId: "A1234",
+				WorkflowAppID: "A1234",
 				Name:          "name",
 				Description:   "desc",
 				Shortcut:      &Shortcut{},
@@ -56,7 +56,7 @@ func TestClient_WorkflowsTriggerCreate(t *testing.T) {
 			inputTrigger: TriggerRequest{
 				Type:          types.TriggerTypeShortcut,
 				Workflow:      "#/workflows/test",
-				WorkflowAppId: "A1234",
+				WorkflowAppID: "A1234",
 				Name:          "name",
 				Description:   "desc",
 				Shortcut:      &Shortcut{},
@@ -70,7 +70,7 @@ func TestClient_WorkflowsTriggerCreate(t *testing.T) {
 			inputTrigger: TriggerRequest{
 				Type:          types.TriggerTypeEvent,
 				Workflow:      "#/workflows/test",
-				WorkflowAppId: "A1234",
+				WorkflowAppID: "A1234",
 				Name:          "name",
 				Description:   "desc",
 				Event:         types.ToRawJson(`{"event_type":"reaction_added","channel_ids":["C1234"]}`),
@@ -83,7 +83,7 @@ func TestClient_WorkflowsTriggerCreate(t *testing.T) {
 			inputTrigger: TriggerRequest{
 				Type:          types.TriggerTypeScheduled,
 				Workflow:      "#/workflows/test",
-				WorkflowAppId: "A1234",
+				WorkflowAppID: "A1234",
 				Name:          "name",
 				Description:   "desc",
 				Schedule:      types.ToRawJson(`{"start_time":"2020-03-15","frequency":{"type":"daily"}}`),
@@ -96,7 +96,7 @@ func TestClient_WorkflowsTriggerCreate(t *testing.T) {
 			inputTrigger: TriggerRequest{
 				Type:          types.TriggerTypeWebhook,
 				Workflow:      "#/workflows/test",
-				WorkflowAppId: "A1234",
+				WorkflowAppID: "A1234",
 				Name:          "name",
 				Description:   "desc",
 				WebHook:       types.ToRawJson(`{"filter":{"root":{},"version":1},"channel_ids":["C1234"]}`),
@@ -167,11 +167,11 @@ func TestClient_WorkflowsTriggerUpdate(t *testing.T) {
 		{
 			name: "Valid shortcut",
 			input: TriggerUpdateRequest{
-				TriggerId: "Ft123",
+				TriggerID: "Ft123",
 				TriggerRequest: TriggerRequest{
 					Type:          types.TriggerTypeShortcut,
 					Workflow:      "#/workflows/test",
-					WorkflowAppId: "A1234",
+					WorkflowAppID: "A1234",
 					Name:          "name",
 					Description:   "desc",
 					Shortcut:      &Shortcut{},
@@ -183,11 +183,11 @@ func TestClient_WorkflowsTriggerUpdate(t *testing.T) {
 		{
 			name: "Valid shortcut, with inputs",
 			input: TriggerUpdateRequest{
-				TriggerId: "Ft123",
+				TriggerID: "Ft123",
 				TriggerRequest: TriggerRequest{
 					Type:          types.TriggerTypeShortcut,
 					Workflow:      "#/workflows/test",
-					WorkflowAppId: "A1234",
+					WorkflowAppID: "A1234",
 					Name:          "name",
 					Description:   "desc",
 					Shortcut:      &Shortcut{},
@@ -200,11 +200,11 @@ func TestClient_WorkflowsTriggerUpdate(t *testing.T) {
 		{
 			name: "Valid event",
 			input: TriggerUpdateRequest{
-				TriggerId: "Ft123",
+				TriggerID: "Ft123",
 				TriggerRequest: TriggerRequest{
 					Type:          types.TriggerTypeEvent,
 					Workflow:      "#/workflows/test",
-					WorkflowAppId: "A1234",
+					WorkflowAppID: "A1234",
 					Name:          "name",
 					Description:   "desc",
 					Event:         types.ToRawJson(`{"event_type":"reaction_added","channel_ids":["C1234"]}`),
@@ -216,11 +216,11 @@ func TestClient_WorkflowsTriggerUpdate(t *testing.T) {
 		{
 			name: "Valid schedule",
 			input: TriggerUpdateRequest{
-				TriggerId: "Ft123",
+				TriggerID: "Ft123",
 				TriggerRequest: TriggerRequest{
 					Type:          types.TriggerTypeScheduled,
 					Workflow:      "#/workflows/test",
-					WorkflowAppId: "A1234",
+					WorkflowAppID: "A1234",
 					Name:          "name",
 					Description:   "desc",
 					Schedule:      types.ToRawJson(`{"start_time":"2020-03-15","frequency":{"type":"daily"}}`),
@@ -232,11 +232,11 @@ func TestClient_WorkflowsTriggerUpdate(t *testing.T) {
 		{
 			name: "Valid webhook",
 			input: TriggerUpdateRequest{
-				TriggerId: "Ft123",
+				TriggerID: "Ft123",
 				TriggerRequest: TriggerRequest{
 					Type:          types.TriggerTypeWebhook,
 					Workflow:      "#/workflows/test",
-					WorkflowAppId: "A1234",
+					WorkflowAppID: "A1234",
 					Name:          "name",
 					Description:   "desc",
 					WebHook:       types.ToRawJson(`{"filter":{"root":{},"version":1},"channel_ids":["C1234"]}`),
@@ -438,7 +438,7 @@ func Test_API_WorkflowTriggersList(t *testing.T) {
 
 			// Execute test
 			args := TriggerListRequest{
-				AppId:  tt.argsAppID,
+				AppID:  tt.argsAppID,
 				Limit:  tt.argsLimit,
 				Cursor: tt.argsCursor,
 			}

--- a/internal/api/workflows_test.go
+++ b/internal/api/workflows_test.go
@@ -382,7 +382,7 @@ func Test_API_WorkflowTriggersList(t *testing.T) {
 			argsToken:             "xoxp-123",
 			argsAppID:             "A0123",
 			httpResponseJSON:      `this is not valid json {"ok": true}`,
-			expectedErrorContains: errHttpResponseInvalid.Code,
+			expectedErrorContains: errHTTPResponseInvalid.Code,
 		},
 		{
 			name:                  "Successful request",

--- a/internal/api/workflows_test.go
+++ b/internal/api/workflows_test.go
@@ -32,8 +32,8 @@ func TestClient_WorkflowsTriggerCreate(t *testing.T) {
 
 	tests := []struct {
 		name         string
-		resultJson   string
-		expectedJson string
+		resultJSON   string
+		expectedJSON string
 		inputTrigger TriggerRequest
 		wantErr      bool
 		errMessage   string
@@ -48,8 +48,8 @@ func TestClient_WorkflowsTriggerCreate(t *testing.T) {
 				Description:   "desc",
 				Shortcut:      &Shortcut{},
 			},
-			expectedJson: `{"type":"shortcut","name":"name","description":"desc","shortcut":{},"workflow":"#/workflows/test","workflow_app_id":"A1234"}`,
-			resultJson:   `{"ok": true, "trigger": {"id":"Ft123", "type":"shortcut", "name":"name", "desc":"desc"}}`,
+			expectedJSON: `{"type":"shortcut","name":"name","description":"desc","shortcut":{},"workflow":"#/workflows/test","workflow_app_id":"A1234"}`,
+			resultJSON:   `{"ok": true, "trigger": {"id":"Ft123", "type":"shortcut", "name":"name", "desc":"desc"}}`,
 		},
 		{
 			name: "Valid shortcut, with inputs",
@@ -62,8 +62,8 @@ func TestClient_WorkflowsTriggerCreate(t *testing.T) {
 				Shortcut:      &Shortcut{},
 				Inputs:        inputs,
 			},
-			expectedJson: `{"type":"shortcut","name":"name","description":"desc","shortcut":{},"workflow":"#/workflows/test","workflow_app_id":"A1234","inputs":{"test":{"value":"val"}}}`,
-			resultJson:   `{"ok": true, "trigger": {"id":"Ft123", "type":"shortcut", "name":"name", "desc":"desc"}}`,
+			expectedJSON: `{"type":"shortcut","name":"name","description":"desc","shortcut":{},"workflow":"#/workflows/test","workflow_app_id":"A1234","inputs":{"test":{"value":"val"}}}`,
+			resultJSON:   `{"ok": true, "trigger": {"id":"Ft123", "type":"shortcut", "name":"name", "desc":"desc"}}`,
 		},
 		{
 			name: "Valid event",
@@ -73,10 +73,10 @@ func TestClient_WorkflowsTriggerCreate(t *testing.T) {
 				WorkflowAppID: "A1234",
 				Name:          "name",
 				Description:   "desc",
-				Event:         types.ToRawJson(`{"event_type":"reaction_added","channel_ids":["C1234"]}`),
+				Event:         types.ToRawJSON(`{"event_type":"reaction_added","channel_ids":["C1234"]}`),
 			},
-			expectedJson: `{"type":"event","name":"name","description":"desc","workflow":"#/workflows/test","workflow_app_id":"A1234","event":{"event_type":"reaction_added","channel_ids":["C1234"]}}`,
-			resultJson:   `{"ok": true, "trigger": {"id":"Ft123", "type":"event", "name":"name", "desc":"desc"}}`,
+			expectedJSON: `{"type":"event","name":"name","description":"desc","workflow":"#/workflows/test","workflow_app_id":"A1234","event":{"event_type":"reaction_added","channel_ids":["C1234"]}}`,
+			resultJSON:   `{"ok": true, "trigger": {"id":"Ft123", "type":"event", "name":"name", "desc":"desc"}}`,
 		},
 		{
 			name: "Valid schedule",
@@ -86,10 +86,10 @@ func TestClient_WorkflowsTriggerCreate(t *testing.T) {
 				WorkflowAppID: "A1234",
 				Name:          "name",
 				Description:   "desc",
-				Schedule:      types.ToRawJson(`{"start_time":"2020-03-15","frequency":{"type":"daily"}}`),
+				Schedule:      types.ToRawJSON(`{"start_time":"2020-03-15","frequency":{"type":"daily"}}`),
 			},
-			expectedJson: `{"type":"scheduled","name":"name","description":"desc","workflow":"#/workflows/test","workflow_app_id":"A1234","schedule":{"start_time":"2020-03-15","frequency":{"type":"daily"}}}`,
-			resultJson:   `{"ok": true, "trigger": {"id":"Ft123", "type":"scheduled", "name":"name", "desc":"desc"}}`,
+			expectedJSON: `{"type":"scheduled","name":"name","description":"desc","workflow":"#/workflows/test","workflow_app_id":"A1234","schedule":{"start_time":"2020-03-15","frequency":{"type":"daily"}}}`,
+			resultJSON:   `{"ok": true, "trigger": {"id":"Ft123", "type":"scheduled", "name":"name", "desc":"desc"}}`,
 		},
 		{
 			name: "Valid webhook",
@@ -99,14 +99,14 @@ func TestClient_WorkflowsTriggerCreate(t *testing.T) {
 				WorkflowAppID: "A1234",
 				Name:          "name",
 				Description:   "desc",
-				WebHook:       types.ToRawJson(`{"filter":{"root":{},"version":1},"channel_ids":["C1234"]}`),
+				WebHook:       types.ToRawJSON(`{"filter":{"root":{},"version":1},"channel_ids":["C1234"]}`),
 			},
-			expectedJson: `{"type":"webhook","name":"name","description":"desc","workflow":"#/workflows/test","workflow_app_id":"A1234","webhook":{"filter":{"root":{},"version":1},"channel_ids":["C1234"]}}`,
-			resultJson:   `{"ok": true, "trigger": {"id":"Ft123", "type":"webhook", "name":"name", "desc":"desc"}}`,
+			expectedJSON: `{"type":"webhook","name":"name","description":"desc","workflow":"#/workflows/test","workflow_app_id":"A1234","webhook":{"filter":{"root":{},"version":1},"channel_ids":["C1234"]}}`,
+			resultJSON:   `{"ok": true, "trigger": {"id":"Ft123", "type":"webhook", "name":"name", "desc":"desc"}}`,
 		},
 		{
 			name:       "Propagates errors",
-			resultJson: `{"ok": false, "error":"invalid_scopes"}`,
+			resultJSON: `{"ok": false, "error":"invalid_scopes"}`,
 			wantErr:    true,
 			errMessage: "invalid_scopes",
 		},
@@ -119,12 +119,12 @@ func TestClient_WorkflowsTriggerCreate(t *testing.T) {
 			// prepare
 			handlerFunc := func(w http.ResponseWriter, r *http.Request) {
 				require.Contains(t, r.URL.Path, workflowsTriggersCreateMethod)
-				if tt.expectedJson != "" {
+				if tt.expectedJSON != "" {
 					payload, err := io.ReadAll(r.Body)
 					require.NoError(t, err)
-					require.Equal(t, tt.expectedJson, string(payload))
+					require.Equal(t, tt.expectedJSON, string(payload))
 				}
-				result := tt.resultJson
+				result := tt.resultJSON
 				_, err := fmt.Fprintln(w, result)
 				require.NoError(t, err)
 			}
@@ -158,8 +158,8 @@ func TestClient_WorkflowsTriggerUpdate(t *testing.T) {
 
 	tests := []struct {
 		name         string
-		resultJson   string
-		expectedJson string
+		resultJSON   string
+		expectedJSON string
 		input        TriggerUpdateRequest
 		wantErr      bool
 		errMessage   string
@@ -177,8 +177,8 @@ func TestClient_WorkflowsTriggerUpdate(t *testing.T) {
 					Shortcut:      &Shortcut{},
 				},
 			},
-			expectedJson: `{"type":"shortcut","name":"name","description":"desc","shortcut":{},"workflow":"#/workflows/test","workflow_app_id":"A1234","trigger_id":"Ft123"}`,
-			resultJson:   `{"ok": true, "trigger": {"id":"Ft123", "type":"shortcut", "name":"name", "desc":"desc"}}`,
+			expectedJSON: `{"type":"shortcut","name":"name","description":"desc","shortcut":{},"workflow":"#/workflows/test","workflow_app_id":"A1234","trigger_id":"Ft123"}`,
+			resultJSON:   `{"ok": true, "trigger": {"id":"Ft123", "type":"shortcut", "name":"name", "desc":"desc"}}`,
 		},
 		{
 			name: "Valid shortcut, with inputs",
@@ -194,8 +194,8 @@ func TestClient_WorkflowsTriggerUpdate(t *testing.T) {
 					Inputs:        inputs,
 				},
 			},
-			expectedJson: `{"type":"shortcut","name":"name","description":"desc","shortcut":{},"workflow":"#/workflows/test","workflow_app_id":"A1234","inputs":{"test":{"value":"val"}},"trigger_id":"Ft123"}`,
-			resultJson:   `{"ok": true, "trigger": {"id":"Ft123", "type":"shortcut", "name":"name", "desc":"desc"}}`,
+			expectedJSON: `{"type":"shortcut","name":"name","description":"desc","shortcut":{},"workflow":"#/workflows/test","workflow_app_id":"A1234","inputs":{"test":{"value":"val"}},"trigger_id":"Ft123"}`,
+			resultJSON:   `{"ok": true, "trigger": {"id":"Ft123", "type":"shortcut", "name":"name", "desc":"desc"}}`,
 		},
 		{
 			name: "Valid event",
@@ -207,11 +207,11 @@ func TestClient_WorkflowsTriggerUpdate(t *testing.T) {
 					WorkflowAppID: "A1234",
 					Name:          "name",
 					Description:   "desc",
-					Event:         types.ToRawJson(`{"event_type":"reaction_added","channel_ids":["C1234"]}`),
+					Event:         types.ToRawJSON(`{"event_type":"reaction_added","channel_ids":["C1234"]}`),
 				},
 			},
-			expectedJson: `{"type":"event","name":"name","description":"desc","workflow":"#/workflows/test","workflow_app_id":"A1234","event":{"event_type":"reaction_added","channel_ids":["C1234"]},"trigger_id":"Ft123"}`,
-			resultJson:   `{"ok": true, "trigger": {"id":"Ft123", "type":"event", "name":"name", "desc":"desc"}}`,
+			expectedJSON: `{"type":"event","name":"name","description":"desc","workflow":"#/workflows/test","workflow_app_id":"A1234","event":{"event_type":"reaction_added","channel_ids":["C1234"]},"trigger_id":"Ft123"}`,
+			resultJSON:   `{"ok": true, "trigger": {"id":"Ft123", "type":"event", "name":"name", "desc":"desc"}}`,
 		},
 		{
 			name: "Valid schedule",
@@ -223,11 +223,11 @@ func TestClient_WorkflowsTriggerUpdate(t *testing.T) {
 					WorkflowAppID: "A1234",
 					Name:          "name",
 					Description:   "desc",
-					Schedule:      types.ToRawJson(`{"start_time":"2020-03-15","frequency":{"type":"daily"}}`),
+					Schedule:      types.ToRawJSON(`{"start_time":"2020-03-15","frequency":{"type":"daily"}}`),
 				},
 			},
-			expectedJson: `{"type":"scheduled","name":"name","description":"desc","workflow":"#/workflows/test","workflow_app_id":"A1234","schedule":{"start_time":"2020-03-15","frequency":{"type":"daily"}},"trigger_id":"Ft123"}`,
-			resultJson:   `{"ok": true, "trigger": {"id":"Ft123", "type":"scheduled", "name":"name", "desc":"desc"}}`,
+			expectedJSON: `{"type":"scheduled","name":"name","description":"desc","workflow":"#/workflows/test","workflow_app_id":"A1234","schedule":{"start_time":"2020-03-15","frequency":{"type":"daily"}},"trigger_id":"Ft123"}`,
+			resultJSON:   `{"ok": true, "trigger": {"id":"Ft123", "type":"scheduled", "name":"name", "desc":"desc"}}`,
 		},
 		{
 			name: "Valid webhook",
@@ -239,15 +239,15 @@ func TestClient_WorkflowsTriggerUpdate(t *testing.T) {
 					WorkflowAppID: "A1234",
 					Name:          "name",
 					Description:   "desc",
-					WebHook:       types.ToRawJson(`{"filter":{"root":{},"version":1},"channel_ids":["C1234"]}`),
+					WebHook:       types.ToRawJSON(`{"filter":{"root":{},"version":1},"channel_ids":["C1234"]}`),
 				},
 			},
-			expectedJson: `{"type":"webhook","name":"name","description":"desc","workflow":"#/workflows/test","workflow_app_id":"A1234","webhook":{"filter":{"root":{},"version":1},"channel_ids":["C1234"]},"trigger_id":"Ft123"}`,
-			resultJson:   `{"ok": true, "trigger": {"id":"Ft123", "type":"webhook", "name":"name", "desc":"desc"}}`,
+			expectedJSON: `{"type":"webhook","name":"name","description":"desc","workflow":"#/workflows/test","workflow_app_id":"A1234","webhook":{"filter":{"root":{},"version":1},"channel_ids":["C1234"]},"trigger_id":"Ft123"}`,
+			resultJSON:   `{"ok": true, "trigger": {"id":"Ft123", "type":"webhook", "name":"name", "desc":"desc"}}`,
 		},
 		{
 			name:       "Propagates errors",
-			resultJson: `{"ok": false, "error":"invalid_scopes"}`,
+			resultJSON: `{"ok": false, "error":"invalid_scopes"}`,
 			wantErr:    true,
 			errMessage: "invalid_scopes",
 		},
@@ -260,12 +260,12 @@ func TestClient_WorkflowsTriggerUpdate(t *testing.T) {
 			// prepare
 			handlerFunc := func(w http.ResponseWriter, r *http.Request) {
 				require.Contains(t, r.URL.Path, workflowsTriggersUpdateMethod)
-				if tt.expectedJson != "" {
+				if tt.expectedJSON != "" {
 					payload, err := io.ReadAll(r.Body)
 					require.NoError(t, err)
-					require.Equal(t, tt.expectedJson, string(payload))
+					require.Equal(t, tt.expectedJSON, string(payload))
 				}
-				result := tt.resultJson
+				result := tt.resultJSON
 				_, err := fmt.Fprintln(w, result)
 				require.NoError(t, err)
 			}
@@ -296,17 +296,17 @@ func TestClient_WorkflowsTriggerUpdate(t *testing.T) {
 func TestClient_WorkflowsTriggerDelete(t *testing.T) {
 	tests := []struct {
 		name       string
-		resultJson string
+		resultJSON string
 		wantErr    bool
 		errMessage string
 	}{
 		{
 			name:       "OK result",
-			resultJson: `{"ok":true}`,
+			resultJSON: `{"ok":true}`,
 		},
 		{
 			name:       "Error result",
-			resultJson: `{"ok":false,"error":"invalid_scopes"}`,
+			resultJSON: `{"ok":false,"error":"invalid_scopes"}`,
 			wantErr:    true,
 			errMessage: "invalid_scopes",
 		},
@@ -318,11 +318,11 @@ func TestClient_WorkflowsTriggerDelete(t *testing.T) {
 			// prepare
 			handlerFunc := func(w http.ResponseWriter, r *http.Request) {
 				require.Contains(t, r.URL.Path, workflowsTriggersDeleteMethod)
-				expectedJson := `{"trigger_id":"FtABC"}`
+				expectedJSON := `{"trigger_id":"FtABC"}`
 				payload, err := io.ReadAll(r.Body)
 				require.NoError(t, err)
-				require.Equal(t, expectedJson, string(payload))
-				result := tt.resultJson
+				require.Equal(t, expectedJSON, string(payload))
+				result := tt.resultJSON
 				_, err = fmt.Fprintln(w, result)
 				require.NoError(t, err)
 			}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -35,7 +35,7 @@ type Client struct {
 
 // NewClient returns a client with access to the API
 func NewClient(
-	apiClient api.ApiInterface,
+	apiClient api.APIInterface,
 	config *config.Config,
 	fs afero.Fs,
 	os types.Os,

--- a/internal/app/app_client.go
+++ b/internal/app/app_client.go
@@ -298,7 +298,7 @@ func (ac *AppClient) readDeployedApps() error {
 	}
 
 	if err = json.Unmarshal(f, &ac.apps); err != nil {
-		return slackerror.New(slackerror.ErrUnableToParseJson).
+		return slackerror.New(slackerror.ErrUnableToParseJSON).
 			WithMessage("Failed to parse contents of deployed apps file").
 			WithRootCause(err).
 			WithRemediation("Check that %s is valid JSON", style.HomePath(deployedAppsPath))
@@ -373,7 +373,7 @@ func (ac *AppClient) readLocalApps() error {
 
 	err = json.Unmarshal(f, &ac.apps.LocalApps)
 	if err != nil {
-		return slackerror.New(slackerror.ErrUnableToParseJson).
+		return slackerror.New(slackerror.ErrUnableToParseJSON).
 			WithMessage("Failed to parse contents of local apps file").
 			WithRootCause(err).
 			WithRemediation("Check that %s is valid JSON", style.HomePath(devAppsPath))

--- a/internal/app/app_client.go
+++ b/internal/app/app_client.go
@@ -442,11 +442,11 @@ func (ac *AppClient) migrateToAppByTeamID() error {
 // See also: migrateToAuthByTeamID
 func (ac *AppClient) migrateToAppByTeamIDLocal() error {
 	// Ensure apps.dev.json is written by team_id
-	localAppsByTeamId, err := ac.apps.MapByTeamID(ac.apps.LocalApps)
+	localAppsByTeamID, err := ac.apps.MapByTeamID(ac.apps.LocalApps)
 	if err != nil {
 		return err
 	}
-	ac.apps.LocalApps = localAppsByTeamId
+	ac.apps.LocalApps = localAppsByTeamID
 	if err = ac.saveLocalApps(); err != nil {
 		return err
 	}

--- a/internal/app/app_client_mock.go
+++ b/internal/app/app_client_mock.go
@@ -25,8 +25,8 @@ type AppClientMock struct {
 	mock.Mock
 }
 
-func (m *AppClientMock) NewDeployed(ctx context.Context, teamId string) (types.App, error) {
-	args := m.Called(ctx, teamId)
+func (m *AppClientMock) NewDeployed(ctx context.Context, teamID string) (types.App, error) {
+	args := m.Called(ctx, teamID)
 	return args.Get(0).(types.App), args.Error(1)
 }
 

--- a/internal/app/app_client_test.go
+++ b/internal/app/app_client_test.go
@@ -162,7 +162,7 @@ func Test_AppClient_ReadDeployedApps_BrokenAppsJSON(t *testing.T) {
 	require.NoError(t, err)
 	err = ac.readDeployedApps()
 	require.Error(t, err)
-	assert.Equal(t, err.(*slackerror.Error).Code, slackerror.ErrUnableToParseJson)
+	assert.Equal(t, err.(*slackerror.Error).Code, slackerror.ErrUnableToParseJSON)
 }
 
 // Test that pre-existing dev app details get read from apps.dev.json
@@ -204,7 +204,7 @@ func Test_AppClient_ReadDevApps_BrokenAppsJSON(t *testing.T) {
 	require.NoError(t, err)
 	err = ac.readLocalApps()
 	require.Error(t, err)
-	assert.Equal(t, err.(*slackerror.Error).Code, slackerror.ErrUnableToParseJson)
+	assert.Equal(t, err.(*slackerror.Error).Code, slackerror.ErrUnableToParseJSON)
 }
 
 // Test that a team flag config defines the default app name in an empty AppClient

--- a/internal/app/app_client_test.go
+++ b/internal/app/app_client_test.go
@@ -122,7 +122,7 @@ func Test_AppClient_SaveLocalApps(t *testing.T) {
 }
 
 // Test that pre-existing deployed app details get read from apps.json
-func Test_AppClient_ReadDeployedApps_ExistingAppsJson(t *testing.T) {
+func Test_AppClient_ReadDeployedApps_ExistingAppsJSON(t *testing.T) {
 	ac, _, _, pathToAppsJSON, _, teardown := setup(t)
 	defer teardown(t)
 	jsonContents := []byte(`{
@@ -145,7 +145,7 @@ func Test_AppClient_ReadDeployedApps_ExistingAppsJson(t *testing.T) {
 }
 
 // Test that a missing apps.json writes an empty apps.json
-func Test_AppClient_ReadDeployedApps_NoAppsJson(t *testing.T) {
+func Test_AppClient_ReadDeployedApps_NoAppsJSON(t *testing.T) {
 	ac, _, _, pathToAppsJSON, _, teardown := setup(t)
 	defer teardown(t)
 	err := ac.readDeployedApps()
@@ -166,7 +166,7 @@ func Test_AppClient_ReadDeployedApps_BrokenAppsJSON(t *testing.T) {
 }
 
 // Test that pre-existing dev app details get read from apps.dev.json
-func Test_AppClient_ReadDevApps_ExistingAppsJson(t *testing.T) {
+func Test_AppClient_ReadDevApps_ExistingAppsJSON(t *testing.T) {
 	ac, _, _, _, pathToDevAppsJSON, teardown := setup(t)
 	defer teardown(t)
 	jsonContents := []byte(`{
@@ -187,7 +187,7 @@ func Test_AppClient_ReadDevApps_ExistingAppsJson(t *testing.T) {
 }
 
 // Test that a missing apps.dev.json writes an empty apps.dev.json
-func Test_AppClient_ReadDevApps_NoAppsJson(t *testing.T) {
+func Test_AppClient_ReadDevApps_NoAppsJSON(t *testing.T) {
 	ac, _, _, _, pathToDevAppsJSON, teardown := setup(t)
 	defer teardown(t)
 	err := ac.readLocalApps()
@@ -652,7 +652,7 @@ func TestAppClient_CleanupSlackFolder(t *testing.T) {
 		"an unexpected error occurred while stating the .slack directory")
 }
 
-func TestAppClient_CleanupAppsJsonFiles(t *testing.T) {
+func TestAppClient_CleanupAppsJSONFiles(t *testing.T) {
 	blankAppsJSONExample := []byte(`{}`)
 	appsJSONExample := []byte(`{
   "apps": {

--- a/internal/app/manifest.go
+++ b/internal/app/manifest.go
@@ -28,7 +28,7 @@ import (
 
 // ManifestClient can manage the state of the project's app manifest file
 type ManifestClient struct {
-	apiClient        api.ApiInterface
+	apiClient        api.APIInterface
 	domainAuthTokens string
 	Env              map[string]string
 }
@@ -57,7 +57,7 @@ func SetManifestEnvTeamVars(manifestEnv map[string]string, appTeamDomain string,
 
 // NewManifestClient returns a new, empty instance of the ManifestClient
 func NewManifestClient(
-	apiClient api.ApiInterface,
+	apiClient api.APIInterface,
 	config *config.Config,
 ) *ManifestClient {
 	client := &ManifestClient{

--- a/internal/app/manifest_test.go
+++ b/internal/app/manifest_test.go
@@ -129,7 +129,7 @@ func Test_AppManifest_GetManifestLocal(t *testing.T) {
 			configMock := config.NewConfig(fsMock, osMock)
 			configMock.DomainAuthTokens = "api.slack.com"
 			configMock.ManifestEnv = mockManifestEnv
-			manifestClient := NewManifestClient(&api.ApiMock{}, configMock)
+			manifestClient := NewManifestClient(&api.APIMock{}, configMock)
 
 			actualManifest, err := manifestClient.GetManifestLocal(ctx, mockSDKConfig, mockHookExecutor)
 			if tt.expectedErr != nil {
@@ -183,7 +183,7 @@ func Test_AppManifest_GetManifestRemote(t *testing.T) {
 			osMock := slackdeps.NewOsMock()
 			osMock.AddDefaultMocks()
 			configMock := config.NewConfig(fsMock, osMock)
-			apic := &api.ApiMock{}
+			apic := &api.APIMock{}
 			apic.On("ExportAppManifest", mock.Anything, mock.Anything, mock.Anything).
 				Return(api.ExportAppResult{Manifest: tt.mockManifestResponse}, tt.mockManifestError)
 			manifestClient := NewManifestClient(apic, configMock)

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -217,7 +217,7 @@ func (c *Client) auths(ctx context.Context) (map[string]types.SlackAuth, error) 
 
 	err = json.Unmarshal(raw, &auths)
 	if err != nil {
-		return auths, slackerror.New(slackerror.ErrUnableToParseJson).
+		return auths, slackerror.New(slackerror.ErrUnableToParseJSON).
 			WithMessage("Failed to parse contents of credentials file").
 			WithRootCause(err).
 			WithRemediation("Check that %s is valid JSON", style.HomePath(path))

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -469,7 +469,7 @@ func (c *Client) ResolveApiHost(ctx context.Context, apiHostFlag string, customA
 	var isLoginCommand = goutils.Contains(os.Args, "login", true)
 	var apiHost string
 	if apiHostFlag != "" {
-		apiHost = goutils.ToHttps(apiHostFlag)
+		apiHost = goutils.ToHTTPS(apiHostFlag)
 		c.config.SlackDevFlag = c.IsApiHostSlackDev(apiHostFlag)
 	} else if c.config.SlackDevFlag {
 		apiHost = defaultDevApiClientHost
@@ -477,7 +477,7 @@ func (c *Client) ResolveApiHost(ctx context.Context, apiHostFlag string, customA
 		// When a custom auth, we want to respect the APIHost
 		// When not set, we default to prod
 		if customAuth.ApiHost != nil {
-			apiHost = goutils.ToHttps(*customAuth.ApiHost)
+			apiHost = goutils.ToHTTPS(*customAuth.ApiHost)
 		} else {
 			apiHost = defaultProdApiClientHost
 		}

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -40,15 +40,15 @@ import (
 
 // Constants
 const credentialsFileName = "credentials.json"
-const defaultProdApiClientHost = "https://slack.com"
-const defaultDevApiClientHost = "https://dev.slack.com"
+const defaultProdAPIClientHost = "https://slack.com"
+const defaultDevAPIClientHost = "https://dev.slack.com"
 const defaultHost = "slack.com"
 
 var localBuildGitSHAInVersionRegex = regexp.MustCompile(`(?mi)-g[a-f0-9]{1,40}$`)
 
 // Client can manage the state of the system's user/workspace authentications.
 type Client struct {
-	api       api.ApiInterface
+	api       api.APIInterface
 	appClient *app.Client
 	config    *config.Config
 	io        iostreams.IOStreamer
@@ -77,18 +77,18 @@ type AuthInterface interface {
 	// RevokeToken removes access for a given token, filtering known and safe errors
 	RevokeToken(ctx context.Context, token string) error
 
-	// ResolveApiHost returns the API Host based on the API Host Flag, Dev Flag, Project Config, and Stored Auth API Host.
-	ResolveApiHost(ctx context.Context, apiHostFlag string, customAuth *types.SlackAuth) string
+	// ResolveAPIHost returns the API Host based on the API Host Flag, Dev Flag, Project Config, and Stored Auth API Host.
+	ResolveAPIHost(ctx context.Context, apiHostFlag string, customAuth *types.SlackAuth) string
 	// ResolveLogstashHost returns the error log stash host based on API Host and CLI version
 	ResolveLogstashHost(ctx context.Context, apiHost string, cliVersion string) string
 
 	// MapAuthTokensToDomains groups tokens by API host then delineates the host
 	MapAuthTokensToDomains(ctx context.Context) string
 
-	// IsApiHostSlackProd returns true if host is a development endpoint target
-	IsApiHostSlackDev(host string) bool
-	// IsApiHostSlackProd returns true if host is the production endpoint target
-	IsApiHostSlackProd(host string) bool
+	// IsAPIHostSlackProd returns true if host is a development endpoint target
+	IsAPIHostSlackDev(host string) bool
+	// IsAPIHostSlackProd returns true if host is the production endpoint target
+	IsAPIHostSlackProd(host string) bool
 
 	// FilterKnownAuthErrors catches known error codes that can be ignored to allow
 	// the process to proceed safely without exiting.
@@ -96,7 +96,7 @@ type AuthInterface interface {
 }
 
 // NewClient returns a new, empty instance of the Client
-func NewClient(apiClient api.ApiInterface, appClient *app.Client, config *config.Config, io iostreams.IOStreamer, fs afero.Fs) *Client {
+func NewClient(apiClient api.APIInterface, appClient *app.Client, config *config.Config, io iostreams.IOStreamer, fs afero.Fs) *Client {
 	var client = Client{
 		api:       apiClient,
 		appClient: appClient,
@@ -317,13 +317,13 @@ func (c *Client) rotateToken(ctx context.Context, auth types.SlackAuth) (types.S
 	// Store the current apiHost before rotation
 	// We need this because we need to restore
 	// the apiHost to what it was before rotating each of the user's auths
-	activeApiHostBeforeRotation := c.api.Host()
+	activeAPIHostBeforeRotation := c.api.Host()
 
-	if auth.ApiHost != nil {
-		c.api.SetHost(*auth.ApiHost)
-	} else if auth.ApiHost == nil || c.api.Host() == "" {
+	if auth.APIHost != nil {
+		c.api.SetHost(*auth.APIHost)
+	} else if auth.APIHost == nil || c.api.Host() == "" {
 		// always default to prod when we don't know what the api host is
-		c.api.SetHost(defaultProdApiClientHost)
+		c.api.SetHost(defaultProdAPIClientHost)
 	}
 
 	var result, err = c.api.RotateToken(ctx, auth)
@@ -338,7 +338,7 @@ func (c *Client) rotateToken(ctx context.Context, auth types.SlackAuth) (types.S
 	auth.LastUpdated = time.Now()
 
 	// now restore the previous default apiHost
-	c.api.SetHost(activeApiHostBeforeRotation)
+	c.api.SetHost(activeAPIHostBeforeRotation)
 
 	return auth, true /* tokenIsUpdated */, nil
 }
@@ -398,14 +398,14 @@ func (c *Client) SetSelectedAuth(ctx context.Context, auth types.SlackAuth, conf
 	//
 	// Often set after standard selections but custom authentication must set this
 	// unless the command is exiting right after, like 'login'.
-	config.ApiHostResolved = c.ResolveApiHost(ctx, config.ApiHostFlag, &auth)
-	config.LogstashHostResolved = c.ResolveLogstashHost(ctx, config.ApiHostResolved, config.Version)
+	config.APIHostResolved = c.ResolveAPIHost(ctx, config.APIHostFlag, &auth)
+	config.LogstashHostResolved = c.ResolveLogstashHost(ctx, config.APIHostResolved, config.Version)
 
 	// Set environment variables for app development configurations and processes.
 	if _, ok := os.LookupEnv("SLACK_API_URL"); !ok {
 		_ = os.Setenv(
 			"SLACK_API_URL",
-			fmt.Sprintf("%s/api/", config.ApiHostResolved),
+			fmt.Sprintf("%s/api/", config.APIHostResolved),
 		)
 	}
 }
@@ -431,8 +431,8 @@ func (c *Client) DeleteAuth(ctx context.Context, auth types.SlackAuth) (types.Sl
 	return toDelete, nil
 }
 
-// IsApiHostSlackDev returns true if host is the Slack Dev endpoint (dev.slack.com, https://dev1234.api.slack.com, etc)
-func (c *Client) IsApiHostSlackDev(host string) bool {
+// IsAPIHostSlackDev returns true if host is the Slack Dev endpoint (dev.slack.com, https://dev1234.api.slack.com, etc)
+func (c *Client) IsAPIHostSlackDev(host string) bool {
 	if host == "" {
 		return false
 	}
@@ -450,13 +450,13 @@ func (c *Client) IsApiHostSlackDev(host string) bool {
 // Either we should always save the api hostname even when it's a prod auth,
 // or we should update this function to also return true if the api hostname
 // is empty/undefined
-// IsApiHostSlackProd returns true if host is the production endpoint target.
-func (c *Client) IsApiHostSlackProd(host string) bool {
-	return host == defaultProdApiClientHost
+// IsAPIHostSlackProd returns true if host is the production endpoint target.
+func (c *Client) IsAPIHostSlackProd(host string) bool {
+	return host == defaultProdAPIClientHost
 }
 
-// ResolveApiHost returns the API Host based on the API Host Flag, Dev Flag, Project Config, and Stored Auth API Host.
-func (c *Client) ResolveApiHost(ctx context.Context, apiHostFlag string, customAuth *types.SlackAuth) string {
+// ResolveAPIHost returns the API Host based on the API Host Flag, Dev Flag, Project Config, and Stored Auth API Host.
+func (c *Client) ResolveAPIHost(ctx context.Context, apiHostFlag string, customAuth *types.SlackAuth) string {
 	// TODO - Update this comment
 	// Here is the order of relevance / importance:
 	// 1. If the command is login
@@ -470,25 +470,25 @@ func (c *Client) ResolveApiHost(ctx context.Context, apiHostFlag string, customA
 	var apiHost string
 	if apiHostFlag != "" {
 		apiHost = goutils.ToHTTPS(apiHostFlag)
-		c.config.SlackDevFlag = c.IsApiHostSlackDev(apiHostFlag)
+		c.config.SlackDevFlag = c.IsAPIHostSlackDev(apiHostFlag)
 	} else if c.config.SlackDevFlag {
-		apiHost = defaultDevApiClientHost
+		apiHost = defaultDevAPIClientHost
 	} else if customAuth != nil {
 		// When a custom auth, we want to respect the APIHost
 		// When not set, we default to prod
-		if customAuth.ApiHost != nil {
-			apiHost = goutils.ToHTTPS(*customAuth.ApiHost)
+		if customAuth.APIHost != nil {
+			apiHost = goutils.ToHTTPS(*customAuth.APIHost)
 		} else {
-			apiHost = defaultProdApiClientHost
+			apiHost = defaultProdAPIClientHost
 		}
 	} else if isLoginCommand {
-		apiHost = defaultProdApiClientHost
+		apiHost = defaultProdAPIClientHost
 	} else {
-		apiHost = defaultProdApiClientHost
+		apiHost = defaultProdAPIClientHost
 	}
 
 	// when not on prod, warn the user to update SLACK_API_URL where possible
-	if apiHost != defaultProdApiClientHost {
+	if apiHost != defaultProdAPIClientHost {
 		// warn the user if the apihost is not the main slack production apihost to update SLACK_API_URL
 		c.io.PrintDebug(
 			ctx,
@@ -499,21 +499,21 @@ func (c *Client) ResolveApiHost(ctx context.Context, apiHostFlag string, customA
 
 	// warn the user if the apihost is not pointing to a dev instance
 	// but they have the dev flag on
-	if !c.IsApiHostSlackDev(apiHost) && c.config.SlackDevFlag {
+	if !c.IsAPIHostSlackDev(apiHost) && c.config.SlackDevFlag {
 		c.io.PrintWarning(ctx, "Warning: you are using the dev flag but you are signed into a production workspace or are using a custom apihost endpoint")
 	}
 
 	return apiHost
 }
 
-// TODO: how does this play together with ResolveApiHost above?
+// TODO: how does this play together with ResolveAPIHost above?
 // ResolveLogstashHost returns the error log stash host based on API Host and CLI version
 func (c *Client) ResolveLogstashHost(ctx context.Context, apiHost string, cliVersion string) string {
 	c.io.PrintDebug(ctx, "Resolving logstash host, %s, %s", apiHost, cliVersion)
 	if localBuildGitSHAInVersionRegex.Match([]byte(cliVersion)) {
 		return "https://dev.slackb.com/events/cli"
 	}
-	if c.IsApiHostSlackProd(apiHost) {
+	if c.IsAPIHostSlackProd(apiHost) {
 		return "https://slackb.com/events/cli"
 	}
 
@@ -533,8 +533,8 @@ func (c *Client) MapAuthTokensToDomains(ctx context.Context) string {
 	}
 
 	for _, auth := range auths {
-		if auth.ApiHost != nil {
-			u, err := url.Parse(*auth.ApiHost)
+		if auth.APIHost != nil {
+			u, err := url.Parse(*auth.APIHost)
 			if err != nil {
 				continue
 			}

--- a/internal/auth/auth_mock.go
+++ b/internal/auth/auth_mock.go
@@ -71,7 +71,7 @@ func (m *AuthMock) RevokeToken(ctx context.Context, token string) error {
 	return args.Error(0)
 }
 
-func (m *AuthMock) ResolveApiHost(ctx context.Context, apiHostFlag string, customAuth *types.SlackAuth) string {
+func (m *AuthMock) ResolveAPIHost(ctx context.Context, apiHostFlag string, customAuth *types.SlackAuth) string {
 	args := m.Called(ctx, apiHostFlag, customAuth)
 	return args.String(0)
 }
@@ -86,12 +86,12 @@ func (m *AuthMock) MapAuthTokensToDomains(ctx context.Context) string {
 	return args.String(0)
 }
 
-func (m *AuthMock) IsApiHostSlackDev(host string) bool {
+func (m *AuthMock) IsAPIHostSlackDev(host string) bool {
 	args := m.Called(host)
 	return args.Bool(0)
 }
 
-func (m *AuthMock) IsApiHostSlackProd(host string) bool {
+func (m *AuthMock) IsAPIHostSlackProd(host string) bool {
 	args := m.Called(host)
 	return args.Bool(0)
 }

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -220,7 +220,7 @@ func Test_AuthGettersAndSetters(t *testing.T) {
 		require.NoError(t, err)
 		_, err = authClient.auths(ctx)
 		require.Error(t, err)
-		assert.Equal(t, err.(*slackerror.Error).Code, slackerror.ErrUnableToParseJson)
+		assert.Equal(t, err.(*slackerror.Error).Code, slackerror.ErrUnableToParseJSON)
 	})
 }
 

--- a/internal/auth/auth_test.go
+++ b/internal/auth/auth_test.go
@@ -245,23 +245,23 @@ func Test_AuthsRotation(t *testing.T) {
 		oneHourLater := timeNow + 60*60
 
 		// Fixtures
-		_defaultDevApiClientHost := defaultDevApiClientHost
-		_defaultProdApiClientHost := defaultProdApiClientHost
+		_defaultDevAPIClientHost := defaultDevAPIClientHost
+		_defaultProdAPIClientHost := defaultProdAPIClientHost
 		authATeamDomain := "workspace-a"
-		authATeamId := "T123456789A"
+		authATeamID := "T123456789A"
 		authBTeamDomain := "workspace-b"
-		authBTeamId := "T123456789B"
+		authBTeamID := "T123456789B"
 		authA := types.SlackAuth{
-			ApiHost:    &_defaultProdApiClientHost,
+			APIHost:    &_defaultProdAPIClientHost,
 			ExpiresAt:  oneHourLater,
 			TeamDomain: authATeamDomain,
-			TeamID:     authATeamId,
+			TeamID:     authATeamID,
 		}
 		authB := types.SlackAuth{
-			ApiHost:    &_defaultDevApiClientHost,
+			APIHost:    &_defaultDevAPIClientHost,
 			ExpiresAt:  oneHourLater,
 			TeamDomain: authBTeamDomain,
-			TeamID:     authBTeamId,
+			TeamID:     authBTeamID,
 		}
 		auths := types.AuthByTeamDomain{
 			authATeamDomain: authA,
@@ -273,14 +273,14 @@ func Test_AuthsRotation(t *testing.T) {
 		}
 
 		// setup api client
-		authClient.api = api.NewClient(&http.Client{}, defaultProdApiClientHost, authClient.io)
+		authClient.api = api.NewClient(&http.Client{}, defaultProdAPIClientHost, authClient.io)
 
 		// call the function
 		updatedAuths, err := authClient.auths(ctx)
 
 		// Assertions
-		require.Equal(t, authA, updatedAuths[authATeamId], "should return the same auth")
-		require.Equal(t, authB, updatedAuths[authBTeamId], "should return the same auth")
+		require.Equal(t, authA, updatedAuths[authATeamID], "should return the same auth")
+		require.Equal(t, authB, updatedAuths[authBTeamID], "should return the same auth")
 		require.NoError(t, err, "Should not return an error when the contents of credentials are valid")
 	})
 
@@ -292,39 +292,39 @@ func Test_AuthsRotation(t *testing.T) {
 		fiveMinutesAgo := timeNow - 60*5
 
 		// setup a fake api client since we don't want to make actual api calls
-		mockApiClient, teardown := api.NewFakeClient(t, api.FakeClientParams{
+		mockAPIClient, teardown := api.NewFakeClient(t, api.FakeClientParams{
 			ExpectedMethod:  "tooling.tokens.rotate",
 			ExpectedRequest: `refresh_token=valid-refresh-token`,
 			Response:        fmt.Sprintf(`{"ok":true,"token": "new-token", "exp": %d, "refresh_token": "new-valid-refresh-token"}`, oneHourLater),
 		})
 		defer teardown()
 
-		authClient.api = mockApiClient
-		fakeApiHost := mockApiClient.Host()
+		authClient.api = mockAPIClient
+		fakeAPIHost := mockAPIClient.Host()
 
 		// Fixtures
-		_defaultProdApiClientHost := defaultProdApiClientHost
+		_defaultProdAPIClientHost := defaultProdAPIClientHost
 		authATeamDomain := "workspace-a"
-		authATeamId := "T123456789A"
+		authATeamID := "T123456789A"
 		authBTeamDomain := "workspace-b"
-		authBTeamId := "T123456789B"
+		authBTeamID := "T123456789B"
 
 		workspaceAuthA := types.SlackAuth{
-			ApiHost:    &_defaultProdApiClientHost,
+			APIHost:    &_defaultProdAPIClientHost,
 			Token:      "goodToken",
 			ExpiresAt:  oneHourLater,
 			TeamDomain: authATeamDomain,
-			TeamID:     authATeamId,
+			TeamID:     authATeamID,
 		}
 
-		// use the fake api host as the Api host so that we don't end up making actual api calls
+		// use the fake api host as the API host so that we don't end up making actual api calls
 		workspaceAuthB := types.SlackAuth{
-			ApiHost:      &fakeApiHost,
+			APIHost:      &fakeAPIHost,
 			Token:        "expiredToken",
 			RefreshToken: "valid-refresh-token",
 			ExpiresAt:    fiveMinutesAgo,
 			TeamDomain:   authBTeamDomain,
-			TeamID:       authBTeamId,
+			TeamID:       authBTeamID,
 		}
 
 		auths := types.AuthByTeamDomain{
@@ -339,13 +339,13 @@ func Test_AuthsRotation(t *testing.T) {
 		updatedAuths, err := authClient.auths(ctx) // call the function
 		apiHostAfter := authClient.api.Host()      // track the api host after the function runs.
 
-		expectedWorkspaceAuthB := types.SlackAuth{ApiHost: &fakeApiHost, Token: "new-token", RefreshToken: "new-valid-refresh-token", ExpiresAt: oneHourLater}
+		expectedWorkspaceAuthB := types.SlackAuth{APIHost: &fakeAPIHost, Token: "new-token", RefreshToken: "new-valid-refresh-token", ExpiresAt: oneHourLater}
 
 		// Assertions
-		require.Equal(t, workspaceAuthA, updatedAuths[authATeamId], "should return the same auth")
-		require.Equal(t, expectedWorkspaceAuthB.Token, updatedAuths[authBTeamId].Token, "should return the renewed auth")
-		require.Equal(t, expectedWorkspaceAuthB.RefreshToken, updatedAuths[authBTeamId].RefreshToken, "should return the renewed auth")
-		require.Equal(t, expectedWorkspaceAuthB.ExpiresAt, updatedAuths[authBTeamId].ExpiresAt, "should return the renewed auth")
+		require.Equal(t, workspaceAuthA, updatedAuths[authATeamID], "should return the same auth")
+		require.Equal(t, expectedWorkspaceAuthB.Token, updatedAuths[authBTeamID].Token, "should return the renewed auth")
+		require.Equal(t, expectedWorkspaceAuthB.RefreshToken, updatedAuths[authBTeamID].RefreshToken, "should return the renewed auth")
+		require.Equal(t, expectedWorkspaceAuthB.ExpiresAt, updatedAuths[authBTeamID].ExpiresAt, "should return the renewed auth")
 		require.Equal(t, apiHostBefore, apiHostAfter, "api host before and after should be the same")
 		require.NoError(t, err, "Should not return an error when the contents of credentials are valid")
 	})
@@ -358,44 +358,44 @@ func Test_AuthsRotation(t *testing.T) {
 		fiveMinutesAgo := timeNow - 60*5
 
 		// setup a fake api client since we don't want to make actual api calls
-		mockApiClient, teardown := api.NewFakeClient(t, api.FakeClientParams{
+		mockAPIClient, teardown := api.NewFakeClient(t, api.FakeClientParams{
 			ExpectedMethod:  "tooling.tokens.rotate",
 			ExpectedRequest: `refresh_token=valid-refresh-token`,
 			Response:        `{"ok":false,"error": "invalid_auth"}`,
 		})
 		defer teardown()
 
-		authClient.api = mockApiClient
-		fakeApiHost := mockApiClient.Host()
+		authClient.api = mockAPIClient
+		fakeAPIHost := mockAPIClient.Host()
 
 		// Fixtures
-		_defaultProdApiClientHost := defaultProdApiClientHost
+		_defaultProdAPIClientHost := defaultProdAPIClientHost
 		authATeamDomain := "workspace-a"
-		authATeamId := "T123456789A"
+		authATeamID := "T123456789A"
 		authBTeamDomain := "workspace-b"
-		authBTeamId := "T123456789B"
+		authBTeamID := "T123456789B"
 
 		workspaceAuthA := types.SlackAuth{
-			ApiHost:    &_defaultProdApiClientHost,
+			APIHost:    &_defaultProdAPIClientHost,
 			Token:      "goodToken",
 			ExpiresAt:  oneHourLater,
 			TeamDomain: authATeamDomain,
-			TeamID:     authATeamId,
+			TeamID:     authATeamID,
 		}
 
-		// use the fake api host as the Api host so that we don't end up making actual api calls
+		// use the fake api host as the API host so that we don't end up making actual api calls
 		workspaceAuthB := types.SlackAuth{
-			ApiHost:      &fakeApiHost,
+			APIHost:      &fakeAPIHost,
 			Token:        "expiredToken",
 			RefreshToken: "valid-refresh-token",
 			ExpiresAt:    fiveMinutesAgo,
 			TeamDomain:   authBTeamDomain,
-			TeamID:       authBTeamId,
+			TeamID:       authBTeamID,
 		}
 
 		auths := types.AuthByTeamDomain{
-			authATeamId: workspaceAuthA,
-			authBTeamId: workspaceAuthB,
+			authATeamID: workspaceAuthA,
+			authBTeamID: workspaceAuthB,
 		}
 		_, err := authClient.setAuths(ctx, auths)
 		if err != nil {
@@ -405,10 +405,10 @@ func Test_AuthsRotation(t *testing.T) {
 		updatedAuths, err := authClient.auths(ctx) // call the function
 
 		// Assertions
-		require.Equal(t, workspaceAuthA, updatedAuths[authATeamId], "should return the same auth")
+		require.Equal(t, workspaceAuthA, updatedAuths[authATeamID], "should return the same auth")
 
 		// because the token rotation results in an error we expect the old stuff back
-		require.Equal(t, workspaceAuthB, updatedAuths[authBTeamId], "should return the same auth")
+		require.Equal(t, workspaceAuthB, updatedAuths[authBTeamID], "should return the same auth")
 
 		require.Equal(t, len(auths), len(updatedAuths), "we expect the same number of auths even if token rotation failed for one")
 		require.NoError(t, err, "Should not return an error when the contents of credentials are valid")
@@ -435,23 +435,23 @@ func Test_Auths(t *testing.T) {
 		oneHourLater := timeNow + 60*60
 
 		// Fixtures
-		_defaultDevApiClientHost := defaultDevApiClientHost
-		_defaultProdApiClientHost := defaultProdApiClientHost
+		_defaultDevAPIClientHost := defaultDevAPIClientHost
+		_defaultProdAPIClientHost := defaultProdAPIClientHost
 		authATeamDomain := "workspace-a"
-		authATeamId := "T123456789A"
+		authATeamID := "T123456789A"
 		authBTeamDomain := "workspace-b"
-		authBTeamId := "T123456789B"
+		authBTeamID := "T123456789B"
 		authA := types.SlackAuth{
-			ApiHost:    &_defaultProdApiClientHost,
+			APIHost:    &_defaultProdAPIClientHost,
 			ExpiresAt:  oneHourLater,
 			TeamDomain: authATeamDomain,
-			TeamID:     authATeamId,
+			TeamID:     authATeamID,
 		}
 		authB := types.SlackAuth{
-			ApiHost:    &_defaultDevApiClientHost,
+			APIHost:    &_defaultDevAPIClientHost,
 			ExpiresAt:  oneHourLater,
 			TeamDomain: authBTeamDomain,
-			TeamID:     authBTeamId,
+			TeamID:     authBTeamID,
 		}
 		auths := types.AuthByTeamDomain{
 			authATeamDomain: authA,
@@ -463,7 +463,7 @@ func Test_Auths(t *testing.T) {
 		}
 
 		// setup api client
-		authClient.api = api.NewClient(&http.Client{}, defaultProdApiClientHost, authClient.io)
+		authClient.api = api.NewClient(&http.Client{}, defaultProdAPIClientHost, authClient.io)
 
 		// call the function
 		updatedAuths, err := authClient.Auths(ctx)
@@ -519,8 +519,8 @@ func Test_migrateToAuthByTeamID(t *testing.T) {
 		// all auths must be present
 		require.Equal(t, 4, len(mockAuths))
 		for _, auth := range mockAuths {
-			teamId := auth.TeamID
-			if _, exists := updatedAuths[teamId]; !exists {
+			teamID := auth.TeamID
+			if _, exists := updatedAuths[teamID]; !exists {
 				require.FailNow(t, "missing auth after update")
 			}
 		}
@@ -548,7 +548,7 @@ func Test_SetSelectedAuth(t *testing.T) {
 		"associated authentication configurations are made": {
 			auth: types.SlackAuth{
 				TeamID:  "T001",
-				ApiHost: &mockAPIHost,
+				APIHost: &mockAPIHost,
 			},
 			expectedAPIHost: fmt.Sprintf("https://%s", mockAPIHost),
 			expectedAPIURL:  fmt.Sprintf("https://%s/api/", mockAPIHost),
@@ -559,13 +559,13 @@ func Test_SetSelectedAuth(t *testing.T) {
 			ctx, authClient, osMock := setup(t)
 			authClient.SetSelectedAuth(ctx, tt.auth, authClient.config, osMock)
 			assert.Equal(t, authClient.config.TeamFlag, tt.auth.TeamID)
-			assert.Equal(t, authClient.config.ApiHostResolved, tt.expectedAPIHost)
+			assert.Equal(t, authClient.config.APIHostResolved, tt.expectedAPIHost)
 			osMock.AssertCalled(t, "Setenv", "SLACK_API_URL", tt.expectedAPIURL)
 		})
 	}
 }
 
-func Test_IsApiHostSlackDev(t *testing.T) {
+func Test_IsAPIHostSlackDev(t *testing.T) {
 
 	var setup = func(t *testing.T) (context.Context, *Client) {
 		ctx := slackcontext.MockContext(t.Context())
@@ -581,25 +581,25 @@ func Test_IsApiHostSlackDev(t *testing.T) {
 	_, authClient := setup(t)
 
 	mockHostName := ""
-	mockHostName1 := "notAUrl"
+	mockHostName1 := "notAURL"
 	mockHostName2 := "https://doesnothaveprefix.com"
 	mockHostName3 := "https://dev1234.slack.com"
 	mockHostName4 := "https://dev.slack.com"
 
 	t.Run("Should validate api host slack dev", func(t *testing.T) {
-		res := authClient.IsApiHostSlackDev(mockHostName)
+		res := authClient.IsAPIHostSlackDev(mockHostName)
 		require.False(t, res)
 
-		res = authClient.IsApiHostSlackDev(mockHostName1)
+		res = authClient.IsAPIHostSlackDev(mockHostName1)
 		require.False(t, res)
 
-		res = authClient.IsApiHostSlackDev(mockHostName2)
+		res = authClient.IsAPIHostSlackDev(mockHostName2)
 		require.False(t, res)
 
-		res = authClient.IsApiHostSlackDev(mockHostName3)
+		res = authClient.IsAPIHostSlackDev(mockHostName3)
 		require.True(t, res)
 
-		res = authClient.IsApiHostSlackDev(mockHostName4)
+		res = authClient.IsAPIHostSlackDev(mockHostName4)
 		require.True(t, res)
 	})
 }

--- a/internal/auth/revoke_test.go
+++ b/internal/auth/revoke_test.go
@@ -63,7 +63,7 @@ func Test_AuthRevokeToken(t *testing.T) {
 		"errors if the revoke error is an unexpected error": {
 			token:    "xoxb-example-0001",
 			response: `{"ok":false,"error":"not_found"}`,
-			expected: slackerror.New(slackerror.ErrNotFound).AddApiMethod("auth.revoke"),
+			expected: slackerror.New(slackerror.ErrNotFound).AddAPIMethod("auth.revoke"),
 		},
 	}
 	for name, tt := range tests {

--- a/internal/cache/manifest_test.go
+++ b/internal/cache/manifest_test.go
@@ -77,7 +77,7 @@ func TestCache_Manifest_NewManifestHash(t *testing.T) {
 					Name: "slackbot[bot]",
 				},
 				Settings: &types.AppSettings{
-					FunctionRuntime: types.SLACK_HOSTED,
+					FunctionRuntime: types.SlackHosted,
 					EventSubscriptions: &types.ManifestEventSubscriptions{
 						BotEvents:  []string{"chat:write"},
 						UserEvents: []string{"channels:read"},
@@ -96,7 +96,7 @@ func TestCache_Manifest_NewManifestHash(t *testing.T) {
 						UserEvents: []string{"channels:read"},
 						BotEvents:  []string{"chat:write"},
 					},
-					FunctionRuntime: types.SLACK_HOSTED,
+					FunctionRuntime: types.SlackHosted,
 				},
 			},
 			expectedHash: "49691953b3bb36cad1333949846ad9f9c1fde9f12a395674dd2bbdafabccdd0c",

--- a/internal/cmdutil/project.go
+++ b/internal/cmdutil/project.go
@@ -30,7 +30,7 @@ func IsSlackHostedProject(ctx context.Context, clients *shared.ClientFactory) er
 		return err
 	}
 	switch {
-	case manifestSource.Equals(config.MANIFEST_SOURCE_LOCAL):
+	case manifestSource.Equals(config.ManifestSourceLocal):
 		manifest, err := clients.AppClient().Manifest.GetManifestLocal(ctx, clients.SDKConfig, clients.HookExecutor)
 		if err != nil {
 			return err
@@ -38,12 +38,12 @@ func IsSlackHostedProject(ctx context.Context, clients *shared.ClientFactory) er
 		if !manifest.IsFunctionRuntimeSlackHosted() {
 			return slackerror.New(slackerror.ErrAppNotHosted)
 		}
-	case manifestSource.Equals(config.MANIFEST_SOURCE_REMOTE):
+	case manifestSource.Equals(config.ManifestSourceRemote):
 		return slackerror.New(slackerror.ErrAppNotHosted).
 			WithDetails(slackerror.ErrorDetails{
 				{
 					Code:        slackerror.ErrInvalidManifestSource,
-					Message:     fmt.Sprintf("Slack hosted projects use \"%s\" manifest source", config.MANIFEST_SOURCE_LOCAL),
+					Message:     fmt.Sprintf("Slack hosted projects use \"%s\" manifest source", config.ManifestSourceLocal),
 					Remediation: fmt.Sprintf("This value can be changed in configuration: \"%s\"", config.GetProjectConfigJSONFilePath("")),
 				},
 			})

--- a/internal/cmdutil/project_test.go
+++ b/internal/cmdutil/project_test.go
@@ -39,39 +39,39 @@ func TestIsSlackHostedProject(t *testing.T) {
 			mockManifestResponse: types.SlackYaml{
 				AppManifest: types.AppManifest{
 					Settings: &types.AppSettings{
-						FunctionRuntime: types.SLACK_HOSTED,
+						FunctionRuntime: types.SlackHosted,
 					},
 				},
 			},
 			mockManifestError:  nil,
-			mockManifestSource: config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource: config.ManifestSourceLocal,
 			expectedError:      nil,
 		},
 		"errors if the project does not have a slack function runtime": {
 			mockManifestResponse: types.SlackYaml{
 				AppManifest: types.AppManifest{
 					Settings: &types.AppSettings{
-						FunctionRuntime: types.REMOTE,
+						FunctionRuntime: types.Remote,
 					},
 				},
 			},
 			mockManifestError:  nil,
-			mockManifestSource: config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource: config.ManifestSourceLocal,
 			expectedError:      slackerror.New(slackerror.ErrAppNotHosted),
 		},
 		"errors if the project manifest cannot be gathered from hook": {
 			mockManifestResponse: types.SlackYaml{},
 			mockManifestError:    slackerror.New(slackerror.ErrSDKHookInvocationFailed),
-			mockManifestSource:   config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:   config.ManifestSourceLocal,
 			expectedError:        slackerror.New(slackerror.ErrSDKHookInvocationFailed),
 		},
 		"errors if the manifest source is configured to the remote": {
-			mockManifestSource: config.MANIFEST_SOURCE_REMOTE,
+			mockManifestSource: config.ManifestSourceRemote,
 			expectedError: slackerror.New(slackerror.ErrAppNotHosted).
 				WithDetails(slackerror.ErrorDetails{
 					{
 						Code:        slackerror.ErrInvalidManifestSource,
-						Message:     fmt.Sprintf("Slack hosted projects use \"%s\" manifest source", config.MANIFEST_SOURCE_LOCAL),
+						Message:     fmt.Sprintf("Slack hosted projects use \"%s\" manifest source", config.ManifestSourceLocal),
 						Remediation: fmt.Sprintf("This value can be changed in configuration: \"%s\"", config.GetProjectConfigJSONFilePath("")),
 					},
 				}),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,8 +38,8 @@ type Config struct {
 	// Raw flags (for metrics)
 	RawFlags []string
 	// Command flags
-	ApiHostFlag             string
-	ApiHostResolved         string
+	APIHostFlag             string
+	APIHostResolved         string
 	AppFlag                 string
 	AutoRequestAAAFlag      bool
 	ConfigDirFlag           string

--- a/internal/config/context.go
+++ b/internal/config/context.go
@@ -20,18 +20,18 @@ import (
 
 type contextKey string
 
-const CONTEXT_TOKEN contextKey = "token"
-const CONTEXT_TEAM_ID contextKey = "team_id"
-const CONTEXT_TEAM_DOMAIN contextKey = "team_domain" // e.g. "subarachnoid"
-const CONTEXT_USER_ID contextKey = "user_id"
-const CONTEXT_ENTERPRISE_ID contextKey = "enterprise_id"
+const ContextToken contextKey = "token"
+const contextTeamID contextKey = "team_id"
+const contextTeamDomain contextKey = "team_domain" // e.g. "subarachnoid"
+const contextUserID contextKey = "user_id"
+const contextEnterpriseID contextKey = "enterprise_id"
 
 func SetContextToken(ctx context.Context, token string) context.Context {
-	return context.WithValue(ctx, CONTEXT_TOKEN, token)
+	return context.WithValue(ctx, ContextToken, token)
 }
 
 func GetContextToken(ctx context.Context) string {
-	token, ok := ctx.Value(CONTEXT_TOKEN).(string)
+	token, ok := ctx.Value(ContextToken).(string)
 	if !ok {
 		return ""
 	}
@@ -39,11 +39,11 @@ func GetContextToken(ctx context.Context) string {
 }
 
 func SetContextEnterpriseID(ctx context.Context, enterpriseID string) context.Context {
-	return context.WithValue(ctx, CONTEXT_ENTERPRISE_ID, enterpriseID)
+	return context.WithValue(ctx, contextEnterpriseID, enterpriseID)
 }
 
 func GetContextEnterpriseID(ctx context.Context) string {
-	enterpriseID, ok := ctx.Value(CONTEXT_ENTERPRISE_ID).(string)
+	enterpriseID, ok := ctx.Value(contextEnterpriseID).(string)
 	if !ok {
 		return ""
 	}
@@ -51,10 +51,10 @@ func GetContextEnterpriseID(ctx context.Context) string {
 }
 
 func SetContextTeamID(ctx context.Context, teamID string) context.Context {
-	return context.WithValue(ctx, CONTEXT_TEAM_ID, teamID)
+	return context.WithValue(ctx, contextTeamID, teamID)
 }
 func GetContextTeamID(ctx context.Context) string {
-	teamID, ok := ctx.Value(CONTEXT_TEAM_ID).(string)
+	teamID, ok := ctx.Value(contextTeamID).(string)
 	if !ok {
 		return ""
 	}
@@ -62,11 +62,11 @@ func GetContextTeamID(ctx context.Context) string {
 }
 
 func SetContextTeamDomain(ctx context.Context, teamDomain string) context.Context {
-	return context.WithValue(ctx, CONTEXT_TEAM_DOMAIN, teamDomain)
+	return context.WithValue(ctx, contextTeamDomain, teamDomain)
 }
 
 func GetContextTeamDomain(ctx context.Context) string {
-	teamDomain, ok := ctx.Value(CONTEXT_TEAM_DOMAIN).(string)
+	teamDomain, ok := ctx.Value(contextTeamDomain).(string)
 	if !ok {
 		return ""
 	}
@@ -74,11 +74,11 @@ func GetContextTeamDomain(ctx context.Context) string {
 }
 
 func SetContextUserID(ctx context.Context, userID string) context.Context {
-	return context.WithValue(ctx, CONTEXT_USER_ID, userID)
+	return context.WithValue(ctx, contextUserID, userID)
 }
 
 func GetContextUserID(ctx context.Context) string {
-	userID, ok := ctx.Value(CONTEXT_USER_ID).(string)
+	userID, ok := ctx.Value(contextUserID).(string)
 	if !ok {
 		return ""
 	}

--- a/internal/config/flags.go
+++ b/internal/config/flags.go
@@ -30,7 +30,7 @@ func (c *Config) SetFlags(cmd *cobra.Command) {
 
 // InitializeGlobalFlags configures flags and creates links from cmd to config
 func (c *Config) InitializeGlobalFlags(cmd *cobra.Command) {
-	cmd.PersistentFlags().StringVar(&c.ApiHostFlag, "apihost", "", "Slack API host")
+	cmd.PersistentFlags().StringVar(&c.APIHostFlag, "apihost", "", "Slack API host")
 	cmd.PersistentFlags().StringVarP(&c.AppFlag, "app", "a", "", "use a specific app ID or environment")
 	cmd.PersistentFlags().StringVarP(&c.ConfigDirFlag, "config-dir", "", "", "use a custom path for system config directory")
 	cmd.PersistentFlags().BoolVarP(&c.DeprecatedDevAppFlag, "local-run", "l", false, "use the local run app created by the `run` command") // deprecated

--- a/internal/config/manifest.go
+++ b/internal/config/manifest.go
@@ -16,8 +16,8 @@ package config
 type ManifestSource string
 
 const (
-	MANIFEST_SOURCE_LOCAL  ManifestSource = "local"
-	MANIFEST_SOURCE_REMOTE ManifestSource = "remote"
+	ManifestSourceLocal  ManifestSource = "local"
+	ManifestSourceRemote ManifestSource = "remote"
 )
 
 // Equals returns true if the manifest source is the same

--- a/internal/config/manifest_test.go
+++ b/internal/config/manifest_test.go
@@ -26,18 +26,18 @@ func Test_Config_ManifestSource_Equals(t *testing.T) {
 		expected bool
 	}{
 		"matching project sources are equal": {
-			a:        MANIFEST_SOURCE_LOCAL,
-			b:        MANIFEST_SOURCE_LOCAL,
+			a:        ManifestSourceLocal,
+			b:        ManifestSourceLocal,
 			expected: true,
 		},
 		"matching remote sources are equal": {
-			a:        MANIFEST_SOURCE_REMOTE,
-			b:        MANIFEST_SOURCE_REMOTE,
+			a:        ManifestSourceRemote,
+			b:        ManifestSourceRemote,
 			expected: true,
 		},
 		"different manifest sources are not equal": {
-			a:        MANIFEST_SOURCE_LOCAL,
-			b:        MANIFEST_SOURCE_REMOTE,
+			a:        ManifestSourceLocal,
+			b:        ManifestSourceRemote,
 			expected: false,
 		},
 	}
@@ -55,11 +55,11 @@ func Test_Config_ManifestSource_Exists(t *testing.T) {
 		expected bool
 	}{
 		"project source exists": {
-			a:        MANIFEST_SOURCE_LOCAL,
+			a:        ManifestSourceLocal,
 			expected: true,
 		},
 		"remote source exists": {
-			a:        MANIFEST_SOURCE_REMOTE,
+			a:        ManifestSourceRemote,
 			expected: true,
 		},
 		"unknown source exists": {
@@ -85,11 +85,11 @@ func Test_Config_ManifestSource_String(t *testing.T) {
 		expected string
 	}{
 		"project manifest source is local": {
-			a:        MANIFEST_SOURCE_LOCAL,
+			a:        ManifestSourceLocal,
 			expected: "local",
 		},
 		"remote manifest source is remote": {
-			a:        MANIFEST_SOURCE_REMOTE,
+			a:        ManifestSourceRemote,
 			expected: "remote",
 		},
 	}

--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -262,7 +262,7 @@ func (c *ProjectConfig) ReadProjectConfigFile(ctx context.Context) (ProjectConfi
 
 	err = json.Unmarshal(projectConfigFileBytes, &projectConfig)
 	if err != nil {
-		return projectConfig, slackerror.New(slackerror.ErrUnableToParseJson).
+		return projectConfig, slackerror.New(slackerror.ErrUnableToParseJSON).
 			WithMessage("Failed to parse contents of project-level config file").
 			WithRootCause(err).
 			WithRemediation("Check that %s is valid JSON", style.HomePath(projectConfigFilePath))

--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -163,16 +163,16 @@ func (c *ProjectConfig) GetManifestSource(ctx context.Context) (ManifestSource, 
 	if projectConfig.Manifest != nil {
 		source := ManifestSource(strings.TrimSpace(projectConfig.Manifest.Source))
 		switch {
-		case source.Equals(MANIFEST_SOURCE_LOCAL), source.Equals(MANIFEST_SOURCE_REMOTE):
+		case source.Equals(ManifestSourceLocal), source.Equals(ManifestSourceRemote):
 			return source, nil
 		case !source.Exists():
-			return MANIFEST_SOURCE_LOCAL, nil
+			return ManifestSourceLocal, nil
 		default:
 			return "", slackerror.New(slackerror.ErrProjectConfigManifestSource)
 		}
 	}
 
-	return MANIFEST_SOURCE_LOCAL, nil
+	return ManifestSourceLocal, nil
 }
 
 // SetManifestSource saves the manifest source preference for the project

--- a/internal/config/project_mock.go
+++ b/internal/config/project_mock.go
@@ -30,7 +30,7 @@ func NewProjectConfigMock() *ProjectConfigMock {
 }
 
 func (m *ProjectConfigMock) AddDefaultMocks() {
-	m.On("GetManifestSource", mock.Anything).Return(MANIFEST_SOURCE_LOCAL, nil)
+	m.On("GetManifestSource", mock.Anything).Return(ManifestSourceLocal, nil)
 }
 
 func (m *ProjectConfigMock) InitProjectID(ctx context.Context, overwriteExistingProjectID bool) (string, error) {

--- a/internal/config/project_test.go
+++ b/internal/config/project_test.go
@@ -353,7 +353,7 @@ func Test_ProjectConfig_ReadProjectConfigFile(t *testing.T) {
 
 		_, err = projectConfig.ReadProjectConfigFile(ctx)
 		require.Error(t, err)
-		assert.Equal(t, slackerror.ToSlackError(err).Code, slackerror.ErrUnableToParseJson)
+		assert.Equal(t, slackerror.ToSlackError(err).Code, slackerror.ErrUnableToParseJSON)
 		assert.Equal(t, slackerror.ToSlackError(err).Message, "Failed to parse contents of project-level config file")
 	})
 }

--- a/internal/config/project_test.go
+++ b/internal/config/project_test.go
@@ -232,24 +232,24 @@ func Test_ProjectConfig_ManifestSource(t *testing.T) {
 		expectedError                 error
 	}{
 		"saves manifest.source remote to project configs": {
-			mockManifestSource:            MANIFEST_SOURCE_REMOTE,
-			expectedManifestSourceDefault: MANIFEST_SOURCE_LOCAL,
-			expectedManifestSource:        MANIFEST_SOURCE_REMOTE,
+			mockManifestSource:            ManifestSourceRemote,
+			expectedManifestSourceDefault: ManifestSourceLocal,
+			expectedManifestSource:        ManifestSourceRemote,
 		},
 		"saves manifest.source local to project configs": {
-			mockManifestSource:            MANIFEST_SOURCE_LOCAL,
-			expectedManifestSourceDefault: MANIFEST_SOURCE_LOCAL,
-			expectedManifestSource:        MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:            ManifestSourceLocal,
+			expectedManifestSourceDefault: ManifestSourceLocal,
+			expectedManifestSource:        ManifestSourceLocal,
 		},
 		"errors if an unknown manifest.source is provided": {
 			mockManifestSource:            ManifestSource("upstream"),
-			expectedManifestSourceDefault: MANIFEST_SOURCE_LOCAL,
+			expectedManifestSourceDefault: ManifestSourceLocal,
 			expectedError:                 slackerror.New(slackerror.ErrProjectConfigManifestSource),
 		},
 		"defaults to local manifest without manifest.source": {
 			mockManifestSource:            ManifestSource(""),
-			expectedManifestSourceDefault: MANIFEST_SOURCE_LOCAL,
-			expectedManifestSource:        MANIFEST_SOURCE_LOCAL,
+			expectedManifestSourceDefault: ManifestSourceLocal,
+			expectedManifestSource:        ManifestSourceLocal,
 		},
 	}
 	for name, tt := range tests {

--- a/internal/config/system.go
+++ b/internal/config/system.go
@@ -130,7 +130,7 @@ func (c *SystemConfig) UserConfig(ctx context.Context) (*SystemConfig, error) {
 
 	err = json.Unmarshal(configFileBytes, &config)
 	if err != nil {
-		return &config, slackerror.New(slackerror.ErrUnableToParseJson).
+		return &config, slackerror.New(slackerror.ErrUnableToParseJSON).
 			WithMessage("Failed to parse contents of system-level config file").
 			WithRootCause(err).
 			WithRemediation("Check that %s is valid JSON", style.HomePath(path))

--- a/internal/config/system_test.go
+++ b/internal/config/system_test.go
@@ -104,7 +104,7 @@ func Test_SystemConfig_UserConfig(t *testing.T) {
 		_, err = systemConfig.UserConfig(ctx)
 
 		require.Error(t, err)
-		assert.Equal(t, slackerror.ToSlackError(err).Code, slackerror.ErrUnableToParseJson)
+		assert.Equal(t, slackerror.ToSlackError(err).Code, slackerror.ErrUnableToParseJSON)
 		assert.Equal(t, slackerror.ToSlackError(err).Message, "Failed to parse contents of system-level config file")
 	})
 }

--- a/internal/deputil/url.go
+++ b/internal/deputil/url.go
@@ -16,8 +16,8 @@ package deputil
 
 import "net/http"
 
-// urlChecker returns url if it's status code is 200, otherwise returns empty string
-func UrlChecker(url string) string {
+// URLChecker returns url if it's status code is 200, otherwise returns empty string
+func URLChecker(url string) string {
 	resp, err := http.Get(url)
 	if err != nil {
 		return ""

--- a/internal/deputil/url_test.go
+++ b/internal/deputil/url_test.go
@@ -20,10 +20,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_urlChecker(t *testing.T) {
-	url := UrlChecker("https://github.com/slack-samples/deno-starter-template")
+func Test_URLChecker(t *testing.T) {
+	url := URLChecker("https://github.com/slack-samples/deno-starter-template")
 	assert.Equal(t, "https://github.com/slack-samples/deno-starter-template", url, "should return url when url is valid")
 
-	url = UrlChecker("fake_url")
+	url = URLChecker("fake_url")
 	assert.Equal(t, "", url, "should return empty string when url is invalid")
 }

--- a/internal/goutils/json.go
+++ b/internal/goutils/json.go
@@ -46,7 +46,7 @@ func MergeJSON(defaultJSON string, customJSON string, config interface{}) error 
 	return nil
 }
 
-// JsonMarshalUnescaped converts a struct into a JSON encoding without escaping
+// JSONMarshalUnescaped converts a struct into a JSON encoding without escaping
 // characters
 func JSONMarshalUnescaped(v interface{}) (string, error) {
 	var buff bytes.Buffer
@@ -59,9 +59,9 @@ func JSONMarshalUnescaped(v interface{}) (string, error) {
 	return buff.String(), nil
 }
 
-// JsonMarshalUnescapedIndent converts a struct into an easily readable JSON
+// JSONMarshalUnescapedIndent converts a struct into an easily readable JSON
 // encoding without escaping characters
-func JsonMarshalUnescapedIndent(v interface{}) (string, error) {
+func JSONMarshalUnescapedIndent(v interface{}) (string, error) {
 	var buff bytes.Buffer
 	encoder := json.NewEncoder(&buff)
 	encoder.SetEscapeHTML(false)
@@ -73,14 +73,14 @@ func JsonMarshalUnescapedIndent(v interface{}) (string, error) {
 	return buff.String(), nil
 }
 
-// JsonUnmarshal is a wrapper for json.Unmarshal which parses the
+// JSONUnmarshal is a wrapper for json.Unmarshal which parses the
 // JSON-encoded data and stores the result in the value pointed to by v.
 // If v is nil or not a pointer, json.Unmarshal returns an InvalidUnmarshalError
 // which gets converted to a slackerror that is more human readable.
-func JsonUnmarshal(data []byte, v interface{}) error {
+func JSONUnmarshal(data []byte, v interface{}) error {
 	err := json.Unmarshal(data, v)
 	if err != nil {
-		return slackerror.JsonUnmarshalError(err, data)
+		return slackerror.JSONUnmarshalError(err, data)
 	}
 	return nil
 }

--- a/internal/goutils/json.go
+++ b/internal/goutils/json.go
@@ -48,7 +48,7 @@ func MergeJSON(defaultJSON string, customJSON string, config interface{}) error 
 
 // JsonMarshalUnescaped converts a struct into a JSON encoding without escaping
 // characters
-func JsonMarshalUnescaped(v interface{}) (string, error) {
+func JSONMarshalUnescaped(v interface{}) (string, error) {
 	var buff bytes.Buffer
 	encoder := json.NewEncoder(&buff)
 	encoder.SetEscapeHTML(false)

--- a/internal/goutils/json_test.go
+++ b/internal/goutils/json_test.go
@@ -93,7 +93,7 @@ func Test_mergeJSON(t *testing.T) {
 	}
 }
 
-func Test_JsonMarshalUnescaped(t *testing.T) {
+func Test_JSONMarshalUnescaped(t *testing.T) {
 	type TestInput struct {
 		Data    string
 		Numbers []int
@@ -113,7 +113,7 @@ func Test_JsonMarshalUnescaped(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			buff, err := JsonMarshalUnescaped(tt.Input)
+			buff, err := JSONMarshalUnescaped(tt.Input)
 			if assert.NoError(t, err) {
 				assert.Equal(t, tt.Expected, buff)
 			}
@@ -175,7 +175,7 @@ func Test_UnmarshalJson(t *testing.T) {
 		},
 		"invalid json": {
 			data:      `}{`,
-			expectAll: []string{slackerror.ErrUnableToParseJson},
+			expectAll: []string{slackerror.ErrUnableToParseJSON},
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -184,7 +184,7 @@ func Test_UnmarshalJson(t *testing.T) {
 			if tt.expectedError == nil && len(tt.expectAll) == 0 {
 				require.Nil(t, err)
 			} else {
-				require.Contains(t, err.Error(), slackerror.ErrUnableToParseJson)
+				require.Contains(t, err.Error(), slackerror.ErrUnableToParseJSON)
 				for _, s := range tt.expectAll {
 					require.Contains(t, err.Error(), s)
 				}

--- a/internal/goutils/json_test.go
+++ b/internal/goutils/json_test.go
@@ -121,7 +121,7 @@ func Test_JSONMarshalUnescaped(t *testing.T) {
 	}
 }
 
-func Test_JsonMarshalUnescapedIndent(t *testing.T) {
+func Test_JSONMarshalUnescapedIndent(t *testing.T) {
 	type TestInput struct {
 		Data    string
 		Numbers []int
@@ -151,7 +151,7 @@ func Test_JsonMarshalUnescapedIndent(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			buff, err := JsonMarshalUnescapedIndent(tt.Input)
+			buff, err := JSONMarshalUnescapedIndent(tt.Input)
 			if assert.NoError(t, err) {
 				assert.Equal(t, tt.Expected, buff)
 			}
@@ -159,7 +159,7 @@ func Test_JsonMarshalUnescapedIndent(t *testing.T) {
 	}
 }
 
-func Test_UnmarshalJson(t *testing.T) {
+func Test_UnmarshalJSON(t *testing.T) {
 	type testConfig struct {
 		One string `json:"one,omitempty"`
 	}
@@ -180,7 +180,7 @@ func Test_UnmarshalJson(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			var v testConfig
-			err := JsonUnmarshal([]byte(tt.data), &v)
+			err := JSONUnmarshal([]byte(tt.data), &v)
 			if tt.expectedError == nil && len(tt.expectAll) == 0 {
 				require.Nil(t, err)
 			} else {

--- a/internal/goutils/strings.go
+++ b/internal/goutils/strings.go
@@ -160,8 +160,8 @@ func UpperCaseTrimAll(namedEntities string) string {
 	return strings.ReplaceAll(strings.ToUpper(namedEntities), " ", "")
 }
 
-// ToHttps returns url with https protocol
-func ToHttps(urlAddr string) string {
+// ToHTTPS returns url with https protocol
+func ToHTTPS(urlAddr string) string {
 	u, err := url.Parse(urlAddr)
 	if err != nil {
 		return urlAddr

--- a/internal/goutils/strings_test.go
+++ b/internal/goutils/strings_test.go
@@ -422,7 +422,7 @@ func Test_UpperCaseTrimAll(t *testing.T) {
 	}
 }
 
-func Test_ToHttps(t *testing.T) {
+func Test_ToHTTPS(t *testing.T) {
 	tests := []struct {
 		name     string
 		urlAddr  string
@@ -446,7 +446,7 @@ func Test_ToHttps(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			output := ToHttps(tt.urlAddr)
+			output := ToHTTPS(tt.urlAddr)
 			require.Equal(t, output, tt.expected)
 		})
 	}

--- a/internal/hooks/hook_executor_v2.go
+++ b/internal/hooks/hook_executor_v2.go
@@ -49,7 +49,7 @@ func (e *HookExecutorMessageBoundaryProtocol) Execute(ctx context.Context, opts 
 	}
 
 	boundary := generateBoundary()
-	cmdArgVars = append(cmdArgVars, "--protocol="+HOOK_PROTOCOL_V2.String(), "--boundary="+boundary)
+	cmdArgVars = append(cmdArgVars, "--protocol="+HookProtocolV2.String(), "--boundary="+boundary)
 
 	e.IO.PrintDebug(ctx,
 		"starting hook command: %s %s\n", cmdArgs[0], strings.Join(cmdArgVars, " "),

--- a/internal/hooks/hook_executor_v2_test.go
+++ b/internal/hooks/hook_executor_v2_test.go
@@ -29,13 +29,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var MOCK_BOUNDARY_STRING = "boundary-string"
-var SIXTY_FOUR_KB_STRING = string(make([]byte, (64*1024)+1))
-var FIVE_HUNDRED_TWELVE_KB_STRING = string(make([]byte, (512*1024)+1))
+var mockBoundaryString = "boundary-string"
+var sixtyFourKBString = string(make([]byte, (64*1024)+1))
+var fiveHundredTwelveKBString = string(make([]byte, (512*1024)+1))
 
 // mockBoundaryStringGenerator returns a random string for finding in tests
 func mockBoundaryStringGenerator() string {
-	return MOCK_BOUNDARY_STRING
+	return mockBoundaryString
 }
 
 func Test_Hook_Execute_V2_Protocol(t *testing.T) {
@@ -60,7 +60,7 @@ func Test_Hook_Execute_V2_Protocol(t *testing.T) {
 				},
 				Exec: &MockExec{
 					mockCommand: &MockCommand{
-						MockStdout: []byte(MOCK_BOUNDARY_STRING + `{"message": "hello world"}` + MOCK_BOUNDARY_STRING),
+						MockStdout: []byte(mockBoundaryString + `{"message": "hello world"}` + mockBoundaryString),
 						Err:        nil,
 					},
 				},
@@ -81,13 +81,13 @@ func Test_Hook_Execute_V2_Protocol(t *testing.T) {
 				},
 				Exec: &MockExec{
 					mockCommand: &MockCommand{
-						StdoutIO: io.NopCloser(strings.NewReader(MOCK_BOUNDARY_STRING + SIXTY_FOUR_KB_STRING + MOCK_BOUNDARY_STRING)),
+						StdoutIO: io.NopCloser(strings.NewReader(mockBoundaryString + sixtyFourKBString + mockBoundaryString)),
 						Err:      nil,
 					},
 				},
 			},
 			check: func(t *testing.T, response string, err error, mockExec ExecInterface) {
-				require.Equal(t, SIXTY_FOUR_KB_STRING, response)
+				require.Equal(t, sixtyFourKBString, response)
 				require.Equal(t, nil, err)
 				require.Contains(t, mockExec.(*MockExec).mockCommand.Env, `batman="robin"`)
 				require.Contains(t, mockExec.(*MockExec).mockCommand.Env, `yin="yang"`)
@@ -98,14 +98,14 @@ func Test_Hook_Execute_V2_Protocol(t *testing.T) {
 				Hook: HookScript{Name: "happypath", Command: "echo {}"},
 				Exec: &MockExec{
 					mockCommand: &MockCommand{
-						StdoutIO: io.NopCloser(strings.NewReader("before" + MOCK_BOUNDARY_STRING + FIVE_HUNDRED_TWELVE_KB_STRING + MOCK_BOUNDARY_STRING + "after")),
+						StdoutIO: io.NopCloser(strings.NewReader("before" + mockBoundaryString + fiveHundredTwelveKBString + mockBoundaryString + "after")),
 						Err:      nil,
 					},
 				},
 			},
 			check: func(t *testing.T, response string, err error, mockExec ExecInterface) {
 				require.NoError(t, err)
-				require.Equal(t, FIVE_HUNDRED_TWELVE_KB_STRING, response)
+				require.Equal(t, fiveHundredTwelveKBString, response)
 			},
 		},
 		"failed command execution": {
@@ -128,7 +128,7 @@ func Test_Hook_Execute_V2_Protocol(t *testing.T) {
 				Env:  map[string]string{},
 				Exec: &MockExec{
 					mockCommand: &MockCommand{
-						StdoutIO: io.NopCloser(strings.NewReader("diagnostic info" + MOCK_BOUNDARY_STRING + MOCK_BOUNDARY_STRING + `{"message": "hello world"}` + MOCK_BOUNDARY_STRING)),
+						StdoutIO: io.NopCloser(strings.NewReader("diagnostic info" + mockBoundaryString + mockBoundaryString + `{"message": "hello world"}` + mockBoundaryString)),
 						StderrIO: io.NopCloser(strings.NewReader(``)),
 						Err:      nil,
 					},

--- a/internal/hooks/hooks.go
+++ b/internal/hooks/hooks.go
@@ -30,7 +30,7 @@ type HookExecutor interface {
 func GetHookExecutor(ios iostreams.IOStreamer, cfg SDKCLIConfig) HookExecutor {
 	protocol := cfg.Config.SupportedProtocols.Preferred()
 	switch protocol {
-	case HOOK_PROTOCOL_V2:
+	case HookProtocolV2:
 		return &HookExecutorMessageBoundaryProtocol{
 			IO: ios,
 		}

--- a/internal/hooks/hooks_test.go
+++ b/internal/hooks/hooks_test.go
@@ -28,20 +28,20 @@ func Test_Hooks_GetHookExecutor(t *testing.T) {
 		protocolVersions ProtocolVersions
 		expectedType     interface{}
 	}{
-		"Type HOOK_PROTOCOL_V2": {
-			protocolVersions: ProtocolVersions{HOOK_PROTOCOL_V2},
+		"Type HookProtocolV2": {
+			protocolVersions: ProtocolVersions{HookProtocolV2},
 			expectedType:     &HookExecutorMessageBoundaryProtocol{},
 		},
-		"Type HOOK_PROTOCOL_DEFAULT": {
-			protocolVersions: ProtocolVersions{HOOK_PROTOCOL_DEFAULT},
+		"Type HookProtocolDefault": {
+			protocolVersions: ProtocolVersions{HookProtocolDefault},
 			expectedType:     &HookExecutorDefaultProtocol{},
 		},
-		"Both HOOK_PROTOCOL_V2 and HOOK_PROTOCOL_DEFAULT": {
-			protocolVersions: ProtocolVersions{HOOK_PROTOCOL_V2, HOOK_PROTOCOL_DEFAULT},
+		"Both HookProtocolV2 and HookProtocolDefault": {
+			protocolVersions: ProtocolVersions{HookProtocolV2, HookProtocolDefault},
 			expectedType:     &HookExecutorMessageBoundaryProtocol{},
 		},
-		"Both HOOK_PROTOCOL_DEFAULT and HOOK_PROTOCOL_V2": {
-			protocolVersions: ProtocolVersions{HOOK_PROTOCOL_DEFAULT, HOOK_PROTOCOL_V2},
+		"Both HookProtocolDefault and HookProtocolV2": {
+			protocolVersions: ProtocolVersions{HookProtocolDefault, HookProtocolV2},
 			expectedType:     &HookExecutorDefaultProtocol{},
 		},
 	}

--- a/internal/hooks/protocol.go
+++ b/internal/hooks/protocol.go
@@ -18,8 +18,8 @@ package hooks
 type Protocol string
 
 const (
-	HOOK_PROTOCOL_DEFAULT Protocol = "default"
-	HOOK_PROTOCOL_V2      Protocol = "message-boundaries"
+	HookProtocolDefault Protocol = "default"
+	HookProtocolV2      Protocol = "message-boundaries"
 )
 
 func (p Protocol) String() string {
@@ -28,5 +28,5 @@ func (p Protocol) String() string {
 
 // Valid returns true if this protocol is understood by the CLI.
 func (p Protocol) Valid() bool {
-	return p == HOOK_PROTOCOL_DEFAULT || p == HOOK_PROTOCOL_V2
+	return p == HookProtocolDefault || p == HookProtocolV2
 }

--- a/internal/hooks/protocol_test.go
+++ b/internal/hooks/protocol_test.go
@@ -23,20 +23,20 @@ import (
 func Test_Protocol_String(t *testing.T) {
 	var p Protocol
 
-	p = HOOK_PROTOCOL_DEFAULT
-	require.Equal(t, string(HOOK_PROTOCOL_DEFAULT), p.String())
+	p = HookProtocolDefault
+	require.Equal(t, string(HookProtocolDefault), p.String())
 
-	p = HOOK_PROTOCOL_V2
-	require.Equal(t, string(HOOK_PROTOCOL_V2), p.String())
+	p = HookProtocolV2
+	require.Equal(t, string(HookProtocolV2), p.String())
 }
 
 func Test_Protocol_Valid(t *testing.T) {
 	var p Protocol
 
-	p = HOOK_PROTOCOL_DEFAULT
+	p = HookProtocolDefault
 	require.True(t, p.Valid())
 
-	p = HOOK_PROTOCOL_V2
+	p = HookProtocolV2
 	require.True(t, p.Valid())
 
 	p = "invalid_protocol"

--- a/internal/hooks/sdk_config.go
+++ b/internal/hooks/sdk_config.go
@@ -64,7 +64,7 @@ func (pv ProtocolVersions) Preferred() Protocol {
 			return p
 		}
 	}
-	return HOOK_PROTOCOL_DEFAULT
+	return HookProtocolDefault
 }
 
 type WatchOpts struct {

--- a/internal/hooks/sdk_config_test.go
+++ b/internal/hooks/sdk_config_test.go
@@ -61,13 +61,13 @@ func Test_ProtocolResolution(t *testing.T) {
 			}{
 				SupportedProtocols: ProtocolVersions{
 					"fake-news",
-					HOOK_PROTOCOL_V2,
+					HookProtocolV2,
 					"news-fake",
-					HOOK_PROTOCOL_DEFAULT,
+					HookProtocolDefault,
 				},
 			}},
 			check: func(t *testing.T, p Protocol) {
-				assert.Equal(t, p, HOOK_PROTOCOL_V2)
+				assert.Equal(t, p, HookProtocolV2)
 			},
 		},
 		"Returns default config if no valid protocols are present": {
@@ -82,13 +82,13 @@ func Test_ProtocolResolution(t *testing.T) {
 				},
 			}},
 			check: func(t *testing.T, p Protocol) {
-				assert.Equal(t, p, HOOK_PROTOCOL_DEFAULT)
+				assert.Equal(t, p, HookProtocolDefault)
 			},
 		},
 		"Returns default config if no protocols are present": {
 			config: SDKCLIConfig{},
 			check: func(t *testing.T, p Protocol) {
-				assert.Equal(t, p, HOOK_PROTOCOL_DEFAULT)
+				assert.Equal(t, p, HookProtocolDefault)
 			},
 		},
 	}

--- a/internal/pkg/apps/delete.go
+++ b/internal/pkg/apps/delete.go
@@ -56,7 +56,7 @@ func Delete(ctx context.Context, clients *shared.ClientFactory, log *logger.Logg
 	log.Info("on_apps_delete_app_init")
 
 	// Delete app remotely via Slack API
-	err = clients.ApiInterface().DeleteApp(ctx, config.GetContextToken(ctx), app.AppID)
+	err = clients.APIInterface().DeleteApp(ctx, config.GetContextToken(ctx), app.AppID)
 	if err != nil {
 		return app, err
 	}
@@ -88,10 +88,10 @@ func getAuthSession(ctx context.Context, clients *shared.ClientFactory, auth typ
 	// Update the APIHost with the selected login, this is important for commands that use the Login to temporarily
 	// get an auth without updating the default auth. It's less important for the Login command that terminals afterward,
 	// because on start up, the root command resolves the auth's current APIHost.
-	clients.Config.ApiHostResolved = clients.AuthInterface().ResolveApiHost(ctx, clients.Config.ApiHostFlag, &auth)
-	clients.Config.LogstashHostResolved = clients.AuthInterface().ResolveLogstashHost(ctx, clients.Config.ApiHostResolved, clients.Config.Version)
+	clients.Config.APIHostResolved = clients.AuthInterface().ResolveAPIHost(ctx, clients.Config.APIHostFlag, &auth)
+	clients.Config.LogstashHostResolved = clients.AuthInterface().ResolveLogstashHost(ctx, clients.Config.APIHostResolved, clients.Config.Version)
 
-	authSession, err := clients.ApiInterface().ValidateSession(ctx, token)
+	authSession, err := clients.APIInterface().ValidateSession(ctx, token)
 	if err != nil {
 		return ctx, api.AuthSession{}, slackerror.Wrap(err, slackerror.ErrInvalidAuth)
 	}

--- a/internal/pkg/apps/delete_test.go
+++ b/internal/pkg/apps/delete_test.go
@@ -81,13 +81,13 @@ func TestAppsDelete(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := shared.NewClientsMock()
-			clientsMock.AuthInterface.On("ResolveApiHost", mock.Anything, mock.Anything, mock.Anything).Return("api host")
+			clientsMock.AuthInterface.On("ResolveAPIHost", mock.Anything, mock.Anything, mock.Anything).Return("api host")
 			clientsMock.AuthInterface.On("ResolveLogstashHost", mock.Anything, mock.Anything, mock.Anything).Return("logstash host")
-			clientsMock.ApiInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{
+			clientsMock.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{
 				TeamName: &tt.auth.TeamDomain,
 				TeamID:   &tt.auth.TeamID,
 			}, nil)
-			clientsMock.ApiInterface.On("DeleteApp", mock.Anything, mock.Anything, tt.app.AppID).Return(nil)
+			clientsMock.APIInterface.On("DeleteApp", mock.Anything, mock.Anything, tt.app.AppID).Return(nil)
 			clientsMock.AddDefaultMocks()
 
 			clients := shared.NewClientFactory(clientsMock.MockClientFactory())
@@ -110,7 +110,7 @@ func TestAppsDelete(t *testing.T) {
 			app, err := Delete(ctx, clients, logger.New(nil), tt.app.TeamDomain, tt.app, tt.auth)
 			require.NoError(t, err)
 			assert.Equal(t, tt.app, app)
-			clientsMock.ApiInterface.AssertCalled(
+			clientsMock.APIInterface.AssertCalled(
 				t,
 				"DeleteApp",
 				mock.Anything,

--- a/internal/pkg/apps/install.go
+++ b/internal/pkg/apps/install.go
@@ -185,7 +185,7 @@ func Install(ctx context.Context, clients *shared.ClientFactory, log *logger.Log
 		return app, "", err
 	}
 
-	if installState != types.SUCCESS {
+	if installState != types.InstallSuccess {
 		printNonSuccessInstallState(ctx, clients, installState)
 		return app, installState, nil
 	}
@@ -228,7 +228,7 @@ func Install(ctx context.Context, clients *shared.ClientFactory, log *logger.Log
 	log.Data["installTime"] = fmt.Sprintf("%.1fs", time.Since(start).Seconds())
 	log.Info("app_install_complete")
 
-	return app, types.SUCCESS, nil
+	return app, types.InstallSuccess, nil
 }
 
 func printNonSuccessInstallState(ctx context.Context, clients *shared.ClientFactory, installState types.InstallState) {
@@ -236,13 +236,13 @@ func printNonSuccessInstallState(ctx context.Context, clients *shared.ClientFact
 		primary   string
 		secondary string
 	)
-	if installState == types.REQUEST_PENDING {
+	if installState == types.InstallRequestPending {
 		primary = "Your request to install the app is pending"
 		secondary = fmt.Sprintf("You will receive a Slackbot message after an admin has reviewed your request\nOnce your request is approved, complete installation by re-running %s", style.Commandf(clients.Config.Command, true))
-	} else if installState == types.REQUEST_CANCELLED {
+	} else if installState == types.InstallRequestCancelled {
 		primary = "Your request to install the app has been cancelled"
 		secondary = ""
-	} else if installState == types.REQUEST_NOT_SENT {
+	} else if installState == types.InstallRequestNotSent {
 		primary = "You've declined to send a request to an admin"
 		secondary = "Please submit a request to install or update your app"
 	}
@@ -473,7 +473,7 @@ func InstallLocalApp(ctx context.Context, clients *shared.ClientFactory, orgGran
 		return app, api.DeveloperAppInstallResult{}, "", err
 	}
 
-	if installState != types.SUCCESS {
+	if installState != types.InstallSuccess {
 		printNonSuccessInstallState(ctx, clients, installState)
 		return app, api.DeveloperAppInstallResult{}, installState, nil
 	}
@@ -513,7 +513,7 @@ func InstallLocalApp(ctx context.Context, clients *shared.ClientFactory, orgGran
 	log.Data["installTime"] = fmt.Sprintf("%.1fs", time.Since(start).Seconds())
 	log.Info("app_install_complete")
 
-	return app, result, types.SUCCESS, nil
+	return app, result, types.InstallSuccess, nil
 }
 
 // getIconHash returns the MD5 hash of the icon file

--- a/internal/pkg/apps/install_test.go
+++ b/internal/pkg/apps/install_test.go
@@ -43,13 +43,13 @@ func TestInstall(t *testing.T) {
 
 	tests := map[string]struct {
 		mockApp                 types.App
-		mockApiCreate           api.CreateAppResult
-		mockApiCreateError      error
-		mockApiInstall          api.DeveloperAppInstallResult
-		mockApiInstallState     types.InstallState
-		mockApiInstallError     error
-		mockApiUpdate           api.UpdateAppResult
-		mockApiUpdateError      error
+		mockAPICreate           api.CreateAppResult
+		mockAPICreateError      error
+		mockAPIInstall          api.DeveloperAppInstallResult
+		mockAPIInstallState     types.InstallState
+		mockAPIInstallError     error
+		mockAPIUpdate           api.UpdateAppResult
+		mockAPIUpdateError      error
 		mockAuth                types.SlackAuth
 		mockAuthSession         api.AuthSession
 		mockBoltExperiment      bool
@@ -69,10 +69,10 @@ func TestInstall(t *testing.T) {
 	}{
 		"create a hosted app manifest with expected rosi values": {
 			mockApp: types.App{},
-			mockApiCreate: api.CreateAppResult{
+			mockAPICreate: api.CreateAppResult{
 				AppID: "A001",
 			},
-			mockApiUpdateError: slackerror.New(slackerror.ErrAppAdd),
+			mockAPIUpdateError: slackerror.New(slackerror.ErrAppAdd),
 			mockAuth: types.SlackAuth{
 				EnterpriseID: mockEnterpriseID,
 				TeamID:       mockTeamID,
@@ -87,14 +87,14 @@ func TestInstall(t *testing.T) {
 				UserID:       &mockUserID,
 			},
 			mockBoltExperiment: true,
-			mockManifestSource: config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource: config.ManifestSourceLocal,
 			mockManifest: types.SlackYaml{
 				AppManifest: types.AppManifest{
 					MetaData: &types.ManifestMetaData{
 						MajorVersion: 2,
 					},
 					Settings: &types.AppSettings{
-						FunctionRuntime: types.SLACK_HOSTED,
+						FunctionRuntime: types.SlackHosted,
 					},
 				},
 			},
@@ -109,7 +109,7 @@ func TestInstall(t *testing.T) {
 					MajorVersion: 2,
 				},
 				Settings: &types.AppSettings{
-					FunctionRuntime: types.SLACK_HOSTED,
+					FunctionRuntime: types.SlackHosted,
 					EventSubscriptions: &types.ManifestEventSubscriptions{
 						RequestURL: "https://slack.com",
 					},
@@ -128,8 +128,8 @@ func TestInstall(t *testing.T) {
 				TeamID:     mockTeamID,
 				TeamDomain: mockTeamDomain,
 			},
-			mockApiCreateError: slackerror.New(slackerror.ErrAppCreate),
-			mockApiUpdate: api.UpdateAppResult{
+			mockAPICreateError: slackerror.New(slackerror.ErrAppCreate),
+			mockAPIUpdate: api.UpdateAppResult{
 				AppID: "A001",
 			},
 			mockAuth: types.SlackAuth{
@@ -146,14 +146,14 @@ func TestInstall(t *testing.T) {
 				UserID:       &mockUserID,
 			},
 			mockBoltExperiment: true,
-			mockManifestSource: config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource: config.ManifestSourceLocal,
 			mockManifest: types.SlackYaml{
 				AppManifest: types.AppManifest{
 					MetaData: &types.ManifestMetaData{
 						MajorVersion: 2,
 					},
 					Settings: &types.AppSettings{
-						FunctionRuntime: types.SLACK_HOSTED,
+						FunctionRuntime: types.SlackHosted,
 					},
 				},
 			},
@@ -168,7 +168,7 @@ func TestInstall(t *testing.T) {
 					MajorVersion: 2,
 				},
 				Settings: &types.AppSettings{
-					FunctionRuntime: types.SLACK_HOSTED,
+					FunctionRuntime: types.SlackHosted,
 					EventSubscriptions: &types.ManifestEventSubscriptions{
 						RequestURL: "https://slack.com",
 					},
@@ -186,12 +186,12 @@ func TestInstall(t *testing.T) {
 				AppID:  "A002",
 				TeamID: mockTeamID,
 			},
-			mockApiCreateError: slackerror.New(slackerror.ErrAppCreate),
-			mockApiInstall: api.DeveloperAppInstallResult{
+			mockAPICreateError: slackerror.New(slackerror.ErrAppCreate),
+			mockAPIInstall: api.DeveloperAppInstallResult{
 				AppID: "A002",
 			},
-			mockApiInstallState: types.SUCCESS,
-			mockApiUpdate: api.UpdateAppResult{
+			mockAPIInstallState: types.SUCCESS,
+			mockAPIUpdate: api.UpdateAppResult{
 				AppID: "A002",
 			},
 			mockAuth: types.SlackAuth{
@@ -217,7 +217,7 @@ func TestInstall(t *testing.T) {
 						Name: "example-2",
 					},
 					Settings: &types.AppSettings{
-						FunctionRuntime: types.REMOTE,
+						FunctionRuntime: types.Remote,
 						EventSubscriptions: &types.ManifestEventSubscriptions{
 							RequestURL: "https://example.com",
 						},
@@ -239,7 +239,7 @@ func TestInstall(t *testing.T) {
 					Name: "example-2",
 				},
 				Settings: &types.AppSettings{
-					FunctionRuntime: types.REMOTE,
+					FunctionRuntime: types.Remote,
 					EventSubscriptions: &types.ManifestEventSubscriptions{
 						RequestURL: "https://example.com",
 					},
@@ -252,11 +252,11 @@ func TestInstall(t *testing.T) {
 				AppID:  "A003",
 				TeamID: mockTeamID,
 			},
-			mockApiInstall: api.DeveloperAppInstallResult{
+			mockAPIInstall: api.DeveloperAppInstallResult{
 				AppID: "A003",
 			},
-			mockApiInstallState: types.SUCCESS,
-			mockApiUpdate: api.UpdateAppResult{
+			mockAPIInstallState: types.SUCCESS,
+			mockAPIUpdate: api.UpdateAppResult{
 				AppID: "A003",
 			},
 			mockAuth: types.SlackAuth{
@@ -313,11 +313,11 @@ func TestInstall(t *testing.T) {
 				TeamName: &mockTeamDomain,
 				UserID:   &mockUserID,
 			},
-			mockApiCreateError:  slackerror.New(slackerror.ErrAppCreate),
-			mockApiUpdateError:  slackerror.New(slackerror.ErrAppAdd),
-			mockApiInstallError: slackerror.New(slackerror.ErrAppInstall),
+			mockAPICreateError:  slackerror.New(slackerror.ErrAppCreate),
+			mockAPIUpdateError:  slackerror.New(slackerror.ErrAppAdd),
+			mockAPIInstallError: slackerror.New(slackerror.ErrAppInstall),
 			mockBoltExperiment:  true,
-			mockManifestSource:  config.MANIFEST_SOURCE_REMOTE,
+			mockManifestSource:  config.ManifestSourceRemote,
 			expectedApp: types.App{
 				AppID:  "A004",
 				TeamID: mockTeamID,
@@ -342,13 +342,13 @@ func TestInstall(t *testing.T) {
 				TeamName: &mockTeamDomain,
 				UserID:   &mockUserID,
 			},
-			mockApiCreateError:      slackerror.New(slackerror.ErrAppCreate),
-			mockApiUpdateError:      slackerror.New(slackerror.ErrAppAdd),
-			mockApiInstallError:     slackerror.New(slackerror.ErrAppInstall),
+			mockAPICreateError:      slackerror.New(slackerror.ErrAppCreate),
+			mockAPIUpdateError:      slackerror.New(slackerror.ErrAppAdd),
+			mockAPIInstallError:     slackerror.New(slackerror.ErrAppInstall),
 			mockBoltExperiment:      true,
 			mockManifestHashInitial: "pt1",
 			mockManifestHashUpdated: "pt2",
-			mockManifestSource:      config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:      config.ManifestSourceLocal,
 			expectedCreate:          false,
 			expectedError:           slackerror.New(slackerror.ErrAppManifestUpdate),
 			expectedInstallState:    "",
@@ -360,12 +360,12 @@ func TestInstall(t *testing.T) {
 				TeamID:       mockTeamID,
 				EnterpriseID: mockEnterpriseID,
 			},
-			mockApiCreateError: slackerror.New(slackerror.ErrAppCreate),
-			mockApiInstall: api.DeveloperAppInstallResult{
+			mockAPICreateError: slackerror.New(slackerror.ErrAppCreate),
+			mockAPIInstall: api.DeveloperAppInstallResult{
 				AppID: "A005",
 			},
-			mockApiInstallState: types.SUCCESS,
-			mockApiUpdate: api.UpdateAppResult{
+			mockAPIInstallState: types.SUCCESS,
+			mockAPIUpdate: api.UpdateAppResult{
 				AppID: "A005",
 			},
 			mockAuth: types.SlackAuth{
@@ -404,12 +404,12 @@ func TestInstall(t *testing.T) {
 				AppID:  "A006",
 				TeamID: mockTeamID,
 			},
-			mockApiCreateError: slackerror.New(slackerror.ErrAppCreate),
-			mockApiInstall: api.DeveloperAppInstallResult{
+			mockAPICreateError: slackerror.New(slackerror.ErrAppCreate),
+			mockAPIInstall: api.DeveloperAppInstallResult{
 				AppID: "A006",
 			},
-			mockApiInstallState: types.SUCCESS,
-			mockApiUpdate: api.UpdateAppResult{
+			mockAPIInstallState: types.SUCCESS,
+			mockAPIUpdate: api.UpdateAppResult{
 				AppID: "A006",
 			},
 			mockAuth: types.SlackAuth{
@@ -459,17 +459,17 @@ func TestInstall(t *testing.T) {
 			clientsMock := shared.NewClientsMock()
 			clientsMock.IO.On("IsTTY").Return(tt.mockIsTTY)
 			clientsMock.AddDefaultMocks()
-			clientsMock.ApiInterface.On(
+			clientsMock.APIInterface.On(
 				"CreateApp",
 				mock.Anything,
 				mock.Anything,
 				mock.Anything,
 				mock.Anything,
 			).Return(
-				tt.mockApiCreate,
-				tt.mockApiCreateError,
+				tt.mockAPICreate,
+				tt.mockAPICreateError,
 			)
-			clientsMock.ApiInterface.On(
+			clientsMock.APIInterface.On(
 				"DeveloperAppInstall",
 				mock.Anything,
 				mock.Anything,
@@ -480,11 +480,11 @@ func TestInstall(t *testing.T) {
 				mock.Anything,
 				mock.Anything,
 			).Return(
-				tt.mockApiInstall,
-				tt.mockApiInstallState,
-				tt.mockApiInstallError,
+				tt.mockAPIInstall,
+				tt.mockAPIInstallState,
+				tt.mockAPIInstallError,
 			)
-			clientsMock.ApiInterface.On(
+			clientsMock.APIInterface.On(
 				"ExportAppManifest",
 				mock.Anything,
 				mock.Anything,
@@ -493,7 +493,7 @@ func TestInstall(t *testing.T) {
 				api.ExportAppResult{},
 				nil,
 			)
-			clientsMock.ApiInterface.On(
+			clientsMock.APIInterface.On(
 				"ValidateAppManifest",
 				mock.Anything,
 				mock.Anything,
@@ -503,7 +503,7 @@ func TestInstall(t *testing.T) {
 				api.ValidateAppManifestResult{},
 				nil,
 			)
-			clientsMock.ApiInterface.On(
+			clientsMock.APIInterface.On(
 				"UpdateApp",
 				mock.Anything,
 				mock.Anything,
@@ -512,10 +512,10 @@ func TestInstall(t *testing.T) {
 				mock.Anything,
 				mock.Anything,
 			).Return(
-				tt.mockApiUpdate,
-				tt.mockApiUpdateError,
+				tt.mockAPIUpdate,
+				tt.mockAPIUpdateError,
 			)
-			clientsMock.ApiInterface.On(
+			clientsMock.APIInterface.On(
 				"ValidateSession",
 				mock.Anything,
 				mock.Anything,
@@ -593,7 +593,7 @@ func TestInstall(t *testing.T) {
 			assert.Equal(t, tt.expectedInstallState, state)
 			assert.Equal(t, tt.expectedApp, app)
 			if tt.expectedUpdate {
-				clientsMock.ApiInterface.AssertCalled(
+				clientsMock.APIInterface.AssertCalled(
 					t,
 					"UpdateApp",
 					mock.Anything,
@@ -603,9 +603,9 @@ func TestInstall(t *testing.T) {
 					mock.Anything,
 					mock.Anything,
 				)
-				clientsMock.ApiInterface.AssertNotCalled(t, "CreateApp")
+				clientsMock.APIInterface.AssertNotCalled(t, "CreateApp")
 			} else if tt.expectedCreate {
-				clientsMock.ApiInterface.AssertCalled(
+				clientsMock.APIInterface.AssertCalled(
 					t,
 					"CreateApp",
 					mock.Anything,
@@ -613,9 +613,9 @@ func TestInstall(t *testing.T) {
 					mock.Anything,
 					mock.Anything,
 				)
-				clientsMock.ApiInterface.AssertNotCalled(t, "UpdateApp")
+				clientsMock.APIInterface.AssertNotCalled(t, "UpdateApp")
 			}
-			for _, call := range clientsMock.ApiInterface.Calls {
+			for _, call := range clientsMock.APIInterface.Calls {
 				args := call.Arguments
 				switch call.Method {
 				case "CreateApp":
@@ -642,13 +642,13 @@ func TestInstallLocalApp(t *testing.T) {
 	tests := map[string]struct {
 		isExperimental          bool
 		mockApp                 types.App
-		mockApiCreate           api.CreateAppResult
-		mockApiCreateError      error
-		mockApiInstall          api.DeveloperAppInstallResult
-		mockApiInstallState     types.InstallState
-		mockApiInstallError     error
-		mockApiUpdate           api.UpdateAppResult
-		mockApiUpdateError      error
+		mockAPICreate           api.CreateAppResult
+		mockAPICreateError      error
+		mockAPIInstall          api.DeveloperAppInstallResult
+		mockAPIInstallState     types.InstallState
+		mockAPIInstallError     error
+		mockAPIUpdate           api.UpdateAppResult
+		mockAPIUpdateError      error
 		mockAuth                types.SlackAuth
 		mockAuthSession         api.AuthSession
 		mockBoltExperiment      bool
@@ -668,10 +668,10 @@ func TestInstallLocalApp(t *testing.T) {
 		"create a new run on slack app with a local function runtime using expected rosi defaults": {
 			isExperimental: false,
 			mockApp:        types.App{},
-			mockApiCreate: api.CreateAppResult{
+			mockAPICreate: api.CreateAppResult{
 				AppID: "A001",
 			},
-			mockApiUpdateError: slackerror.New(slackerror.ErrAppAdd),
+			mockAPIUpdateError: slackerror.New(slackerror.ErrAppAdd),
 			mockAuth: types.SlackAuth{
 				EnterpriseID: mockEnterpriseID,
 				TeamID:       mockTeamID,
@@ -694,7 +694,7 @@ func TestInstallLocalApp(t *testing.T) {
 						Name: "example-1",
 					},
 					Settings: &types.AppSettings{
-						FunctionRuntime: types.SLACK_HOSTED,
+						FunctionRuntime: types.SlackHosted,
 					},
 				},
 			},
@@ -714,7 +714,7 @@ func TestInstallLocalApp(t *testing.T) {
 					Name: "example-1 (local)",
 				},
 				Settings: &types.AppSettings{
-					FunctionRuntime:   types.LOCALLY_RUN,
+					FunctionRuntime:   types.LocallyRun,
 					SocketModeEnabled: &mockTrue,
 					Interactivity: &types.ManifestInteractivity{
 						IsEnabled: true,
@@ -731,8 +731,8 @@ func TestInstallLocalApp(t *testing.T) {
 				TeamID: mockTeamID,
 				UserID: mockUserID,
 			},
-			mockApiCreateError: slackerror.New(slackerror.ErrAppCreate),
-			mockApiUpdate: api.UpdateAppResult{
+			mockAPICreateError: slackerror.New(slackerror.ErrAppCreate),
+			mockAPIUpdate: api.UpdateAppResult{
 				AppID: "A002",
 			},
 			mockAuth: types.SlackAuth{
@@ -761,7 +761,7 @@ func TestInstallLocalApp(t *testing.T) {
 						},
 					},
 					Settings: &types.AppSettings{
-						FunctionRuntime: types.REMOTE,
+						FunctionRuntime: types.Remote,
 						EventSubscriptions: &types.ManifestEventSubscriptions{
 							RequestURL: "https://example.com",
 						},
@@ -789,7 +789,7 @@ func TestInstallLocalApp(t *testing.T) {
 					},
 				},
 				Settings: &types.AppSettings{
-					FunctionRuntime: types.REMOTE,
+					FunctionRuntime: types.Remote,
 					EventSubscriptions: &types.ManifestEventSubscriptions{
 						RequestURL: "https://example.com",
 					},
@@ -804,8 +804,8 @@ func TestInstallLocalApp(t *testing.T) {
 				TeamID: mockTeamID,
 				UserID: mockUserID,
 			},
-			mockApiCreateError: slackerror.New(slackerror.ErrAppCreate),
-			mockApiUpdate: api.UpdateAppResult{
+			mockAPICreateError: slackerror.New(slackerror.ErrAppCreate),
+			mockAPIUpdate: api.UpdateAppResult{
 				AppID: "A003",
 			},
 			mockAuth: types.SlackAuth{
@@ -879,11 +879,11 @@ func TestInstallLocalApp(t *testing.T) {
 				TeamName: &mockTeamDomain,
 				UserID:   &mockUserID,
 			},
-			mockApiCreateError:  slackerror.New(slackerror.ErrAppCreate),
-			mockApiUpdateError:  slackerror.New(slackerror.ErrAppAdd),
-			mockApiInstallError: slackerror.New(slackerror.ErrAppInstall),
+			mockAPICreateError:  slackerror.New(slackerror.ErrAppCreate),
+			mockAPIUpdateError:  slackerror.New(slackerror.ErrAppAdd),
+			mockAPIInstallError: slackerror.New(slackerror.ErrAppInstall),
 			mockBoltExperiment:  true,
-			mockManifestSource:  config.MANIFEST_SOURCE_REMOTE,
+			mockManifestSource:  config.ManifestSourceRemote,
 			expectedApp: types.App{
 				AppID:  "A004",
 				IsDev:  true,
@@ -902,17 +902,17 @@ func TestInstallLocalApp(t *testing.T) {
 			clientsMock := shared.NewClientsMock()
 			clientsMock.IO.On("IsTTY").Return(tt.mockIsTTY)
 			clientsMock.AddDefaultMocks()
-			clientsMock.ApiInterface.On(
+			clientsMock.APIInterface.On(
 				"CreateApp",
 				mock.Anything,
 				mock.Anything,
 				mock.Anything,
 				mock.Anything,
 			).Return(
-				tt.mockApiCreate,
-				tt.mockApiCreateError,
+				tt.mockAPICreate,
+				tt.mockAPICreateError,
 			)
-			clientsMock.ApiInterface.On(
+			clientsMock.APIInterface.On(
 				"DeveloperAppInstall",
 				mock.Anything,
 				mock.Anything,
@@ -923,11 +923,11 @@ func TestInstallLocalApp(t *testing.T) {
 				mock.Anything,
 				mock.Anything,
 			).Return(
-				tt.mockApiInstall,
-				tt.mockApiInstallState,
-				tt.mockApiInstallError,
+				tt.mockAPIInstall,
+				tt.mockAPIInstallState,
+				tt.mockAPIInstallError,
 			)
-			clientsMock.ApiInterface.On(
+			clientsMock.APIInterface.On(
 				"ExportAppManifest",
 				mock.Anything,
 				mock.Anything,
@@ -936,7 +936,7 @@ func TestInstallLocalApp(t *testing.T) {
 				api.ExportAppResult{Manifest: tt.mockManifest},
 				nil,
 			)
-			clientsMock.ApiInterface.On(
+			clientsMock.APIInterface.On(
 				"ValidateAppManifest",
 				mock.Anything,
 				mock.Anything,
@@ -946,7 +946,7 @@ func TestInstallLocalApp(t *testing.T) {
 				api.ValidateAppManifestResult{},
 				nil,
 			)
-			clientsMock.ApiInterface.On(
+			clientsMock.APIInterface.On(
 				"UpdateApp",
 				mock.Anything,
 				mock.Anything,
@@ -955,10 +955,10 @@ func TestInstallLocalApp(t *testing.T) {
 				mock.Anything,
 				mock.Anything,
 			).Return(
-				tt.mockApiUpdate,
-				tt.mockApiUpdateError,
+				tt.mockAPIUpdate,
+				tt.mockAPIUpdateError,
 			)
-			clientsMock.ApiInterface.On(
+			clientsMock.APIInterface.On(
 				"ValidateSession",
 				mock.Anything,
 				mock.Anything,
@@ -1027,7 +1027,7 @@ func TestInstallLocalApp(t *testing.T) {
 			assert.Equal(t, tt.expectedInstallState, state)
 			assert.Equal(t, tt.expectedApp, app)
 			if tt.expectedUpdate {
-				clientsMock.ApiInterface.AssertCalled(
+				clientsMock.APIInterface.AssertCalled(
 					t,
 					"UpdateApp",
 					mock.Anything,
@@ -1037,9 +1037,9 @@ func TestInstallLocalApp(t *testing.T) {
 					mock.Anything,
 					mock.Anything,
 				)
-				clientsMock.ApiInterface.AssertNotCalled(t, "CreateApp")
+				clientsMock.APIInterface.AssertNotCalled(t, "CreateApp")
 			} else if tt.expectedCreate {
-				clientsMock.ApiInterface.AssertCalled(
+				clientsMock.APIInterface.AssertCalled(
 					t,
 					"CreateApp",
 					mock.Anything,
@@ -1047,9 +1047,9 @@ func TestInstallLocalApp(t *testing.T) {
 					mock.Anything,
 					mock.Anything,
 				)
-				clientsMock.ApiInterface.AssertNotCalled(t, "UpdateApp")
+				clientsMock.APIInterface.AssertNotCalled(t, "UpdateApp")
 			}
-			for _, call := range clientsMock.ApiInterface.Calls {
+			for _, call := range clientsMock.APIInterface.Calls {
 				args := call.Arguments
 				switch call.Method {
 				case "CreateApp":
@@ -1147,7 +1147,7 @@ func TestValidateManifestForInstall(t *testing.T) {
 			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := shared.NewClientsMock()
 			tt.setup(clientsMock)
-			clientsMock.ApiInterface.On("ValidateAppManifest", mock.Anything, mock.Anything, mock.Anything, tt.app.AppID).
+			clientsMock.APIInterface.On("ValidateAppManifest", mock.Anything, mock.Anything, mock.Anything, tt.app.AppID).
 				Return(tt.result, tt.err)
 			clients := shared.NewClientFactory(clientsMock.MockClientFactory())
 

--- a/internal/pkg/apps/install_test.go
+++ b/internal/pkg/apps/install_test.go
@@ -190,7 +190,7 @@ func TestInstall(t *testing.T) {
 			mockAPIInstall: api.DeveloperAppInstallResult{
 				AppID: "A002",
 			},
-			mockAPIInstallState: types.SUCCESS,
+			mockAPIInstallState: types.InstallSuccess,
 			mockAPIUpdate: api.UpdateAppResult{
 				AppID: "A002",
 			},
@@ -230,7 +230,7 @@ func TestInstall(t *testing.T) {
 				AppID:  "A002",
 				TeamID: mockTeamID,
 			},
-			expectedInstallState: types.SUCCESS,
+			expectedInstallState: types.InstallSuccess,
 			expectedManifest: types.AppManifest{
 				MetaData: &types.ManifestMetaData{
 					MajorVersion: 1,
@@ -255,7 +255,7 @@ func TestInstall(t *testing.T) {
 			mockAPIInstall: api.DeveloperAppInstallResult{
 				AppID: "A003",
 			},
-			mockAPIInstallState: types.SUCCESS,
+			mockAPIInstallState: types.InstallSuccess,
 			mockAPIUpdate: api.UpdateAppResult{
 				AppID: "A003",
 			},
@@ -286,7 +286,7 @@ func TestInstall(t *testing.T) {
 				AppID:  "A003",
 				TeamID: mockTeamID,
 			},
-			expectedInstallState: types.SUCCESS,
+			expectedInstallState: types.InstallSuccess,
 			expectedManifest: types.AppManifest{
 				DisplayInformation: types.DisplayInformation{
 					Name: "example-3",
@@ -364,7 +364,7 @@ func TestInstall(t *testing.T) {
 			mockAPIInstall: api.DeveloperAppInstallResult{
 				AppID: "A005",
 			},
-			mockAPIInstallState: types.SUCCESS,
+			mockAPIInstallState: types.InstallSuccess,
 			mockAPIUpdate: api.UpdateAppResult{
 				AppID: "A005",
 			},
@@ -408,7 +408,7 @@ func TestInstall(t *testing.T) {
 			mockAPIInstall: api.DeveloperAppInstallResult{
 				AppID: "A006",
 			},
-			mockAPIInstallState: types.SUCCESS,
+			mockAPIInstallState: types.InstallSuccess,
 			mockAPIUpdate: api.UpdateAppResult{
 				AppID: "A006",
 			},
@@ -440,7 +440,7 @@ func TestInstall(t *testing.T) {
 				AppID:  "A006",
 				TeamID: mockTeamID,
 			},
-			expectedInstallState: types.SUCCESS,
+			expectedInstallState: types.InstallSuccess,
 			expectedManifest: types.AppManifest{
 				MetaData: &types.ManifestMetaData{
 					MajorVersion: 1,

--- a/internal/pkg/apps/list.go
+++ b/internal/pkg/apps/list.go
@@ -80,24 +80,24 @@ func List(ctx context.Context, clients *shared.ClientFactory) ([]types.App, stri
 // FetchAppInstallStates fetches app installation status from the backend and sets the values on the given apps
 func FetchAppInstallStates(ctx context.Context, clients *shared.ClientFactory, apps []types.App) ([]types.App, error) {
 	// Sort apps by team and ID
-	appIdsByTeamId := map[string][]string{}
-	appIdsByEnterpriseTeamId := map[string][]string{}
-	appsByAppId := map[string]types.App{}
+	appIDsByTeamID := map[string][]string{}
+	appIDsByEnterpriseTeamID := map[string][]string{}
+	appsByAppID := map[string]types.App{}
 	for _, a := range apps {
 		// Add app by its team id
-		if appIdsByTeamId[a.TeamID] == nil {
-			appIdsByTeamId[a.TeamID] = []string{}
+		if appIDsByTeamID[a.TeamID] == nil {
+			appIDsByTeamID[a.TeamID] = []string{}
 		}
-		appIdsByTeamId[a.TeamID] = append(appIdsByTeamId[a.TeamID], a.AppID)
-		appsByAppId[a.AppID] = a
+		appIDsByTeamID[a.TeamID] = append(appIDsByTeamID[a.TeamID], a.AppID)
+		appsByAppID[a.AppID] = a
 
 		// If app is an enterprise workspace app, also add it by its enterprise teamID
 		if a.IsEnterpriseWorkspaceApp() {
-			if appIdsByEnterpriseTeamId[a.EnterpriseID] == nil {
-				appIdsByEnterpriseTeamId[a.EnterpriseID] = []string{}
+			if appIDsByEnterpriseTeamID[a.EnterpriseID] == nil {
+				appIDsByEnterpriseTeamID[a.EnterpriseID] = []string{}
 			}
-			appIdsByEnterpriseTeamId[a.EnterpriseID] = append(appIdsByEnterpriseTeamId[a.EnterpriseID], a.AppID)
-			appsByAppId[a.AppID] = a
+			appIDsByEnterpriseTeamID[a.EnterpriseID] = append(appIDsByEnterpriseTeamID[a.EnterpriseID], a.AppID)
+			appsByAppID[a.AppID] = a
 		}
 	}
 
@@ -118,16 +118,16 @@ func FetchAppInstallStates(ctx context.Context, clients *shared.ClientFactory, a
 	appToEnterpriseGrants := map[string][]types.EnterpriseGrant{}
 	for _, auth := range auths {
 
-		if len(appIdsByTeamId[auth.TeamID]) == 0 && len(appIdsByEnterpriseTeamId[auth.TeamID]) == 0 {
+		if len(appIDsByTeamID[auth.TeamID]) == 0 && len(appIDsByEnterpriseTeamID[auth.TeamID]) == 0 {
 			continue
 		}
 
-		apiClient := clients.ApiInterface()
-		if auth.ApiHost != nil {
+		apiClient := clients.APIInterface()
+		if auth.APIHost != nil {
 			// Most internal/api methods do not explicitly require the host to be set.
 			// Rather, they rely implicitly on host being set on the apiClient when the instance
 			// is created, (see internal/shared/clients.go). The value that the host is set
-			// to today, in turn relies on the global clients.Config.ApiHostResolved value
+			// to today, in turn relies on the global clients.Config.APIHostResolved value
 			// which in most cases is resolved once at the root of the command.
 			//
 			// For most cases, commands only require that a apiHost be set once. But in some cases,
@@ -137,7 +137,7 @@ func FetchAppInstallStates(ctx context.Context, clients *shared.ClientFactory, a
 			//
 			// Refer to types.SlackAuth where we optionally represent this apiHost value.
 			//
-			// It is an anti-pattern to set and reset a global ApiHostResolved value
+			// It is an anti-pattern to set and reset a global APIHostResolved value
 			// for each authorization that we must make a Slack API call for, since:
 			//
 			//  1. setting global value impacts other future instances of apiClient
@@ -148,21 +148,21 @@ func FetchAppInstallStates(ctx context.Context, clients *shared.ClientFactory, a
 			//  3. Since each new apiClient that is instantiated will default to the existing
 			//     global resolved host anyway, we can instead SetHost here without having to reset it
 			//
-			// So here we modify the host of this ApiClient instance,
+			// So here we modify the host of this APIClient instance,
 			// for each GetAppStatus (POST) request it makes.
-			apiClient.SetHost(*auth.ApiHost)
+			apiClient.SetHost(*auth.APIHost)
 		}
 
 		var appStatusResponse api.GetAppStatusResult
 		if auth.IsEnterpriseInstall {
-			var allApps = append(appIdsByEnterpriseTeamId[auth.TeamID], appIdsByTeamId[auth.TeamID]...)
+			var allApps = append(appIDsByEnterpriseTeamID[auth.TeamID], appIDsByTeamID[auth.TeamID]...)
 			appStatusResponse, err = apiClient.GetAppStatus(ctx, auth.Token, allApps, auth.TeamID)
 		} else {
-			appStatusResponse, err = apiClient.GetAppStatus(ctx, auth.Token, appIdsByTeamId[auth.TeamID], auth.TeamID)
+			appStatusResponse, err = apiClient.GetAppStatus(ctx, auth.Token, appIDsByTeamID[auth.TeamID], auth.TeamID)
 		}
 
 		if err != nil {
-			clients.IO.PrintDebug(ctx, "error fetching installation status for apps %v: %s", appIdsByTeamId[auth.TeamID], err.Error())
+			clients.IO.PrintDebug(ctx, "error fetching installation status for apps %v: %s", appIDsByTeamID[auth.TeamID], err.Error())
 			continue
 		}
 

--- a/internal/pkg/apps/list_test.go
+++ b/internal/pkg/apps/list_test.go
@@ -98,7 +98,7 @@ func TestAppsList_FetchInstallStates_NoAuthsShouldReturnUnknownState(t *testing.
 
 	apps, err := FetchAppInstallStates(ctx, clients, []types.App{team1DeployedApp, team2LocalApp})
 	require.NoError(t, err)
-	clientsMock.ApiInterface.AssertNotCalled(t, "GetAppStatus")
+	clientsMock.APIInterface.AssertNotCalled(t, "GetAppStatus")
 
 	require.Contains(t, apps, team1DeployedApp)
 	require.Contains(t, apps, team2LocalApp)
@@ -121,7 +121,7 @@ func TestAppsList_FetchInstallStates_HasEnterpriseApp_HasEnterpriseAuth(t *testi
 	clients := shared.NewClientFactory(clientsMock.MockClientFactory())
 
 	// Return installed true
-	clientsMock.ApiInterface.On("GetAppStatus", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+	clientsMock.APIInterface.On("GetAppStatus", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 		api.GetAppStatusResult{
 			Apps: []api.AppStatusResultAppInfo{{AppID: team1AppID, Installed: true}},
 		}, nil)
@@ -143,11 +143,11 @@ func TestAppsList_FetchInstallStates_TokenFlag(t *testing.T) {
 	clientsMock.AuthInterface.On("AuthWithToken", mock.Anything, team2Token).
 		Return(authTeam2, nil)
 
-	clientsMock.ApiInterface.On("GetAppStatus", mock.Anything, team1Token, []string{team1DeployedApp.AppID}, team1TeamID).Return(
+	clientsMock.APIInterface.On("GetAppStatus", mock.Anything, team1Token, []string{team1DeployedApp.AppID}, team1TeamID).Return(
 		api.GetAppStatusResult{
 			Apps: []api.AppStatusResultAppInfo{{AppID: team1DeployedApp.AppID, Installed: true}},
 		}, nil)
-	clientsMock.ApiInterface.On("GetAppStatus", mock.Anything, team2Token, []string{team2LocalApp.AppID}, team2TeamID).Return(
+	clientsMock.APIInterface.On("GetAppStatus", mock.Anything, team2Token, []string{team2LocalApp.AppID}, team2TeamID).Return(
 		api.GetAppStatusResult{
 			Apps: []api.AppStatusResultAppInfo{{AppID: team2LocalApp.AppID, Installed: false}},
 		}, nil)
@@ -160,7 +160,7 @@ func TestAppsList_FetchInstallStates_TokenFlag(t *testing.T) {
 	apps, err := FetchAppInstallStates(ctx, clients, []types.App{team1DeployedApp, team2LocalApp})
 	require.NoError(t, err)
 	require.Len(t, apps, 2)
-	clientsMock.ApiInterface.AssertNumberOfCalls(t, "GetAppStatus", 2)
+	clientsMock.APIInterface.AssertNumberOfCalls(t, "GetAppStatus", 2)
 
 	for _, app := range apps {
 		switch app.AppID {

--- a/internal/pkg/apps/list_test.go
+++ b/internal/pkg/apps/list_test.go
@@ -178,7 +178,7 @@ func TestAppsList_FetchInstallStates_InvalidTokenFlag(t *testing.T) {
 	clientsMock.AuthInterface.On("Auths", mock.Anything).
 		Return([]types.SlackAuth{}, nil)
 	clientsMock.AuthInterface.On("AuthWithToken", mock.Anything, mock.Anything).
-		Return(types.SlackAuth{}, slackerror.New(slackerror.ErrHttpRequestFailed))
+		Return(types.SlackAuth{}, slackerror.New(slackerror.ErrHTTPRequestFailed))
 	clientsMock.AddDefaultMocks()
 	clients := shared.NewClientFactory(clientsMock.MockClientFactory())
 
@@ -186,7 +186,7 @@ func TestAppsList_FetchInstallStates_InvalidTokenFlag(t *testing.T) {
 
 	apps, err := FetchAppInstallStates(ctx, clients, []types.App{team1DeployedApp, team2LocalApp})
 	if assert.Error(t, err) {
-		assert.Equal(t, slackerror.New(slackerror.ErrHttpRequestFailed), err)
+		assert.Equal(t, slackerror.New(slackerror.ErrHTTPRequestFailed), err)
 	}
 	assert.Equal(t, []types.App{}, apps)
 }

--- a/internal/pkg/apps/uninstall.go
+++ b/internal/pkg/apps/uninstall.go
@@ -56,7 +56,7 @@ func Uninstall(ctx context.Context, clients *shared.ClientFactory, log *logger.L
 
 	// Uninstall the app
 	log.Info("on_apps_uninstall_app_init")
-	err = clients.ApiInterface().UninstallApp(ctx, token, app.AppID, app.TeamID)
+	err = clients.APIInterface().UninstallApp(ctx, token, app.AppID, app.TeamID)
 	if err != nil {
 		return app, err
 	}

--- a/internal/pkg/create/create.go
+++ b/internal/pkg/create/create.go
@@ -139,8 +139,8 @@ func Create(ctx context.Context, clients *shared.ClientFactory, log *logger.Logg
 	}
 
 	// Install project dependencies to add CLI support and cache dev dependencies.
-	// CLI created projects always default to config.MANIFEST_SOURCE_LOCAL.
-	InstallProjectDependencies(ctx, clients, projectDirPath, config.MANIFEST_SOURCE_LOCAL)
+	// CLI created projects always default to config.ManifestSourceLocal.
+	InstallProjectDependencies(ctx, clients, projectDirPath, config.ManifestSourceLocal)
 	clients.IO.PrintTrace(ctx, slacktrace.CreateDependenciesSuccess)
 
 	// Notify listeners that app directory is created
@@ -225,11 +225,11 @@ func createApp(ctx context.Context, dirPath string, template Template, gitBranch
 	if template.isGit {
 		doctorSection, err := doctor.CheckGit(ctx)
 		if doctorSection.HasError() || err != nil {
-			zipFileUrl := generateGitZipFileUrl(template.path, gitBranch)
-			if zipFileUrl == "" {
+			zipFileURL := generateGitZipFileURL(template.path, gitBranch)
+			if zipFileURL == "" {
 				return slackerror.New(slackerror.ErrGitZipDownload)
 			}
-			resp, err := http.Get(zipFileUrl)
+			resp, err := http.Get(zipFileURL)
 			if err != nil {
 				return slackerror.New(slackerror.ErrGitZipDownload)
 			}
@@ -343,7 +343,7 @@ func createApp(ctx context.Context, dirPath string, template Template, gitBranch
 
 // InstallProjectDependencies installs the project runtime dependencies or
 // continues with next steps if that fails. You can specify the manifestSource
-// for the project configuration file (default: MANIFEST_SOURCE_LOCAL)
+// for the project configuration file (default: ManifestSourceLocal)
 func InstallProjectDependencies(
 	ctx context.Context,
 	clients *shared.ClientFactory,
@@ -459,7 +459,7 @@ func InstallProjectDependencies(
 
 	// Set "manifest.source" in .slack/config.json
 	if !manifestSource.Exists() {
-		manifestSource = config.MANIFEST_SOURCE_LOCAL
+		manifestSource = config.ManifestSourceLocal
 	}
 
 	if err := clients.Config.ProjectConfig.SetManifestSource(ctx, manifestSource); err != nil {
@@ -510,23 +510,23 @@ func InstallProjectDependencies(
 	return outputs
 }
 
-// generateGitZipFileUrl will return template's GitHub zip file download link
+// generateGitZipFileURL will return template's GitHub zip file download link
 // In the future, this function can be extended to support other Git hosts, such as GitLab.
 // TODO, @cchensh, we should get prepared for other non-Git hosts and refactor the create pkg
-func generateGitZipFileUrl(templateURL string, gitBranch string) string {
-	zipUrl := strings.Replace(templateURL, ".git", "", -1) + "/archive/refs/heads/"
+func generateGitZipFileURL(templateURL string, gitBranch string) string {
+	zipURL := strings.Replace(templateURL, ".git", "", -1) + "/archive/refs/heads/"
 
 	if gitBranch == "" {
-		mainUrl := zipUrl + "main.zip"
-		masterUrl := zipUrl + "master.zip"
-		zipUrl = deputil.UrlChecker(mainUrl)
-		if zipUrl == "" {
-			zipUrl = deputil.UrlChecker(masterUrl)
+		mainURL := zipURL + "main.zip"
+		masterURL := zipURL + "master.zip"
+		zipURL = deputil.URLChecker(mainURL)
+		if zipURL == "" {
+			zipURL = deputil.URLChecker(masterURL)
 		}
 	} else {
-		zipUrl = zipUrl + gitBranch + ".zip"
+		zipURL = zipURL + gitBranch + ".zip"
 	}
-	return zipUrl
+	return zipURL
 }
 
 func createGitArgs(templatePath string, dirPath string, gitBranch string) []string {

--- a/internal/pkg/create/create_test.go
+++ b/internal/pkg/create/create_test.go
@@ -74,18 +74,18 @@ func TestGetAvailableDirectory(t *testing.T) {
 	assert.Nil(t, err, "should not return an error")
 }
 
-func Test_generateGitZipFileUrl(t *testing.T) {
-	url := generateGitZipFileUrl("https://github.com/slack-samples/deno-starter-template", "pre-release-0316")
+func Test_generateGitZipFileURL(t *testing.T) {
+	url := generateGitZipFileURL("https://github.com/slack-samples/deno-starter-template", "pre-release-0316")
 	assert.Equal(t, "https://github.com/slack-samples/deno-starter-template/archive/refs/heads/pre-release-0316.zip", url, "should return zip download link with branch")
 
-	url = generateGitZipFileUrl("https://github.com/slack-samples/deno-starter-template", "")
+	url = generateGitZipFileURL("https://github.com/slack-samples/deno-starter-template", "")
 	assert.Equal(t, "https://github.com/slack-samples/deno-starter-template/archive/refs/heads/main.zip", url, "should return zip download link with main")
 
-	// TODO - We should mock the `deputil.UrlChecker` HTTP request so that the unit test is not dependent on the network activity and repo configuration
-	url = generateGitZipFileUrl("https://github.com/google/uuid", "")
+	// TODO - We should mock the `deputil.URLChecker` HTTP request so that the unit test is not dependent on the network activity and repo configuration
+	url = generateGitZipFileURL("https://github.com/google/uuid", "")
 	assert.Equal(t, "https://github.com/google/uuid/archive/refs/heads/master.zip", url, "should return zip download link with 'master' when 'main' branch doesn't exist")
 
-	url = generateGitZipFileUrl("fake_url", "")
+	url = generateGitZipFileURL("fake_url", "")
 	assert.Equal(t, "", url, "should return empty string when url is invalid")
 }
 
@@ -203,7 +203,7 @@ func Test_Create_installProjectDependencies(t *testing.T) {
 		},
 		"When manifest source is provided, should set it": {
 			experiments:    []string{"bolt"},
-			manifestSource: config.MANIFEST_SOURCE_REMOTE,
+			manifestSource: config.ManifestSourceRemote,
 			expectedOutputs: []string{
 				"Updated config.json manifest source to remote",
 			},

--- a/internal/pkg/create/sample.go
+++ b/internal/pkg/create/sample.go
@@ -93,7 +93,7 @@ func getSampleReposFromGitHub(client Sampler) ([]GithubRepo, error) {
 		return []GithubRepo{}, err
 	}
 	req.Header.Set("Accept", "application/vnd.github+json")
-	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	req.Header.Set("X-GitHub-API-Version", "2022-11-28")
 	res, err := client.Do(req)
 	if err != nil {
 		return []GithubRepo{}, err

--- a/internal/pkg/create/sample.go
+++ b/internal/pkg/create/sample.go
@@ -93,7 +93,7 @@ func getSampleReposFromGitHub(client Sampler) ([]GithubRepo, error) {
 		return []GithubRepo{}, err
 	}
 	req.Header.Set("Accept", "application/vnd.github+json")
-	req.Header.Set("X-GitHub-API-Version", "2022-11-28")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
 	res, err := client.Do(req)
 	if err != nil {
 		return []GithubRepo{}, err

--- a/internal/pkg/create/sample_test.go
+++ b/internal/pkg/create/sample_test.go
@@ -98,7 +98,7 @@ func TestSamples_GetSampleRepos(t *testing.T) {
 			req, err = http.NewRequest("GET", "https://api.github.com/orgs/slack-samples/repos?type=public", nil)
 			require.NoError(t, err)
 			req.Header.Set("Accept", "application/vnd.github+json")
-			req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+			req.Header.Set("X-GitHub-API-Version", "2022-11-28")
 			clientMock.On("Do", req).Return(res, nil)
 
 			result, err := GetSampleRepos(clientMock)

--- a/internal/pkg/create/sample_test.go
+++ b/internal/pkg/create/sample_test.go
@@ -98,7 +98,7 @@ func TestSamples_GetSampleRepos(t *testing.T) {
 			req, err = http.NewRequest("GET", "https://api.github.com/orgs/slack-samples/repos?type=public", nil)
 			require.NoError(t, err)
 			req.Header.Set("Accept", "application/vnd.github+json")
-			req.Header.Set("X-GitHub-API-Version", "2022-11-28")
+			req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
 			clientMock.On("Do", req).Return(res, nil)
 
 			result, err := GetSampleRepos(clientMock)

--- a/internal/pkg/datastore/bulk_delete.go
+++ b/internal/pkg/datastore/bulk_delete.go
@@ -31,7 +31,7 @@ func BulkDelete(ctx context.Context, clients *shared.ClientFactory, log *logger.
 	// Get auth token
 	var token = config.GetContextToken(ctx)
 
-	deleteResult, err := clients.ApiInterface().AppsDatastoreBulkDelete(ctx, token, request)
+	deleteResult, err := clients.APIInterface().AppsDatastoreBulkDelete(ctx, token, request)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/datastore/bulk_delete_test.go
+++ b/internal/pkg/datastore/bulk_delete_test.go
@@ -62,7 +62,7 @@ func TestDatastoreBulkDeleteArguments(t *testing.T) {
 			log := logger.Logger{
 				Data: map[string]interface{}{},
 			}
-			clientsMock.ApiInterface.On("AppsDatastoreBulkDelete", mock.Anything, mock.Anything, tt.Query).
+			clientsMock.APIInterface.On("AppsDatastoreBulkDelete", mock.Anything, mock.Anything, tt.Query).
 				Return(tt.Results, nil)
 			client := shared.NewClientFactory(clientsMock.MockClientFactory())
 

--- a/internal/pkg/datastore/bulk_get.go
+++ b/internal/pkg/datastore/bulk_get.go
@@ -31,7 +31,7 @@ func BulkGet(ctx context.Context, clients *shared.ClientFactory, log *logger.Log
 	// Get auth token
 	var token = config.GetContextToken(ctx)
 
-	getResult, err := clients.ApiInterface().AppsDatastoreBulkGet(ctx, token, request)
+	getResult, err := clients.APIInterface().AppsDatastoreBulkGet(ctx, token, request)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/datastore/bulk_get_test.go
+++ b/internal/pkg/datastore/bulk_get_test.go
@@ -63,7 +63,7 @@ func TestDatastoreBulkGetArguments(t *testing.T) {
 			log := logger.Logger{
 				Data: map[string]interface{}{},
 			}
-			clientsMock.ApiInterface.On("AppsDatastoreBulkGet", mock.Anything, mock.Anything, tt.Query).
+			clientsMock.APIInterface.On("AppsDatastoreBulkGet", mock.Anything, mock.Anything, tt.Query).
 				Return(tt.Results, nil)
 			client := shared.NewClientFactory(clientsMock.MockClientFactory())
 

--- a/internal/pkg/datastore/bulk_put.go
+++ b/internal/pkg/datastore/bulk_put.go
@@ -31,7 +31,7 @@ func BulkPut(ctx context.Context, clients *shared.ClientFactory, log *logger.Log
 	// Get auth token
 	var token = config.GetContextToken(ctx)
 
-	bulkPutResult, err := clients.ApiInterface().AppsDatastoreBulkPut(ctx, token, request)
+	bulkPutResult, err := clients.APIInterface().AppsDatastoreBulkPut(ctx, token, request)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/datastore/bulk_put_test.go
+++ b/internal/pkg/datastore/bulk_put_test.go
@@ -70,7 +70,7 @@ func TestDatastoreBulkPutArguments(t *testing.T) {
 			log := logger.Logger{
 				Data: map[string]interface{}{},
 			}
-			clientsMock.ApiInterface.On("AppsDatastoreBulkPut", mock.Anything, mock.Anything, tt.Query).
+			clientsMock.APIInterface.On("AppsDatastoreBulkPut", mock.Anything, mock.Anything, tt.Query).
 				Return(tt.Results, nil)
 			client := shared.NewClientFactory(clientsMock.MockClientFactory())
 

--- a/internal/pkg/datastore/delete.go
+++ b/internal/pkg/datastore/delete.go
@@ -31,7 +31,7 @@ func Delete(ctx context.Context, clients *shared.ClientFactory, log *logger.Logg
 	// Get auth token
 	var token = config.GetContextToken(ctx)
 
-	deleteResult, err := clients.ApiInterface().AppsDatastoreDelete(ctx, token, request)
+	deleteResult, err := clients.APIInterface().AppsDatastoreDelete(ctx, token, request)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/datastore/delete_test.go
+++ b/internal/pkg/datastore/delete_test.go
@@ -51,7 +51,7 @@ func TestDatastoreDeleteArguments(t *testing.T) {
 			log := logger.Logger{
 				Data: map[string]interface{}{},
 			}
-			clientsMock.ApiInterface.On("AppsDatastoreDelete", mock.Anything, mock.Anything, tt.Query).
+			clientsMock.APIInterface.On("AppsDatastoreDelete", mock.Anything, mock.Anything, tt.Query).
 				Return(tt.Results, nil)
 			client := shared.NewClientFactory(clientsMock.MockClientFactory())
 

--- a/internal/pkg/datastore/get.go
+++ b/internal/pkg/datastore/get.go
@@ -31,7 +31,7 @@ func Get(ctx context.Context, clients *shared.ClientFactory, log *logger.Logger,
 	// Get auth token
 	var token = config.GetContextToken(ctx)
 
-	getResult, err := clients.ApiInterface().AppsDatastoreGet(ctx, token, request)
+	getResult, err := clients.APIInterface().AppsDatastoreGet(ctx, token, request)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/datastore/get_test.go
+++ b/internal/pkg/datastore/get_test.go
@@ -51,7 +51,7 @@ func TestDatastoreGetArguments(t *testing.T) {
 			log := logger.Logger{
 				Data: map[string]interface{}{},
 			}
-			clientsMock.ApiInterface.On("AppsDatastoreGet", mock.Anything, mock.Anything, tt.Query).
+			clientsMock.APIInterface.On("AppsDatastoreGet", mock.Anything, mock.Anything, tt.Query).
 				Return(tt.Results, nil)
 			client := shared.NewClientFactory(clientsMock.MockClientFactory())
 

--- a/internal/pkg/datastore/put.go
+++ b/internal/pkg/datastore/put.go
@@ -31,7 +31,7 @@ func Put(ctx context.Context, clients *shared.ClientFactory, log *logger.Logger,
 	// Get auth token
 	var token = config.GetContextToken(ctx)
 
-	putResult, err := clients.ApiInterface().AppsDatastorePut(ctx, token, request)
+	putResult, err := clients.APIInterface().AppsDatastorePut(ctx, token, request)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/datastore/put_test.go
+++ b/internal/pkg/datastore/put_test.go
@@ -51,7 +51,7 @@ func TestDatastorePutArguments(t *testing.T) {
 			log := logger.Logger{
 				Data: map[string]interface{}{},
 			}
-			clientsMock.ApiInterface.On("AppsDatastorePut", mock.Anything, mock.Anything, tt.Query).
+			clientsMock.APIInterface.On("AppsDatastorePut", mock.Anything, mock.Anything, tt.Query).
 				Return(tt.Results, nil)
 			client := shared.NewClientFactory(clientsMock.MockClientFactory())
 

--- a/internal/pkg/datastore/query.go
+++ b/internal/pkg/datastore/query.go
@@ -31,7 +31,7 @@ func Query(ctx context.Context, clients *shared.ClientFactory, log *logger.Logge
 	// Get auth token
 	var token = config.GetContextToken(ctx)
 
-	queryResult, err := clients.ApiInterface().AppsDatastoreQuery(ctx, token, request)
+	queryResult, err := clients.APIInterface().AppsDatastoreQuery(ctx, token, request)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/datastore/query_test.go
+++ b/internal/pkg/datastore/query_test.go
@@ -109,7 +109,7 @@ func TestDatastoreQueryArguments(t *testing.T) {
 			log := logger.Logger{
 				Data: map[string]interface{}{},
 			}
-			clientsMock.ApiInterface.On("AppsDatastoreQuery", mock.Anything, mock.Anything, tt.Query).
+			clientsMock.APIInterface.On("AppsDatastoreQuery", mock.Anything, mock.Anything, tt.Query).
 				Return(tt.Results, nil)
 			client := shared.NewClientFactory(clientsMock.MockClientFactory())
 

--- a/internal/pkg/datastore/update.go
+++ b/internal/pkg/datastore/update.go
@@ -31,7 +31,7 @@ func Update(ctx context.Context, clients *shared.ClientFactory, log *logger.Logg
 	// Get auth token
 	var token = config.GetContextToken(ctx)
 
-	updateResult, err := clients.ApiInterface().AppsDatastoreUpdate(ctx, token, request)
+	updateResult, err := clients.APIInterface().AppsDatastoreUpdate(ctx, token, request)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/datastore/update_test.go
+++ b/internal/pkg/datastore/update_test.go
@@ -51,7 +51,7 @@ func TestDatastoreUpdateArguments(t *testing.T) {
 			log := logger.Logger{
 				Data: map[string]interface{}{},
 			}
-			clientsMock.ApiInterface.On("AppsDatastoreUpdate", mock.Anything, mock.Anything, tt.Query).
+			clientsMock.APIInterface.On("AppsDatastoreUpdate", mock.Anything, mock.Anything, tt.Query).
 				Return(tt.Results, nil)
 			client := shared.NewClientFactory(clientsMock.MockClientFactory())
 

--- a/internal/pkg/externalauth/prompt_provider_auth_select.go
+++ b/internal/pkg/externalauth/prompt_provider_auth_select.go
@@ -40,7 +40,7 @@ func ProviderAuthSelectPrompt(ctx context.Context, clients *shared.ClientFactory
 				fmt.Sprintf("Key: %s, Name: %s, Selected Account: None", provider.ProviderKey, provider.ProviderName))
 		} else {
 			lastUpdated := time.Unix(int64(selectedAuth.DateUpdated), 0).Format(timeFormat)
-			providerOptions = append(providerOptions, fmt.Sprintf("Key: %s, Name: %s, Selected Account: %s, Last Updated: %s", provider.ProviderKey, provider.ProviderName, selectedAuth.ExternalUserId, lastUpdated))
+			providerOptions = append(providerOptions, fmt.Sprintf("Key: %s, Name: %s, Selected Account: %s, Last Updated: %s", provider.ProviderKey, provider.ProviderName, selectedAuth.ExternalUserID, lastUpdated))
 		}
 	}
 	if len(providerOptions) == 0 {

--- a/internal/pkg/externalauth/prompt_provider_auth_select.go
+++ b/internal/pkg/externalauth/prompt_provider_auth_select.go
@@ -35,7 +35,7 @@ func ProviderAuthSelectPrompt(ctx context.Context, clients *shared.ClientFactory
 	for _, provider := range providers {
 		providerMap[provider.ProviderKey] = provider
 		selectedAuth := provider.SelectedAuth
-		if selectedAuth.ExternalTokenId == "" {
+		if selectedAuth.ExternalTokenID == "" {
 			providerOptions = append(providerOptions,
 				fmt.Sprintf("Key: %s, Name: %s, Selected Account: None", provider.ProviderKey, provider.ProviderName))
 		} else {

--- a/internal/pkg/externalauth/prompt_provider_auth_select_test.go
+++ b/internal/pkg/externalauth/prompt_provider_auth_select_test.go
@@ -40,8 +40,8 @@ func TestPrompt_ProviderAuthSelectPrompt_empty_list(t *testing.T) {
 
 func TestPrompt_ProviderAuthSelectPrompt_no_selected_auth(t *testing.T) {
 	workflowsInfo := types.WorkflowsInfo{
-		WorkflowId: "Wf0548LABCD1",
-		CallBackId: "my_callback_id1",
+		WorkflowID: "Wf0548LABCD1",
+		CallBackID: "my_callback_id1",
 		Providers: []types.ProvidersInfo{
 			{
 				ProviderKey:  "provider_a",
@@ -52,7 +52,7 @@ func TestPrompt_ProviderAuthSelectPrompt_no_selected_auth(t *testing.T) {
 				ProviderName: "Provider_B",
 				SelectedAuth: types.ExternalTokenInfo{
 					ExternalTokenID: "Et0548LABCDE",
-					ExternalUserId:  "user_a@example.com",
+					ExternalUserID:  "user_a@example.com",
 					DateUpdated:     1682021142,
 				},
 			},
@@ -107,8 +107,8 @@ func TestPrompt_ProviderAuthSelectPrompt_no_selected_auth(t *testing.T) {
 
 func TestPrompt_ProviderAuthSelectPrompt_with_selected_auth(t *testing.T) {
 	workflowsInfo := types.WorkflowsInfo{
-		WorkflowId: "Wf0548LABCD1",
-		CallBackId: "my_callback_id1",
+		WorkflowID: "Wf0548LABCD1",
+		CallBackID: "my_callback_id1",
 		Providers: []types.ProvidersInfo{
 			{
 				ProviderKey:  "provider_a",
@@ -119,7 +119,7 @@ func TestPrompt_ProviderAuthSelectPrompt_with_selected_auth(t *testing.T) {
 				ProviderName: "Provider_B",
 				SelectedAuth: types.ExternalTokenInfo{
 					ExternalTokenID: "Et0548LABCDE",
-					ExternalUserId:  "user_a@example.com",
+					ExternalUserID:  "user_a@example.com",
 					DateUpdated:     1682021142,
 				},
 			},

--- a/internal/pkg/externalauth/prompt_provider_auth_select_test.go
+++ b/internal/pkg/externalauth/prompt_provider_auth_select_test.go
@@ -51,7 +51,7 @@ func TestPrompt_ProviderAuthSelectPrompt_no_selected_auth(t *testing.T) {
 				ProviderKey:  "provider_b",
 				ProviderName: "Provider_B",
 				SelectedAuth: types.ExternalTokenInfo{
-					ExternalTokenId: "Et0548LABCDE",
+					ExternalTokenID: "Et0548LABCDE",
 					ExternalUserId:  "user_a@example.com",
 					DateUpdated:     1682021142,
 				},
@@ -118,7 +118,7 @@ func TestPrompt_ProviderAuthSelectPrompt_with_selected_auth(t *testing.T) {
 				ProviderKey:  "provider_b",
 				ProviderName: "Provider_B",
 				SelectedAuth: types.ExternalTokenInfo{
-					ExternalTokenId: "Et0548LABCDE",
+					ExternalTokenID: "Et0548LABCDE",
 					ExternalUserId:  "user_a@example.com",
 					DateUpdated:     1682021142,
 				},

--- a/internal/pkg/externalauth/prompt_provider_select.go
+++ b/internal/pkg/externalauth/prompt_provider_select.go
@@ -43,9 +43,9 @@ func ProviderSelectPrompt(ctx context.Context, clients *shared.ClientFactory, pr
 		if len(externalTokens) > 0 {
 			externalAccountsList := []string{}
 			for _, externalToken := range externalTokens {
-				externalAccountsList = append(externalAccountsList, externalToken.ExternalUserId)
+				externalAccountsList = append(externalAccountsList, externalToken.ExternalUserID)
 			}
-			providerOptions = append(providerOptions, fmt.Sprintf("Provider Key: %s\n  Provider Name: %s\n  Client ID: %s\n  Client Secret Exists? %s\n  Valid Tokens: %s\n", provider.ProviderKey, provider.ProviderName, provider.ClientId, secretExists, strings.Join(externalAccountsList, ", ")))
+			providerOptions = append(providerOptions, fmt.Sprintf("Provider Key: %s\n  Provider Name: %s\n  Client ID: %s\n  Client Secret Exists? %s\n  Valid Tokens: %s\n", provider.ProviderKey, provider.ProviderName, provider.ClientID, secretExists, strings.Join(externalAccountsList, ", ")))
 		} else {
 			var externalTokenExists string
 			if provider.ValidTokenExists {
@@ -53,7 +53,7 @@ func ProviderSelectPrompt(ctx context.Context, clients *shared.ClientFactory, pr
 			} else {
 				externalTokenExists = "No"
 			}
-			providerOptions = append(providerOptions, fmt.Sprintf("Provider Key: %s\n  Provider Name: %s\n  Client ID: %s\n  Client Secret Exists? %s\n  Valid Token Exists? %s\n", provider.ProviderKey, provider.ProviderName, provider.ClientId, secretExists, externalTokenExists))
+			providerOptions = append(providerOptions, fmt.Sprintf("Provider Key: %s\n  Provider Name: %s\n  Client ID: %s\n  Client Secret Exists? %s\n  Valid Token Exists? %s\n", provider.ProviderKey, provider.ProviderName, provider.ClientID, secretExists, externalTokenExists))
 		}
 	}
 	if len(providerOptions) == 0 {

--- a/internal/pkg/externalauth/prompt_provider_select_test.go
+++ b/internal/pkg/externalauth/prompt_provider_select_test.go
@@ -100,10 +100,10 @@ func TestPrompt_ProviderSelectPrompt_with_token(t *testing.T) {
 				ClientId:           "xxxxx",
 				ClientSecretExists: true,
 				ValidTokenExists:   true,
-				ExternalTokenIds:   []string{"Et0548LYDWCT"},
+				ExternalTokenIDs:   []string{"Et0548LYDWCT"},
 				ExternalTokens: []types.ExternalTokenInfo{
 					{
-						ExternalTokenId: "Et0548LABCDE",
+						ExternalTokenID: "Et0548LABCDE",
 						ExternalUserId:  "xyz@salesforce.com",
 						DateUpdated:     1682021142,
 					},

--- a/internal/pkg/externalauth/prompt_provider_select_test.go
+++ b/internal/pkg/externalauth/prompt_provider_select_test.go
@@ -43,7 +43,7 @@ func TestPrompt_ProviderSelectPrompt_no_token(t *testing.T) {
 			{
 				ProviderName:       "Google",
 				ProviderKey:        "provider_a",
-				ClientId:           "xxxxx",
+				ClientID:           "xxxxx",
 				ClientSecretExists: true,
 				ValidTokenExists:   false,
 			},
@@ -97,14 +97,14 @@ func TestPrompt_ProviderSelectPrompt_with_token(t *testing.T) {
 			{
 				ProviderName:       "Google",
 				ProviderKey:        "provider_a",
-				ClientId:           "xxxxx",
+				ClientID:           "xxxxx",
 				ClientSecretExists: true,
 				ValidTokenExists:   true,
 				ExternalTokenIDs:   []string{"Et0548LYDWCT"},
 				ExternalTokens: []types.ExternalTokenInfo{
 					{
 						ExternalTokenID: "Et0548LABCDE",
-						ExternalUserId:  "xyz@salesforce.com",
+						ExternalUserID:  "xyz@salesforce.com",
 						DateUpdated:     1682021142,
 					},
 				},

--- a/internal/pkg/externalauth/prompt_token_select.go
+++ b/internal/pkg/externalauth/prompt_token_select.go
@@ -33,9 +33,9 @@ func TokenSelectPrompt(ctx context.Context, clients *shared.ClientFactory, selec
 	var externalTokenMap = make(map[string]types.ExternalTokenInfo)
 	var selectedExternalToken types.ExternalTokenInfo
 	for _, externalToken := range selectedProviderAuth.ExternalTokens {
-		externalTokenMap[externalToken.ExternalUserId] = externalToken
+		externalTokenMap[externalToken.ExternalUserID] = externalToken
 		lastUpdated := time.Unix(int64(externalToken.DateUpdated), 0).Format(timeFormat)
-		externalTokenOptions = append(externalTokenOptions, fmt.Sprintf("Account: %s, Last Updated: %s", externalToken.ExternalUserId, lastUpdated))
+		externalTokenOptions = append(externalTokenOptions, fmt.Sprintf("Account: %s, Last Updated: %s", externalToken.ExternalUserID, lastUpdated))
 	}
 	if len(externalTokenOptions) == 0 {
 		return types.ExternalTokenInfo{}, slackerror.New("No connected accounts found").WithRemediation("A token can be added to this app by running %s", style.Commandf("external-auth add", true))

--- a/internal/pkg/externalauth/prompt_token_select_test.go
+++ b/internal/pkg/externalauth/prompt_token_select_test.go
@@ -43,19 +43,19 @@ func TestPrompt_TokenSelectPrompt_with_token(t *testing.T) {
 	authorizationInfo := types.ExternalAuthorizationInfo{
 		ProviderName:       "Google",
 		ProviderKey:        "provider_a",
-		ClientId:           "xxxxx",
+		ClientID:           "xxxxx",
 		ClientSecretExists: true,
 		ValidTokenExists:   true,
 		ExternalTokenIDs:   []string{"Et0548LYDWCT"},
 		ExternalTokens: []types.ExternalTokenInfo{
 			{
 				ExternalTokenID: "Et0548LABCD1",
-				ExternalUserId:  "xyz@salesforce.com",
+				ExternalUserID:  "xyz@salesforce.com",
 				DateUpdated:     1682021142,
 			},
 			{
 				ExternalTokenID: "Et0548LABCDE2",
-				ExternalUserId:  "xyz2@salesforce.com",
+				ExternalUserID:  "xyz2@salesforce.com",
 				DateUpdated:     1682021192,
 			},
 		},
@@ -99,7 +99,7 @@ func TestPrompt_TokenSelectPrompt_with_token(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, selectedToken, types.ExternalTokenInfo{
 			ExternalTokenID: "Et0548LABCDE2",
-			ExternalUserId:  "xyz2@salesforce.com",
+			ExternalUserID:  "xyz2@salesforce.com",
 			DateUpdated:     1682021192,
 		})
 		clientsMock.IO.AssertCalled(t, "SelectPrompt", mock.Anything, "Select an external account", mock.Anything, mock.Anything)

--- a/internal/pkg/externalauth/prompt_token_select_test.go
+++ b/internal/pkg/externalauth/prompt_token_select_test.go
@@ -46,15 +46,15 @@ func TestPrompt_TokenSelectPrompt_with_token(t *testing.T) {
 		ClientId:           "xxxxx",
 		ClientSecretExists: true,
 		ValidTokenExists:   true,
-		ExternalTokenIds:   []string{"Et0548LYDWCT"},
+		ExternalTokenIDs:   []string{"Et0548LYDWCT"},
 		ExternalTokens: []types.ExternalTokenInfo{
 			{
-				ExternalTokenId: "Et0548LABCD1",
+				ExternalTokenID: "Et0548LABCD1",
 				ExternalUserId:  "xyz@salesforce.com",
 				DateUpdated:     1682021142,
 			},
 			{
-				ExternalTokenId: "Et0548LABCDE2",
+				ExternalTokenID: "Et0548LABCDE2",
 				ExternalUserId:  "xyz2@salesforce.com",
 				DateUpdated:     1682021192,
 			},
@@ -98,7 +98,7 @@ func TestPrompt_TokenSelectPrompt_with_token(t *testing.T) {
 		selectedToken, err := TokenSelectPrompt(ctx, clients, authorizationInfo)
 		require.NoError(t, err)
 		require.Equal(t, selectedToken, types.ExternalTokenInfo{
-			ExternalTokenId: "Et0548LABCDE2",
+			ExternalTokenID: "Et0548LABCDE2",
 			ExternalUserId:  "xyz2@salesforce.com",
 			DateUpdated:     1682021192,
 		})

--- a/internal/pkg/externalauth/prompt_workflow_select.go
+++ b/internal/pkg/externalauth/prompt_workflow_select.go
@@ -32,18 +32,18 @@ func WorkflowSelectPrompt(ctx context.Context, clients *shared.ClientFactory, pr
 	var workflowOptions = []string{}
 	var selectedWorkflow types.WorkflowsInfo
 	for _, workflow := range workflows {
-		workflowMap[workflow.CallBackId] = workflow
+		workflowMap[workflow.CallBackID] = workflow
 		providers := workflow.Providers
 		var providerList strings.Builder
 		for _, provider := range providers {
-			var selectedExternalAccountId = "None"
+			var selectedExternalAccountID = "None"
 			selectedAuth := provider.SelectedAuth
 			if selectedAuth.ExternalTokenID != "" {
-				selectedExternalAccountId = selectedAuth.ExternalUserId
+				selectedExternalAccountID = selectedAuth.ExternalUserID
 			}
-			fmt.Fprintf(&providerList, "\tKey: %s, Name: %s, Selected Account: %s\n", provider.ProviderKey, provider.ProviderName, selectedExternalAccountId)
+			fmt.Fprintf(&providerList, "\tKey: %s, Name: %s, Selected Account: %s\n", provider.ProviderKey, provider.ProviderName, selectedExternalAccountID)
 		}
-		optionText := fmt.Sprintf("Workflow: %s\n  Providers:\n %s", workflowCallbackPrefix+workflow.CallBackId, providerList.String())
+		optionText := fmt.Sprintf("Workflow: %s\n  Providers:\n %s", workflowCallbackPrefix+workflow.CallBackID, providerList.String())
 		workflowOptions = append(workflowOptions, optionText)
 	}
 	selection, err := clients.IO.SelectPrompt(ctx, "Select a workflow", workflowOptions, iostreams.SelectPromptConfig{
@@ -53,8 +53,8 @@ func WorkflowSelectPrompt(ctx context.Context, clients *shared.ClientFactory, pr
 	if err != nil {
 		return types.WorkflowsInfo{}, err
 	} else if selection.Flag {
-		callbackId := strings.TrimPrefix(selection.Option, workflowCallbackPrefix)
-		selectedWorkflow = workflowMap[callbackId]
+		callbackID := strings.TrimPrefix(selection.Option, workflowCallbackPrefix)
+		selectedWorkflow = workflowMap[callbackID]
 	} else if selection.Prompt {
 		selectedWorkflow = workflows[selection.Index]
 	}

--- a/internal/pkg/externalauth/prompt_workflow_select.go
+++ b/internal/pkg/externalauth/prompt_workflow_select.go
@@ -38,7 +38,7 @@ func WorkflowSelectPrompt(ctx context.Context, clients *shared.ClientFactory, pr
 		for _, provider := range providers {
 			var selectedExternalAccountId = "None"
 			selectedAuth := provider.SelectedAuth
-			if selectedAuth.ExternalTokenId != "" {
+			if selectedAuth.ExternalTokenID != "" {
 				selectedExternalAccountId = selectedAuth.ExternalUserId
 			}
 			fmt.Fprintf(&providerList, "\tKey: %s, Name: %s, Selected Account: %s\n", provider.ProviderKey, provider.ProviderName, selectedExternalAccountId)

--- a/internal/pkg/externalauth/prompt_workflow_select_test.go
+++ b/internal/pkg/externalauth/prompt_workflow_select_test.go
@@ -93,7 +93,7 @@ func TestPrompt_WorkflowSelectPrompt_with_workflows(t *testing.T) {
 						ProviderKey:  "provider_b",
 						ProviderName: "Provider_B",
 						SelectedAuth: types.ExternalTokenInfo{
-							ExternalTokenId: "Et0548LABCDE",
+							ExternalTokenID: "Et0548LABCDE",
 							ExternalUserId:  "user_a@gmail.com",
 							DateUpdated:     1682021142,
 						},
@@ -112,7 +112,7 @@ func TestPrompt_WorkflowSelectPrompt_with_workflows(t *testing.T) {
 						ProviderKey:  "provider_b",
 						ProviderName: "Provider_B",
 						SelectedAuth: types.ExternalTokenInfo{
-							ExternalTokenId: "Et0548LABCDE",
+							ExternalTokenID: "Et0548LABCDE",
 							ExternalUserId:  "user_a@gmail.com",
 							DateUpdated:     1682021142,
 						},
@@ -170,7 +170,7 @@ func TestPrompt_WorkflowSelectPrompt_with_workflows(t *testing.T) {
 					ProviderKey:  "provider_b",
 					ProviderName: "Provider_B",
 					SelectedAuth: types.ExternalTokenInfo{
-						ExternalTokenId: "Et0548LABCDE",
+						ExternalTokenID: "Et0548LABCDE",
 						ExternalUserId:  "user_a@gmail.com",
 						DateUpdated:     1682021142,
 					},

--- a/internal/pkg/externalauth/prompt_workflow_select_test.go
+++ b/internal/pkg/externalauth/prompt_workflow_select_test.go
@@ -49,7 +49,7 @@ func TestPrompt_WorkflowSelectPrompt_with_no_workflows(t *testing.T) {
 			{
 				ProviderName:       "Google",
 				ProviderKey:        "provider_a",
-				ClientId:           "xxxxx",
+				ClientID:           "xxxxx",
 				ClientSecretExists: true,
 				ValidTokenExists:   false,
 			},
@@ -75,15 +75,15 @@ func TestPrompt_WorkflowSelectPrompt_with_workflows(t *testing.T) {
 			{
 				ProviderName:       "Google",
 				ProviderKey:        "provider_a",
-				ClientId:           "xxxxx",
+				ClientID:           "xxxxx",
 				ClientSecretExists: true,
 				ValidTokenExists:   false,
 			},
 		},
 		Workflows: []types.WorkflowsInfo{
 			{
-				WorkflowId: "Wf0548LABCD1",
-				CallBackId: "my_callback_id1",
+				WorkflowID: "Wf0548LABCD1",
+				CallBackID: "my_callback_id1",
 				Providers: []types.ProvidersInfo{
 					{
 						ProviderKey:  "provider_a",
@@ -94,15 +94,15 @@ func TestPrompt_WorkflowSelectPrompt_with_workflows(t *testing.T) {
 						ProviderName: "Provider_B",
 						SelectedAuth: types.ExternalTokenInfo{
 							ExternalTokenID: "Et0548LABCDE",
-							ExternalUserId:  "user_a@gmail.com",
+							ExternalUserID:  "user_a@gmail.com",
 							DateUpdated:     1682021142,
 						},
 					},
 				},
 			},
 			{
-				WorkflowId: "Wf0548LABCD2",
-				CallBackId: "my_callback_id2",
+				WorkflowID: "Wf0548LABCD2",
+				CallBackID: "my_callback_id2",
 				Providers: []types.ProvidersInfo{
 					{
 						ProviderKey:  "provider_a",
@@ -113,7 +113,7 @@ func TestPrompt_WorkflowSelectPrompt_with_workflows(t *testing.T) {
 						ProviderName: "Provider_B",
 						SelectedAuth: types.ExternalTokenInfo{
 							ExternalTokenID: "Et0548LABCDE",
-							ExternalUserId:  "user_a@gmail.com",
+							ExternalUserID:  "user_a@gmail.com",
 							DateUpdated:     1682021142,
 						},
 					},
@@ -159,8 +159,8 @@ func TestPrompt_WorkflowSelectPrompt_with_workflows(t *testing.T) {
 		selectedWorkflow, err := WorkflowSelectPrompt(ctx, clients, authorizationInfoLists)
 		require.NoError(t, err)
 		require.Equal(t, selectedWorkflow, types.WorkflowsInfo{
-			WorkflowId: "Wf0548LABCD2",
-			CallBackId: "my_callback_id2",
+			WorkflowID: "Wf0548LABCD2",
+			CallBackID: "my_callback_id2",
 			Providers: []types.ProvidersInfo{
 				{
 					ProviderKey:  "provider_a",
@@ -171,7 +171,7 @@ func TestPrompt_WorkflowSelectPrompt_with_workflows(t *testing.T) {
 					ProviderName: "Provider_B",
 					SelectedAuth: types.ExternalTokenInfo{
 						ExternalTokenID: "Et0548LABCDE",
-						ExternalUserId:  "user_a@gmail.com",
+						ExternalUserID:  "user_a@gmail.com",
 						DateUpdated:     1682021142,
 					},
 				},

--- a/internal/pkg/manifest/validate.go
+++ b/internal/pkg/manifest/validate.go
@@ -40,7 +40,7 @@ func ManifestValidate(ctx context.Context, clients *shared.ClientFactory, log *l
 		return nil, nil, slackerror.New(slackerror.ErrAuthToken)
 	}
 
-	_, err := clients.ApiInterface().ValidateSession(ctx, token)
+	_, err := clients.APIInterface().ValidateSession(ctx, token)
 	if err != nil {
 		return nil, nil, slackerror.New(slackerror.ErrAuthToken).WithRootCause(err)
 	}
@@ -51,10 +51,10 @@ func ManifestValidate(ctx context.Context, clients *shared.ClientFactory, log *l
 	}
 
 	// validate the manifest
-	validationResult, err := clients.ApiInterface().ValidateAppManifest(ctx, token, slackManifest.AppManifest, app.AppID)
+	validationResult, err := clients.APIInterface().ValidateAppManifest(ctx, token, slackManifest.AppManifest, app.AppID)
 
 	if retryValidate := HandleConnectorNotInstalled(ctx, clients, token, err); retryValidate {
-		validationResult, err = clients.ApiInterface().ValidateAppManifest(ctx, token, slackManifest.AppManifest, app.AppID)
+		validationResult, err = clients.APIInterface().ValidateAppManifest(ctx, token, slackManifest.AppManifest, app.AppID)
 	}
 
 	if err := HandleConnectorApprovalRequired(ctx, clients, token, err); err != nil {
@@ -82,7 +82,7 @@ func HandleConnectorNotInstalled(ctx context.Context, clients *shared.ClientFact
 		if detail.Code == slackerror.ErrConnectorNotInstalled {
 			attemptInstall = true
 			clients.IO.PrintDebug(ctx, "Attempting to install connector app: %s", detail.RelatedComponent)
-			_, err := clients.ApiInterface().CertifiedAppInstall(ctx, token, detail.RelatedComponent)
+			_, err := clients.APIInterface().CertifiedAppInstall(ctx, token, detail.RelatedComponent)
 			if err != nil {
 				clients.IO.PrintDebug(ctx, "Error installing connector app: %s", detail.RelatedComponent)
 			}
@@ -155,7 +155,7 @@ func attemptConnectorAppsApprovalRequests(ctx context.Context, clients *shared.C
 
 	for _, errorDetail := range approvalRequiredErrorDetails {
 		// Passing in an empty string for team_id here, meaning connectors will be requested at the org level
-		_, err := clients.ApiInterface().RequestAppApproval(ctx, token, errorDetail.RelatedComponent, "", reason, "", []string{})
+		_, err := clients.APIInterface().RequestAppApproval(ctx, token, errorDetail.RelatedComponent, "", reason, "", []string{})
 		if err != nil {
 			clients.IO.PrintDebug(ctx, "Error requesting approval for %s", errorDetail.RelatedComponent)
 			return err

--- a/internal/pkg/manifest/validate_test.go
+++ b/internal/pkg/manifest/validate_test.go
@@ -51,7 +51,7 @@ func Test_ManifestValidate_Success(t *testing.T) {
 		ctx, clients, clientsMock, log, appMock, authMock := setupCommonMocks(t)
 
 		// Mock manifest validation api result with no error
-		clientsMock.ApiInterface.On("ValidateAppManifest", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.ValidateAppManifestResult{}, nil)
+		clientsMock.APIInterface.On("ValidateAppManifest", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.ValidateAppManifestResult{}, nil)
 
 		// Test
 		logEvent, _, err := ManifestValidate(ctx, clients, log, appMock, authMock.Token)
@@ -67,7 +67,7 @@ func Test_ManifestValidate_Warnings(t *testing.T) {
 		ctx, clients, clientsMock, log, appMock, authMock := setupCommonMocks(t)
 
 		// Mock manifest validation api result with no error
-		clientsMock.ApiInterface.On("ValidateAppManifest", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.ValidateAppManifestResult{
+		clientsMock.APIInterface.On("ValidateAppManifest", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.ValidateAppManifestResult{
 			Warnings: slackerror.Warnings{
 				slackerror.Warning{
 					Code: "dummy warning",
@@ -91,7 +91,7 @@ func Test_ManifestValidate_Error(t *testing.T) {
 		ctx, clients, clientsMock, log, appMock, authMock := setupCommonMocks(t)
 
 		// Mock manifest validation api result with an error
-		clientsMock.ApiInterface.On("ValidateAppManifest", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+		clientsMock.APIInterface.On("ValidateAppManifest", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 			api.ValidateAppManifestResult{},
 			slackerror.New("a dummy error").WithDetails(slackerror.ErrorDetails{
 				slackerror.ErrorDetail{
@@ -112,7 +112,7 @@ func Test_ManifestValidate_Error_ErrConnectorNotInstalled(t *testing.T) {
 		ctx, clients, clientsMock, log, appMock, authMock := setupCommonMocks(t)
 
 		// Mock manifest validation api result with an error and error details
-		clientsMock.ApiInterface.On("ValidateAppManifest", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.ValidateAppManifestResult{
+		clientsMock.APIInterface.On("ValidateAppManifest", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.ValidateAppManifestResult{
 			Warnings: nil,
 		}, slackerror.New("a dummy error").WithDetails(slackerror.ErrorDetails{
 			slackerror.ErrorDetail{
@@ -130,7 +130,7 @@ func Test_ManifestValidate_Error_ErrConnectorNotInstalled(t *testing.T) {
 		}))
 
 		// Mock CertifiedAppInstall method success
-		clientsMock.ApiInterface.On("CertifiedAppInstall", mock.Anything, authMock.Token, mock.Anything).Return(api.CertifiedInstallResult{}, nil)
+		clientsMock.APIInterface.On("CertifiedAppInstall", mock.Anything, authMock.Token, mock.Anything).Return(api.CertifiedInstallResult{}, nil)
 
 		// Test
 		_, _, err := ManifestValidate(ctx, clients, log, appMock, authMock.Token)
@@ -140,16 +140,16 @@ func Test_ManifestValidate_Error_ErrConnectorNotInstalled(t *testing.T) {
 		// even after successful CertifiedAppInstall call.
 		assert.Error(t, err)
 
-		clientsMock.ApiInterface.AssertCalled(t, "CertifiedAppInstall", mock.Anything, authMock.Token, "A12345")
-		clientsMock.ApiInterface.AssertCalled(t, "CertifiedAppInstall", mock.Anything, authMock.Token, "A56789")
-		clientsMock.ApiInterface.AssertNumberOfCalls(t, "CertifiedAppInstall", 2)
-		clientsMock.ApiInterface.AssertNumberOfCalls(t, "ValidateAppManifest", 2)
+		clientsMock.APIInterface.AssertCalled(t, "CertifiedAppInstall", mock.Anything, authMock.Token, "A12345")
+		clientsMock.APIInterface.AssertCalled(t, "CertifiedAppInstall", mock.Anything, authMock.Token, "A56789")
+		clientsMock.APIInterface.AssertNumberOfCalls(t, "CertifiedAppInstall", 2)
+		clientsMock.APIInterface.AssertNumberOfCalls(t, "ValidateAppManifest", 2)
 	})
 }
 
 func Test_HandleConnectorApprovalRequired(t *testing.T) {
 
-	test_reason := "GIVE IT TO ME!"
+	testReason := "GIVE IT TO ME!"
 	t.Run("should send request to approve connector", func(t *testing.T) {
 		ctx, clients, clientsMock, _, _, authMock := setupCommonMocks(t)
 		testErr := slackerror.New("a dummy error").WithDetails(slackerror.ErrorDetails{
@@ -174,16 +174,16 @@ func Test_HandleConnectorApprovalRequired(t *testing.T) {
 		})
 
 		clientsMock.IO.On("ConfirmPrompt", mock.Anything, mock.Anything, mock.Anything).Return(true, nil)
-		clientsMock.IO.On("InputPrompt", mock.Anything, mock.Anything, mock.Anything).Return(test_reason, nil)
-		clientsMock.ApiInterface.On("RequestAppApproval", mock.Anything, authMock.Token, mock.Anything, mock.Anything, test_reason, mock.Anything, mock.Anything).Return(api.AppsApprovalsRequestsCreateResult{}, nil)
+		clientsMock.IO.On("InputPrompt", mock.Anything, mock.Anything, mock.Anything).Return(testReason, nil)
+		clientsMock.APIInterface.On("RequestAppApproval", mock.Anything, authMock.Token, mock.Anything, mock.Anything, testReason, mock.Anything, mock.Anything).Return(api.AppsApprovalsRequestsCreateResult{}, nil)
 
 		// Test
 		err := HandleConnectorApprovalRequired(ctx, clients, authMock.Token, testErr)
 
 		assert.NoError(t, err)
-		clientsMock.ApiInterface.AssertCalled(t, "RequestAppApproval", mock.Anything, authMock.Token, "A12345", mock.Anything, test_reason, mock.Anything, mock.Anything)
-		clientsMock.ApiInterface.AssertCalled(t, "RequestAppApproval", mock.Anything, authMock.Token, "A56789", mock.Anything, test_reason, mock.Anything, mock.Anything)
-		clientsMock.ApiInterface.AssertNumberOfCalls(t, "RequestAppApproval", 2)
+		clientsMock.APIInterface.AssertCalled(t, "RequestAppApproval", mock.Anything, authMock.Token, "A12345", mock.Anything, testReason, mock.Anything, mock.Anything)
+		clientsMock.APIInterface.AssertCalled(t, "RequestAppApproval", mock.Anything, authMock.Token, "A56789", mock.Anything, testReason, mock.Anything, mock.Anything)
+		clientsMock.APIInterface.AssertNumberOfCalls(t, "RequestAppApproval", 2)
 		assert.Equal(t, len(testErr.Details), 1)
 	})
 
@@ -204,7 +204,7 @@ func Test_HandleConnectorApprovalRequired(t *testing.T) {
 		err := HandleConnectorApprovalRequired(ctx, clients, authMock.Token, testErr)
 
 		assert.NoError(t, err)
-		clientsMock.ApiInterface.AssertNumberOfCalls(t, "RequestAppApproval", 0)
+		clientsMock.APIInterface.AssertNumberOfCalls(t, "RequestAppApproval", 0)
 		assert.Equal(t, len(testErr.Details), 0)
 	})
 
@@ -220,14 +220,14 @@ func Test_HandleConnectorApprovalRequired(t *testing.T) {
 		})
 
 		clientsMock.IO.On("ConfirmPrompt", mock.Anything, mock.Anything, mock.Anything).Return(true, nil)
-		clientsMock.IO.On("InputPrompt", mock.Anything, mock.Anything, mock.Anything).Return(test_reason, nil)
-		clientsMock.ApiInterface.On("RequestAppApproval", mock.Anything, authMock.Token, mock.Anything, mock.Anything, test_reason, mock.Anything, mock.Anything).Return(api.AppsApprovalsRequestsCreateResult{}, slackerror.New("dummy error"))
+		clientsMock.IO.On("InputPrompt", mock.Anything, mock.Anything, mock.Anything).Return(testReason, nil)
+		clientsMock.APIInterface.On("RequestAppApproval", mock.Anything, authMock.Token, mock.Anything, mock.Anything, testReason, mock.Anything, mock.Anything).Return(api.AppsApprovalsRequestsCreateResult{}, slackerror.New("dummy error"))
 
 		// Test
 		err := HandleConnectorApprovalRequired(ctx, clients, authMock.Token, testErr)
 
 		assert.Error(t, err)
-		clientsMock.ApiInterface.AssertNumberOfCalls(t, "RequestAppApproval", 1)
+		clientsMock.APIInterface.AssertNumberOfCalls(t, "RequestAppApproval", 1)
 	})
 }
 
@@ -244,7 +244,7 @@ func setupCommonMocks(t *testing.T) (ctx context.Context, clients *shared.Client
 	})
 
 	// Mock valid auth session
-	clientsMock.ApiInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
+	clientsMock.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
 
 	// Mock the manifest
 	manifestMock := &app.ManifestMockObject{}

--- a/internal/pkg/platform/activity_test.go
+++ b/internal/pkg/platform/activity_test.go
@@ -40,12 +40,12 @@ func Test_prettifyActivity(t *testing.T) {
 		{
 			name: "nil payload should result in valid log without nulls",
 			activity: api.Activity{
-				TraceId:       "a123",
+				TraceID:       "a123",
 				Level:         "info",
 				EventType:     "unknown",
 				Source:        "slack",
 				ComponentType: "new_thing",
-				ComponentId:   "a789",
+				ComponentID:   "a789",
 				Created:       1686939542,
 			},
 			expectedResults: []string{
@@ -61,12 +61,12 @@ func Test_prettifyActivity(t *testing.T) {
 		{
 			name: "unknown EventType should result in valid log without nulls",
 			activity: api.Activity{
-				TraceId:       "a123",
+				TraceID:       "a123",
 				Level:         "info",
 				EventType:     "unknown",
 				Source:        "slack",
 				ComponentType: "new_thing",
-				ComponentId:   "a789",
+				ComponentID:   "a789",
 				Payload: map[string]interface{}{
 					"some": "data",
 				},
@@ -103,21 +103,21 @@ func TestPlatformActivity_StreamingLogs(t *testing.T) {
 	}{
 		"should return error if context contains no token": {
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) context.Context {
-				ctx = context.WithValue(ctx, config.CONTEXT_TOKEN, nil)
+				ctx = context.WithValue(ctx, config.ContextToken, nil)
 				return ctx
 			},
 			ExpectedError: slackerror.New(slackerror.ErrAuthToken),
 		},
 		"should return error if session validation fails": {
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) context.Context {
-				cm.ApiInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, slackerror.New("boomsies"))
+				cm.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, slackerror.New("boomsies"))
 				return ctx
 			},
 			ExpectedError: slackerror.New("boomsies"),
 		},
 		"should return error if activity request fails": {
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) context.Context {
-				cm.ApiInterface.On("Activity", mock.Anything, mock.Anything, mock.Anything).Return(api.ActivityResult{}, slackerror.New("explosions"))
+				cm.APIInterface.On("Activity", mock.Anything, mock.Anything, mock.Anything).Return(api.ActivityResult{}, slackerror.New("explosions"))
 				return ctx
 			},
 			ExpectedError: slackerror.New("explosions"),
@@ -127,11 +127,11 @@ func TestPlatformActivity_StreamingLogs(t *testing.T) {
 				TailArg: false,
 			},
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) context.Context {
-				cm.ApiInterface.On("Activity", mock.Anything, mock.Anything, mock.Anything).Return(api.ActivityResult{}, nil)
+				cm.APIInterface.On("Activity", mock.Anything, mock.Anything, mock.Anything).Return(api.ActivityResult{}, nil)
 				return ctx
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
-				cm.ApiInterface.AssertNumberOfCalls(t, "Activity", 1)
+				cm.APIInterface.AssertNumberOfCalls(t, "Activity", 1)
 			},
 		},
 		"should return nil if TailArg is set and context is canceled": {
@@ -140,7 +140,7 @@ func TestPlatformActivity_StreamingLogs(t *testing.T) {
 				PollingIntervalMS: 20, // poll activity every 20 ms
 			},
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) context.Context {
-				cm.ApiInterface.On("Activity", mock.Anything, mock.Anything, mock.Anything).Return(api.ActivityResult{}, nil)
+				cm.APIInterface.On("Activity", mock.Anything, mock.Anything, mock.Anything).Return(api.ActivityResult{}, nil)
 				ctx, cancel := context.WithCancel(ctx)
 				go func() {
 					time.Sleep(time.Millisecond * 10) // cancel activity in 10 ms
@@ -150,14 +150,14 @@ func TestPlatformActivity_StreamingLogs(t *testing.T) {
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
 				// with the above polling/canceling setup, expectation is activity called only once.
-				cm.ApiInterface.AssertNumberOfCalls(t, "Activity", 1)
+				cm.APIInterface.AssertNumberOfCalls(t, "Activity", 1)
 			},
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			// Create mocks
 			ctxMock := slackcontext.MockContext(t.Context())
-			ctxMock = context.WithValue(ctxMock, config.CONTEXT_TOKEN, "sometoken")
+			ctxMock = context.WithValue(ctxMock, config.ContextToken, "sometoken")
 			clientsMock := shared.NewClientsMock()
 			// Create clients that is mocked for testing
 			clients := shared.NewClientFactory(clientsMock.MockClientFactory())
@@ -166,7 +166,7 @@ func TestPlatformActivity_StreamingLogs(t *testing.T) {
 				ctxMock = tt.Setup(t, ctxMock, clientsMock)
 			}
 			// Setup generic test suite mocks
-			clientsMock.ApiInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
+			clientsMock.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
 			// Setup default mock actions
 			clientsMock.AddDefaultMocks()
 

--- a/internal/pkg/platform/deploy.go
+++ b/internal/pkg/platform/deploy.go
@@ -52,7 +52,7 @@ func Deploy(ctx context.Context, clients *shared.ClientFactory, showTriggers boo
 	}
 
 	// Validate auth session
-	authSession, err := clients.ApiInterface().ValidateSession(ctx, token)
+	authSession, err := clients.APIInterface().ValidateSession(ctx, token)
 	if err != nil {
 		return nil, slackerror.Wrap(err, slackerror.ErrSlackAuth)
 	}
@@ -122,7 +122,7 @@ func deployApp(ctx context.Context, clients *shared.ClientFactory, log *logger.L
 		return app, fmt.Errorf("error getting working directory: %s", err)
 	}
 
-	log.Data["appId"] = app.AppID
+	log.Data["appID"] = app.AppID
 	log.Log("info", "on_app_deploy")
 
 	if clients.Runtime == nil {
@@ -152,19 +152,19 @@ func deployApp(ctx context.Context, clients *shared.ClientFactory, log *logger.L
 
 	//upload zip to s3
 	var startDeploy = time.Now()
-	s3Params, err := clients.ApiInterface().GetPresignedS3PostParams(ctx, token, app.AppID)
+	s3Params, err := clients.APIInterface().GetPresignedS3PostParams(ctx, token, app.AppID)
 	if err != nil {
 		return app, slackerror.Wrapf(err, "failed generating s3 upload params %s", app.AppID)
 	}
 
-	fileName, err := clients.ApiInterface().UploadPackageToS3(ctx, clients.Fs, app.AppID, s3Params, result.Filename)
+	fileName, err := clients.APIInterface().UploadPackageToS3(ctx, clients.Fs, app.AppID, s3Params, result.Filename)
 	if err != nil {
 		return app, slackerror.Wrapf(err, "failed uploading the zip file to s3 %s", app.AppID)
 	}
 
 	// upload
 	runtime := strings.ToLower(clients.Runtime.Name())
-	err = clients.ApiInterface().UploadApp(ctx, token, runtime, app.AppID, fileName)
+	err = clients.APIInterface().UploadApp(ctx, token, runtime, app.AppID, fileName)
 	if err != nil {
 		return app, fmt.Errorf("error uploading app: %s", err)
 	}
@@ -176,10 +176,10 @@ func deployApp(ctx context.Context, clients *shared.ClientFactory, log *logger.L
 	// Set the SLACK_API_URL environment variable for development workspaces
 	//
 	// Note: This errors silently to continue deployment without any problem
-	var apiHost = clients.Config.ApiHostResolved
-	if clients.AuthInterface().IsApiHostSlackDev(apiHost) {
+	var apiHost = clients.Config.APIHostResolved
+	if clients.AuthInterface().IsAPIHostSlackDev(apiHost) {
 		apiHostURL := fmt.Sprintf("%s/api/", apiHost)
-		_ = clients.ApiInterface().AddVariable(ctx, token, app.AppID, "SLACK_API_URL", apiHostURL)
+		_ = clients.APIInterface().AddVariable(ctx, token, app.AppID, "SLACK_API_URL", apiHostURL)
 	}
 
 	return app, nil

--- a/internal/pkg/platform/localserver.go
+++ b/internal/pkg/platform/localserver.go
@@ -91,13 +91,13 @@ func (r *LocalServer) Start(ctx context.Context) error {
 		err := func() error {
 			// Get a socket connection address
 			r.clients.IO.PrintDebug(ctx, "Retrieving and establishing connection to WebSocket URL...")
-			result, err := r.clients.ApiInterface().ConnectionsOpen(ctx, r.token)
+			result, err := r.clients.APIInterface().ConnectionsOpen(ctx, r.token)
 			if err != nil {
 				return slackerror.Wrap(err, slackerror.ErrSocketConnection).WithMessage("Error fetching socket connection URL")
 			}
 
 			// Open the websocket connection
-			c, _, err := websocketDialerDial(websocket.DefaultDialer, result.Url, nil)
+			c, _, err := websocketDialerDial(websocket.DefaultDialer, result.URL, nil)
 			if err != nil {
 				return slackerror.Wrap(err, slackerror.ErrSocketConnection).WithMessage("Error establishing socket connection")
 			}
@@ -363,17 +363,17 @@ func (r *LocalServer) Watch(ctx context.Context, auth types.SlackAuth, app types
 func (r *LocalServer) WatchActivityLogs(ctx context.Context, minLevel string) error {
 	// Default minimum log level
 	if strings.TrimSpace(minLevel) == "" {
-		minLevel = ACTIVITY_MIN_LEVEL
+		minLevel = ActivityMinLevelDefault
 	}
 
 	var activityArgs = types.ActivityArgs{
-		TeamId:            r.localHostedContext.TeamID,
-		AppId:             r.localHostedContext.AppID,
+		TeamID:            r.localHostedContext.TeamID,
+		AppID:             r.localHostedContext.AppID,
 		TailArg:           true,
-		PollingIntervalMS: ACTIVITY_POLLING_INTERVAL_SECONDS * 1000,
+		PollingIntervalMS: ActivityPollingIntervalDefault * 1000,
 		MinDateCreated:    time.Now().UnixMicro(),
 		MinLevel:          minLevel,
-		Limit:             ACTIVITY_LIMIT,
+		Limit:             ActivityLimitDefault,
 
 		// Timeout after 24 hours - TODO(@mbrooks) can we remove the timeout entirely?
 		IdleTimeoutM: 60 * 24,

--- a/internal/pkg/platform/localserver_test.go
+++ b/internal/pkg/platform/localserver_test.go
@@ -47,7 +47,7 @@ func Test_LocalServer_Start(t *testing.T) {
 	}{
 		"should return an error if there was a problem asking for a WebSocket connection URL": {
 			Setup: func(t *testing.T, cm *shared.ClientsMock, clients *shared.ClientFactory, conn *WebSocketConnMock) {
-				cm.ApiInterface.On("ConnectionsOpen", mock.Anything, mock.Anything).Return(api.AppsConnectionsOpenResult{}, slackerror.New("no can do, pipes are clogged"))
+				cm.APIInterface.On("ConnectionsOpen", mock.Anything, mock.Anything).Return(api.AppsConnectionsOpenResult{}, slackerror.New("no can do, pipes are clogged"))
 			},
 			Test: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, server LocalServer, conn *WebSocketConnMock) {
 				require.ErrorContains(t, server.Start(ctx), "pipes are clogged")
@@ -130,7 +130,7 @@ func Test_LocalServer_Start(t *testing.T) {
 			if tt.Setup != nil {
 				tt.Setup(t, clientsMock, clients, conn)
 			}
-			clientsMock.ApiInterface.On("ConnectionsOpen", mock.Anything, mock.Anything).Return(api.AppsConnectionsOpenResult{Url: wsFakeURL}, nil)
+			clientsMock.APIInterface.On("ConnectionsOpen", mock.Anything, mock.Anything).Return(api.AppsConnectionsOpenResult{URL: wsFakeURL}, nil)
 			// Setup default mock actions
 			conn.AddDefaultMocks()
 			clientsMock.AddDefaultMocks()

--- a/internal/pkg/platform/run.go
+++ b/internal/pkg/platform/run.go
@@ -51,7 +51,7 @@ func Run(ctx context.Context, clients *shared.ClientFactory, log *logger.Logger,
 	ctx = config.SetContextToken(ctx, runArgs.Auth.Token)
 
 	// Validate auth session
-	authSession, err := clients.ApiInterface().ValidateSession(ctx, runArgs.Auth.Token)
+	authSession, err := clients.APIInterface().ValidateSession(ctx, runArgs.Auth.Token)
 	if err != nil {
 		err = slackerror.Wrap(err, "No auth session found")
 		return nil, "", slackerror.Wrap(err, slackerror.ErrLocalAppRun)
@@ -111,7 +111,7 @@ func Run(ctx context.Context, clients *shared.ClientFactory, log *logger.Logger,
 	if value, ok := variables["SLACK_API_URL"]; ok {
 		_ = clients.Os.Setenv("SLACK_API_URL", value)
 	} else {
-		variables["SLACK_API_URL"] = fmt.Sprintf("%s/api/", clients.Config.ApiHostResolved)
+		variables["SLACK_API_URL"] = fmt.Sprintf("%s/api/", clients.Config.APIHostResolved)
 	}
 
 	var localHostedContext = LocalHostedContext{

--- a/internal/pkg/platform/run.go
+++ b/internal/pkg/platform/run.go
@@ -82,8 +82,8 @@ func Run(ctx context.Context, clients *shared.ClientFactory, log *logger.Logger,
 		return nil, "", slackerror.Wrap(err, slackerror.ErrLocalAppRun)
 	}
 
-	if installState == types.REQUEST_PENDING || installState == types.REQUEST_CANCELLED || installState == types.REQUEST_NOT_SENT {
-		return log.SuccessEvent(), types.SUCCESS, nil
+	if installState == types.InstallRequestPending || installState == types.InstallRequestCancelled || installState == types.InstallRequestNotSent {
+		return log.SuccessEvent(), types.InstallSuccess, nil
 	}
 
 	if runArgs.ShowTriggers {
@@ -194,13 +194,13 @@ func Run(ctx context.Context, clients *shared.ClientFactory, log *logger.Logger,
 	if err := <-errChan; err != nil {
 		switch slackerror.ToSlackError(err).Code {
 		case slackerror.ErrLocalAppRunCleanExit:
-			return log.SuccessEvent(), types.SUCCESS, nil
+			return log.SuccessEvent(), types.InstallSuccess, nil
 		case slackerror.ErrSDKHookInvocationFailed:
 			return nil, "", err
 		}
 		return nil, "", slackerror.Wrap(err, slackerror.ErrLocalAppRun)
 	}
-	return log.SuccessEvent(), types.SUCCESS, nil
+	return log.SuccessEvent(), types.InstallSuccess, nil
 }
 
 func deleteAppOnTerminate(ctx context.Context, clients *shared.ClientFactory, auth types.SlackAuth, app types.App, log *logger.Logger) {

--- a/internal/prompts/app_select.go
+++ b/internal/prompts/app_select.go
@@ -284,8 +284,8 @@ func getApps(ctx context.Context, clients *shared.ClientFactory) (map[string]Sel
 		}
 		auth := apps[0].Auth
 		apiHost := ""
-		if auth.ApiHost != nil {
-			apiHost = *auth.ApiHost
+		if auth.APIHost != nil {
+			apiHost = *auth.APIHost
 		}
 		ids := []string{}
 		for _, app := range apps {
@@ -545,7 +545,7 @@ func getTokenApp(ctx context.Context, clients *shared.ClientFactory, token strin
 		return SelectedApp{}, err
 	}
 	var appStatus api.AppStatusResultAppInfo
-	if appStatusResult, err := clients.ApiInterface().GetAppStatus(ctx, token, []string{appID}, auth.TeamID); err != nil {
+	if appStatusResult, err := clients.APIInterface().GetAppStatus(ctx, token, []string{appID}, auth.TeamID); err != nil {
 		return SelectedApp{}, err
 	} else if len(appStatusResult.Apps) != 1 || appStatusResult.Apps[0].AppID != appID {
 		return SelectedApp{}, slackerror.New(slackerror.ErrAppNotFound)
@@ -588,8 +588,8 @@ func appendAppInstallStatus(ctx context.Context, clients *shared.ClientFactory, 
 	}
 	if len(appIDs) > 0 {
 		var apiHost = ""
-		if auth.ApiHost != nil {
-			apiHost = *auth.ApiHost
+		if auth.APIHost != nil {
+			apiHost = *auth.APIHost
 		}
 		appInfo, err := getInstallationStatuses(ctx, clients, auth.Token, appIDs, auth.TeamID, apiHost)
 		if err != nil {
@@ -627,7 +627,7 @@ func getInstallationStatuses(ctx context.Context, clients *shared.ClientFactory,
 	startTimer := time.Now()
 
 	// Ensure that the client's host in this case is set to any apiHost provided
-	apiClient := clients.ApiInterface()
+	apiClient := clients.APIInterface()
 	if apiHost != "" {
 		apiClient.SetHost(apiHost)
 	}
@@ -910,7 +910,7 @@ func selectTeamApp(ctx context.Context, clients *shared.ClientFactory, workspace
 	}
 
 	teamIDsWithApps, domainsWithApps, domainsWithAppsLabels := []string{}, []string{}, []string{}
-	unusedTeamIds, unusedDomains, unusedDomainsLabels := []string{}, []string{}, []string{}
+	unusedTeamIDs, unusedDomains, unusedDomainsLabels := []string{}, []string{}, []string{}
 	for _, workspace := range workspaceApps {
 		if includeApp(workspace.Hosted.App) {
 
@@ -928,7 +928,7 @@ func selectTeamApp(ctx context.Context, clients *shared.ClientFactory, workspace
 		} else {
 			// Neither hosted nor local app can be included, so this teamApp's remaining auth domain is unused
 			if workspace.Auth.TeamID != "" {
-				unusedTeamIds = append(unusedTeamIds, workspace.Auth.TeamID)
+				unusedTeamIDs = append(unusedTeamIDs, workspace.Auth.TeamID)
 				unusedDomains = append(unusedDomains, workspace.Auth.TeamDomain)
 				unusedDomainsLabels = append(unusedDomainsLabels, style.TeamSelectLabel(workspace.Auth.TeamDomain, workspace.Auth.TeamID))
 			}
@@ -942,7 +942,7 @@ func selectTeamApp(ctx context.Context, clients *shared.ClientFactory, workspace
 	if err := SortAlphaNumeric(domainsWithApps, domainsWithAppsLabels, teamIDsWithApps); err != nil {
 		return "", SelectedApp{}, err
 	}
-	if err := SortAlphaNumeric(unusedDomains, unusedDomainsLabels, unusedTeamIds); err != nil {
+	if err := SortAlphaNumeric(unusedDomains, unusedDomainsLabels, unusedTeamIDs); err != nil {
 		return "", SelectedApp{}, err
 	}
 
@@ -995,7 +995,7 @@ func selectTeamApp(ctx context.Context, clients *shared.ClientFactory, workspace
 			}
 		} else if selection.Prompt {
 			selectedDomain = unusedDomains[selection.Index]
-			selectedTeamID = unusedTeamIds[selection.Index]
+			selectedTeamID = unusedTeamIDs[selection.Index]
 		}
 		clients.IO.PrintInfo(ctx, false, "\n%s", style.Sectionf(appTransferDisclaimer))
 	}
@@ -1162,7 +1162,7 @@ func flatAppSelectPrompt(
 			return SelectedApp{}, slackerror.New(slackerror.ErrInstallationRequired)
 		}
 	case ShowAllApps, ShowInstalledAndNewApps:
-		if manifestSource.Equals(config.MANIFEST_SOURCE_LOCAL) {
+		if manifestSource.Equals(config.ManifestSourceLocal) {
 			option := Selection{
 				label: style.Secondary("Create a new app"),
 			}
@@ -1687,7 +1687,7 @@ func TeamAppSelectPrompt(ctx context.Context, clients *shared.ClientFactory, env
 
 // OrgSelectWorkspacePrompt prompts the user to select a single workspace to grant app access to, or grant all workspaces within the org.
 func OrgSelectWorkspacePrompt(ctx context.Context, clients *shared.ClientFactory, orgDomain, token string, topOptionAllWorkspaces bool) (string, error) {
-	teams, paginationCursor, err := clients.ApiInterface().AuthTeamsList(ctx, token, api.DefaultAuthTeamsListPageSize)
+	teams, paginationCursor, err := clients.APIInterface().AuthTeamsList(ctx, token, api.DefaultAuthTeamsListPageSize)
 	if err != nil {
 		return "", err
 	}
@@ -1824,12 +1824,12 @@ func appExists(app types.App) bool {
 // validateAuth checks if the auth for the selected app is valid and if not,
 // prompts the user to re-authenticate
 func validateAuth(ctx context.Context, clients *shared.ClientFactory, auth *types.SlackAuth) error {
-	apiClient := clients.ApiInterface()
+	apiClient := clients.APIInterface()
 	if auth == nil {
 		auth = &types.SlackAuth{}
 	}
-	if auth.ApiHost != nil {
-		apiClient.SetHost(*auth.ApiHost)
+	if auth.APIHost != nil {
+		apiClient.SetHost(*auth.APIHost)
 	}
 	_, err := apiClient.ValidateSession(ctx, auth.Token)
 	if err == nil {

--- a/internal/prompts/app_select_test.go
+++ b/internal/prompts/app_select_test.go
@@ -239,7 +239,7 @@ func TestGetTeamApps(t *testing.T) {
 				tt.mockAuthWithTeamIDResponse,
 				tt.mockAuthWithTeamIDError,
 			)
-			clientsMock.ApiInterface.On(
+			clientsMock.APIInterface.On(
 				GetAppStatus,
 				mock.Anything,
 				mock.Anything,
@@ -249,7 +249,7 @@ func TestGetTeamApps(t *testing.T) {
 				tt.mockGetAppStatusResponse,
 				tt.mockGetAppStatusError,
 			)
-			clientsMock.ApiInterface.On(
+			clientsMock.APIInterface.On(
 				"ValidateSession",
 				mock.Anything,
 				mock.Anything,
@@ -374,7 +374,7 @@ func TestGetTokenApp(t *testing.T) {
 			clientsMock := shared.NewClientsMock()
 			clientsMock.AuthInterface.On(AuthWithToken, mock.Anything, test.tokenFlag).
 				Return(test.tokenAuth, test.tokenErr)
-			clientsMock.ApiInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 				Return(test.appStatus, test.statusErr)
 			clientsMock.AddDefaultMocks()
 
@@ -452,7 +452,7 @@ func Test_FilterAuthsByToken_Flags(t *testing.T) {
 	clientsMock.AuthInterface.On(AuthWithToken, mock.Anything, team2Token).
 		Return(mockAuthTeam2, nil)
 
-	clientsMock.ApiInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.GetAppStatusResult{}, nil)
+	clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.GetAppStatusResult{}, nil)
 	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
 	clientsMock.AuthInterface.On(SetAuth, mock.Anything).Return(types.SlackAuth{}, nil)
 	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, errors.New(slackerror.ErrCredentialsNotFound))
@@ -581,7 +581,7 @@ func TestPrompt_AppSelectPrompt_SelectedAuthExpired_UserReAuthenticates(t *testi
 	// Auth is present but invalid
 	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
 	mockReauthentication(clientsMock)
-	clientsMock.ApiInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+	clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 		api.GetAppStatusResult{}, nil)
 	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
 
@@ -612,7 +612,7 @@ func TestPrompt_AppSelectPrompt_SelectedAuthExpired_UserReAuthenticates(t *testi
 	require.NoError(t, err)
 	selection.Auth.LastUpdated = time.Time{} // ignore time for this test
 	require.Equal(t, fakeAuthsByTeamDomain[team1TeamDomain], selection.Auth)
-	clientsMock.ApiInterface.AssertCalled(t, "ExchangeAuthTicket", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	clientsMock.APIInterface.AssertCalled(t, "ExchangeAuthTicket", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
 func TestPrompt_AppSelectPrompt_AuthsNoApps(t *testing.T) {
@@ -620,7 +620,7 @@ func TestPrompt_AppSelectPrompt_AuthsNoApps(t *testing.T) {
 	// Set up mocks
 	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
-	clientsMock.ApiInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
+	clientsMock.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
 	clients := shared.NewClientFactory(clientsMock.MockClientFactory())
 
 	clientsMock.AddDefaultMocks()
@@ -695,7 +695,7 @@ func TestPrompt_AppSelectPrompt_TokenAppFlag(t *testing.T) {
 			clientsMock := shared.NewClientsMock()
 			clientsMock.AuthInterface.On(AuthWithToken, mock.Anything, test.tokenFlag).
 				Return(test.tokenAuth, nil)
-			clientsMock.ApiInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 				Return(test.appStatus, test.statusErr)
 			clientsMock.AddDefaultMocks()
 
@@ -725,13 +725,13 @@ func TestPrompt_AppSelectPrompt_AuthsWithDeployedAppInstalled_ShowAllApps(t *tes
 	// Set up mocks
 	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
-	clientsMock.ApiInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+	clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 		api.GetAppStatusResult{
 			Apps: []api.AppStatusResultAppInfo{{AppID: "A1EXAMPLE01", Installed: true}},
 		}, nil)
 	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
 	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
-	clientsMock.ApiInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
+	clientsMock.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
 	clientsMock.AddDefaultMocks()
 
 	clients := shared.NewClientFactory(clientsMock.MockClientFactory())
@@ -772,13 +772,13 @@ func TestPrompt_AppSelectPrompt_AuthsWithDeployedAppInstalled_ShowInstalledAppsO
 	// Set up mocks
 	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
-	clientsMock.ApiInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+	clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 		api.GetAppStatusResult{
 			Apps: []api.AppStatusResultAppInfo{{AppID: "A1EXAMPLE01", Installed: true}},
 		}, nil)
 	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
 	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
-	clientsMock.ApiInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
+	clientsMock.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
 	clientsMock.AddDefaultMocks()
 
 	clients := shared.NewClientFactory(clientsMock.MockClientFactory())
@@ -820,13 +820,13 @@ func TestPrompt_AppSelectPrompt_AuthsWithDeployedAppInstalled_InstalledAppOnly_F
 	// Set up mocks
 	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
-	clientsMock.ApiInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+	clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 		api.GetAppStatusResult{
 			Apps: []api.AppStatusResultAppInfo{{AppID: "A1EXAMPLE01", Installed: true}},
 		}, nil)
 	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
 	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
-	clientsMock.ApiInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
+	clientsMock.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
 	clientsMock.AddDefaultMocks()
 
 	clients := shared.NewClientFactory(clientsMock.MockClientFactory())
@@ -946,7 +946,7 @@ func TestPrompt_AppSelectPrompt_AuthsWithBothEnvsInstalled_InstalledAppOnly_Flag
 	mockAuthTeam2.Token = team2Token
 
 	clientsMock := shared.NewClientsMock()
-	clientsMock.ApiInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+	clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 		api.GetAppStatusResult{
 			Apps: []api.AppStatusResultAppInfo{
 				{AppID: "A1EXAMPLE01", Installed: true},
@@ -956,7 +956,7 @@ func TestPrompt_AppSelectPrompt_AuthsWithBothEnvsInstalled_InstalledAppOnly_Flag
 	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
 	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mockAuthTeam1.TeamID).Return(mockAuthTeam1, nil)
 	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mockAuthTeam2.TeamID).Return(mockAuthTeam2, nil)
-	clientsMock.ApiInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
+	clientsMock.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
 
 	clientsMock.AuthInterface.On(AuthWithToken, mock.Anything, team1Token).
 		Return(mockAuthTeam1, nil)
@@ -1098,7 +1098,7 @@ func TestPrompt_AppSelectPrompt_AuthsWithBothEnvsInstalled_MultiWorkspaceAllApps
 	// Set up mocks
 	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
-	clientsMock.ApiInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+	clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 		api.GetAppStatusResult{
 			Apps: []api.AppStatusResultAppInfo{
 				{AppID: "A1EXAMPLE01", Installed: true},
@@ -1107,7 +1107,7 @@ func TestPrompt_AppSelectPrompt_AuthsWithBothEnvsInstalled_MultiWorkspaceAllApps
 			}}, nil)
 	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
 	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
-	clientsMock.ApiInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
+	clientsMock.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
 	clientsMock.AddDefaultMocks()
 
 	clients := shared.NewClientFactory(clientsMock.MockClientFactory())
@@ -1224,7 +1224,7 @@ func TestPrompt_AppSelectPrompt_AuthsWithHostedInstalled_AllApps_CreateNew(t *te
 	// Set up mocks
 	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
-	clientsMock.ApiInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+	clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 		api.GetAppStatusResult{
 			Apps: []api.AppStatusResultAppInfo{
 				{AppID: "A1EXAMPLE01", Installed: true},
@@ -1232,7 +1232,7 @@ func TestPrompt_AppSelectPrompt_AuthsWithHostedInstalled_AllApps_CreateNew(t *te
 			}}, nil)
 	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
 	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
-	clientsMock.ApiInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
+	clientsMock.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
 	clientsMock.AddDefaultMocks()
 
 	clients := shared.NewClientFactory(clientsMock.MockClientFactory())
@@ -1303,8 +1303,8 @@ func TestPrompt_AppSelectPrompt_ShowExpectedLabels(t *testing.T) {
 		})
 		clientsMock.AuthInterface.On(Auths, mock.Anything).Return(auths, nil)
 		clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
-		clientsMock.ApiInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
-		clientsMock.ApiInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+		clientsMock.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
+		clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 			api.GetAppStatusResult{
 				Apps: []api.AppStatusResultAppInfo{
 					{AppID: deployedTeam1InstalledAppID, Installed: deployedTeam1AppIsInstalled},
@@ -1685,7 +1685,7 @@ func TestPrompt_AppSelectPrompt_GetApps(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := shared.NewClientsMock()
-			clientsMock.ApiInterface.On(
+			clientsMock.APIInterface.On(
 				GetAppStatus,
 				mock.Anything,
 				mock.Anything,
@@ -1695,7 +1695,7 @@ func TestPrompt_AppSelectPrompt_GetApps(t *testing.T) {
 				tt.mockTeam1Status,
 				tt.mockTeam1StatusError,
 			)
-			clientsMock.ApiInterface.On(
+			clientsMock.APIInterface.On(
 				GetAppStatus,
 				mock.Anything,
 				mock.Anything,
@@ -1705,7 +1705,7 @@ func TestPrompt_AppSelectPrompt_GetApps(t *testing.T) {
 				tt.mockTeam2Status,
 				tt.mockTeam2StatusError,
 			)
-			clientsMock.ApiInterface.On(
+			clientsMock.APIInterface.On(
 				"ValidateSession",
 				mock.Anything,
 				mock.Anything,
@@ -1819,7 +1819,7 @@ func TestPrompt_AppSelectPrompt_FlatAppSelectPrompt(t *testing.T) {
 					UserID:     team2UserID,
 				},
 			},
-			mockManifestSource:         config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:         config.ManifestSourceLocal,
 			appPromptConfigEnvironment: ShowAllEnvironments,
 			appPromptConfigOptions: []string{
 				"A1 team1 T1",
@@ -1844,7 +1844,7 @@ func TestPrompt_AppSelectPrompt_FlatAppSelectPrompt(t *testing.T) {
 		"creates new application if selected": {
 			mockAuths:                  fakeAuthsByTeamDomainSlice,
 			mockAppsDeployed:           []types.App{},
-			mockManifestSource:         config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:         config.ManifestSourceLocal,
 			appPromptConfigEnvironment: ShowHostedOnly,
 			appPromptConfigOptions: []string{
 				"Create a new app",
@@ -1863,7 +1863,7 @@ func TestPrompt_AppSelectPrompt_FlatAppSelectPrompt(t *testing.T) {
 		"errors if installation required and no apps saved": {
 			mockAuths:                  fakeAuthsByTeamDomainSlice,
 			mockAppsDeployed:           []types.App{},
-			mockManifestSource:         config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:         config.ManifestSourceLocal,
 			appPromptConfigEnvironment: ShowHostedOnly,
 			appPromptConfigStatus:      ShowInstalledAppsOnly,
 			expectedError:              slackerror.New(slackerror.ErrInstallationRequired),
@@ -1889,7 +1889,7 @@ func TestPrompt_AppSelectPrompt_FlatAppSelectPrompt(t *testing.T) {
 			appPromptResponseOption:  "Create a new app",
 			teamPromptResponseFlag:   true,
 			teamPromptResponseOption: team1TeamDomain,
-			mockManifestSource:       config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:       config.ManifestSourceLocal,
 			expectedError: slackerror.New(slackerror.ErrAppExists).
 				WithDetails(slackerror.ErrorDetails{{
 					Message: `The app "A1" already exists for team "team1" (T1)`,
@@ -1900,7 +1900,7 @@ func TestPrompt_AppSelectPrompt_FlatAppSelectPrompt(t *testing.T) {
 			mockAuths:                  fakeAuthsByTeamDomainSlice,
 			mockFlagApp:                "deployed",
 			mockFlagTeam:               team1TeamID,
-			mockManifestSource:         config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:         config.ManifestSourceLocal,
 			appPromptConfigEnvironment: ShowHostedOnly,
 			appPromptConfigStatus:      ShowInstalledAndNewApps,
 			expectedSelection: SelectedApp{
@@ -1919,7 +1919,7 @@ func TestPrompt_AppSelectPrompt_FlatAppSelectPrompt(t *testing.T) {
 			},
 			mockFlagApp:                "deployed",
 			mockFlagTeam:               team2TeamID,
-			mockManifestSource:         config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:         config.ManifestSourceLocal,
 			appPromptConfigEnvironment: ShowHostedOnly,
 			appPromptConfigStatus:      ShowAllApps,
 			expectedSelection: SelectedApp{
@@ -2177,7 +2177,7 @@ func TestPrompt_AppSelectPrompt_FlatAppSelectPrompt(t *testing.T) {
 		"errors if deployed app environment flag and team id flag for local app prompt": {
 			mockFlagApp:                "deployed",
 			mockFlagTeam:               team1TeamID,
-			mockManifestSource:         config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:         config.ManifestSourceLocal,
 			appPromptConfigEnvironment: ShowLocalOnly,
 			appPromptConfigStatus:      ShowInstalledAndNewApps,
 			expectedError:              slackerror.New(slackerror.ErrDeployedAppNotSupported),
@@ -2185,14 +2185,14 @@ func TestPrompt_AppSelectPrompt_FlatAppSelectPrompt(t *testing.T) {
 		"errors if local app environment flag and team id flag for hosted app prompt": {
 			mockFlagApp:                "local",
 			mockFlagTeam:               team1TeamID,
-			mockManifestSource:         config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:         config.ManifestSourceLocal,
 			appPromptConfigEnvironment: ShowHostedOnly,
 			appPromptConfigStatus:      ShowInstalledAndNewApps,
 			expectedError:              slackerror.New(slackerror.ErrLocalAppNotSupported),
 		},
 		"errors if team id flag does not have authorization": {
 			mockFlagTeam:               team1TeamID,
-			mockManifestSource:         config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:         config.ManifestSourceLocal,
 			appPromptConfigEnvironment: ShowHostedOnly,
 			appPromptConfigStatus:      ShowInstalledAndNewApps,
 			expectedError:              slackerror.New(slackerror.ErrTeamNotFound),
@@ -2241,7 +2241,7 @@ func TestPrompt_AppSelectPrompt_FlatAppSelectPrompt(t *testing.T) {
 			mockAuthWithTeamIDTeamID:   team1TeamID,
 			mockFlagTeam:               team1TeamID,
 			mockFlagToken:              fakeAuthsByTeamDomain[team1TeamDomain].Token,
-			mockManifestSource:         config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:         config.ManifestSourceLocal,
 			appPromptConfigStatus:      ShowInstalledAndNewApps,
 			appPromptConfigEnvironment: ShowHostedOnly,
 			expectedSelection: SelectedApp{
@@ -2258,7 +2258,7 @@ func TestPrompt_AppSelectPrompt_FlatAppSelectPrompt(t *testing.T) {
 			mockAuthWithTeamIDTeamID:   team1TeamID,
 			mockFlagTeam:               team1TeamID,
 			mockFlagToken:              fakeAuthsByTeamDomain[team1TeamDomain].Token,
-			mockManifestSource:         config.MANIFEST_SOURCE_LOCAL,
+			mockManifestSource:         config.ManifestSourceLocal,
 			appPromptConfigStatus:      ShowAllApps,
 			appPromptConfigEnvironment: ShowLocalOnly,
 			expectedSelection: SelectedApp{
@@ -2302,7 +2302,7 @@ func TestPrompt_AppSelectPrompt_FlatAppSelectPrompt(t *testing.T) {
 				tt.mockAuthWithToken,
 				nil,
 			)
-			clientsMock.ApiInterface.On(
+			clientsMock.APIInterface.On(
 				"ValidateSession",
 				mock.Anything,
 				mock.Anything,
@@ -2310,7 +2310,7 @@ func TestPrompt_AppSelectPrompt_FlatAppSelectPrompt(t *testing.T) {
 				api.AuthSession{},
 				nil,
 			)
-			clientsMock.ApiInterface.On(
+			clientsMock.APIInterface.On(
 				GetAppStatus,
 				mock.Anything,
 				mock.Anything,
@@ -2334,7 +2334,7 @@ func TestPrompt_AppSelectPrompt_FlatAppSelectPrompt(t *testing.T) {
 				},
 				nil,
 			)
-			clientsMock.ApiInterface.On(
+			clientsMock.APIInterface.On(
 				GetAppStatus,
 				mock.Anything,
 				mock.Anything,
@@ -2353,7 +2353,7 @@ func TestPrompt_AppSelectPrompt_FlatAppSelectPrompt(t *testing.T) {
 				},
 				nil,
 			)
-			clientsMock.ApiInterface.On(
+			clientsMock.APIInterface.On(
 				GetAppStatus,
 				mock.Anything,
 				mock.Anything,
@@ -2372,7 +2372,7 @@ func TestPrompt_AppSelectPrompt_FlatAppSelectPrompt(t *testing.T) {
 				},
 				nil,
 			)
-			clientsMock.ApiInterface.On(
+			clientsMock.APIInterface.On(
 				GetAppStatus,
 				mock.Anything,
 				mock.Anything,
@@ -2396,7 +2396,7 @@ func TestPrompt_AppSelectPrompt_FlatAppSelectPrompt(t *testing.T) {
 				},
 				nil,
 			)
-			clientsMock.ApiInterface.On(
+			clientsMock.APIInterface.On(
 				GetAppStatus,
 				mock.Anything,
 				mock.Anything,
@@ -2415,7 +2415,7 @@ func TestPrompt_AppSelectPrompt_FlatAppSelectPrompt(t *testing.T) {
 				},
 				nil,
 			)
-			clientsMock.ApiInterface.On(
+			clientsMock.APIInterface.On(
 				GetAppStatus,
 				mock.Anything,
 				mock.Anything,
@@ -2515,7 +2515,7 @@ func TestPrompt_TeamAppSelectPrompt_SelectedAuthExpired_UserReAuthenticates(t *t
 	// Auth is present but invalid
 	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
 	mockReauthentication(clientsMock)
-	clientsMock.ApiInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+	clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 		api.GetAppStatusResult{}, nil)
 	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
 
@@ -2538,7 +2538,7 @@ func TestPrompt_TeamAppSelectPrompt_SelectedAuthExpired_UserReAuthenticates(t *t
 	require.NoError(t, err)
 	selection.Auth.LastUpdated = time.Time{} // ignore time for this test
 	require.Equal(t, fakeAuthsByTeamDomain[team1TeamDomain], selection.Auth)
-	clientsMock.ApiInterface.AssertCalled(t, "ExchangeAuthTicket", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	clientsMock.APIInterface.AssertCalled(t, "ExchangeAuthTicket", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
 func TestPrompt_TeamAppSelectPrompt_NoAuths_UserReAuthenticates(t *testing.T) {
@@ -2548,7 +2548,7 @@ func TestPrompt_TeamAppSelectPrompt_NoAuths_UserReAuthenticates(t *testing.T) {
 	// No auths present
 	clientsMock.AuthInterface.On(Auths, mock.Anything).Return([]types.SlackAuth{}, nil)
 	mockReauthentication(clientsMock)
-	clientsMock.ApiInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+	clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 		api.GetAppStatusResult{}, nil)
 	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
 
@@ -2680,7 +2680,7 @@ func TestPrompt_TeamAppSelectPrompt_TokenAppFlag(t *testing.T) {
 			clientsMock := shared.NewClientsMock()
 			clientsMock.AuthInterface.On(AuthWithToken, mock.Anything, test.tokenFlag).
 				Return(test.tokenAuth, nil)
-			clientsMock.ApiInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 				Return(test.appStatus, test.statusErr)
 			clientsMock.AddDefaultMocks()
 
@@ -2746,7 +2746,7 @@ func TestPrompt_TeamAppSelectPrompt_NoApps(t *testing.T) {
 	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
 	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, team1TeamID).Return(fakeAuthsByTeamDomain[team1TeamDomain], nil)
 	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, team2TeamID).Return(fakeAuthsByTeamDomain[team2TeamDomain], nil)
-	clientsMock.ApiInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
+	clientsMock.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
 	clientsMock.AddDefaultMocks()
 
 	clients := shared.NewClientFactory(clientsMock.MockClientFactory())
@@ -3062,7 +3062,7 @@ func TestPrompt_TeamAppSelectPrompt_TokenFlag(t *testing.T) {
 
 		clientsMock := shared.NewClientsMock()
 
-		clientsMock.ApiInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+		clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 			api.GetAppStatusResult{Apps: appInstallStatus}, nil)
 		clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
 		clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mock.Anything).
@@ -3098,12 +3098,12 @@ func TestPrompt_TeamAppSelectPrompt_HostedAppsOnly(t *testing.T) {
 	// Set up mocks
 	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
-	clientsMock.ApiInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+	clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 		api.GetAppStatusResult{
 			Apps: []api.AppStatusResultAppInfo{{AppID: "A1EXAMPLE01", Installed: true}, {AppID: "A124", Installed: true}},
 		}, nil)
 	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
-	clientsMock.ApiInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
+	clientsMock.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
 	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
 	clientsMock.AddDefaultMocks()
 
@@ -3179,7 +3179,7 @@ func TestPrompt_TeamAppSelectPrompt_HostedAppsOnly_TeamFlagDomain(t *testing.T) 
 	// Set up mocks
 	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
-	clientsMock.ApiInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+	clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 		api.GetAppStatusResult{
 			Apps: []api.AppStatusResultAppInfo{{AppID: "A1EXAMPLE01", Installed: true}},
 		}, nil)
@@ -3227,7 +3227,7 @@ func TestPrompt_TeamAppSelectPrompt_HostedAppsOnly_TeamFlagID(t *testing.T) {
 	// Set up mocks
 	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
-	clientsMock.ApiInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+	clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 		api.GetAppStatusResult{
 			Apps: []api.AppStatusResultAppInfo{{AppID: "A1EXAMPLE01", Installed: true}},
 		}, nil)
@@ -3275,12 +3275,12 @@ func TestPrompt_TeamAppSelectPrompt_LocalAppsOnly(t *testing.T) {
 	// Set up mocks
 	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
-	clientsMock.ApiInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+	clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 		api.GetAppStatusResult{
 			Apps: []api.AppStatusResultAppInfo{{AppID: "A1EXAMPLE01", Installed: true}, {AppID: "A124", Installed: true}},
 		}, nil)
 	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
-	clientsMock.ApiInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
+	clientsMock.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
 	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, team1TeamID).Return(fakeAuthsByTeamDomain[team1TeamDomain], nil)
 	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, team2TeamID).Return(fakeAuthsByTeamDomain[team2TeamDomain], nil)
 	clientsMock.AddDefaultMocks()
@@ -3359,7 +3359,7 @@ func TestPrompt_TeamAppSelectPrompt_LocalAppsOnly_TeamFlagDomain(t *testing.T) {
 	// Set up mocks
 	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
-	clientsMock.ApiInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+	clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 		api.GetAppStatusResult{
 			Apps: []api.AppStatusResultAppInfo{{AppID: "A124", Installed: true}},
 		}, nil)
@@ -3410,7 +3410,7 @@ func TestPrompt_TeamAppSelectPrompt_LocalAppsOnly_TeamFlagID(t *testing.T) {
 	// Set up mocks
 	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
-	clientsMock.ApiInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+	clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 		api.GetAppStatusResult{
 			Apps: []api.AppStatusResultAppInfo{{AppID: "A124", Installed: true}},
 		}, nil)
@@ -3461,7 +3461,7 @@ func TestPrompt_TeamAppSelectPrompt_AllApps(t *testing.T) {
 	// Set up mocks
 	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
-	clientsMock.ApiInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+	clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 		api.GetAppStatusResult{
 			Apps: []api.AppStatusResultAppInfo{
 				{AppID: "A1EXAMPLE01", Installed: true},
@@ -3471,7 +3471,7 @@ func TestPrompt_TeamAppSelectPrompt_AllApps(t *testing.T) {
 			},
 		}, nil)
 	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
-	clientsMock.ApiInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
+	clientsMock.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
 	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
 	clientsMock.AddDefaultMocks()
 
@@ -3553,7 +3553,7 @@ func TestPrompt_TeamAppSelectPrompt_LegacyDevApps(t *testing.T) {
 	// Set up mocks
 	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
-	clientsMock.ApiInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+	clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 		api.GetAppStatusResult{
 			Apps: []api.AppStatusResultAppInfo{
 				{AppID: "A1EXAMPLE01dev", Installed: true},
@@ -3561,7 +3561,7 @@ func TestPrompt_TeamAppSelectPrompt_LegacyDevApps(t *testing.T) {
 			},
 		}, nil)
 	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
-	clientsMock.ApiInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
+	clientsMock.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
 	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
 	clientsMock.AddDefaultMocks()
 
@@ -3637,7 +3637,7 @@ func TestPrompt_TeamAppSelectPrompt_ShowExpectedLabels(t *testing.T) {
 
 	setupClientsMock := func() *shared.ClientsMock {
 		clientsMock := shared.NewClientsMock()
-		clientsMock.ApiInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+		clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 			api.GetAppStatusResult{
 				Apps: []api.AppStatusResultAppInfo{
 					{AppID: deployedTeam1InstalledAppID, Installed: deployedTeam1AppIsInstalled},
@@ -3653,7 +3653,7 @@ func TestPrompt_TeamAppSelectPrompt_ShowExpectedLabels(t *testing.T) {
 			Token:      "xoxe.xoxp-2-token",
 		})
 		clientsMock.AuthInterface.On(Auths, mock.Anything).Return(auths, nil)
-		clientsMock.ApiInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
+		clientsMock.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
 		clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
 		clientsMock.AddDefaultMocks()
 
@@ -3818,7 +3818,7 @@ func TestPrompt_TeamAppSelectPrompt_AllApps_TeamFlagID(t *testing.T) {
 	// Set up mocks
 	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
-	clientsMock.ApiInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.GetAppStatusResult{}, nil)
+	clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.GetAppStatusResult{}, nil)
 	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
 	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
 	clientsMock.AddDefaultMocks()
@@ -3866,7 +3866,7 @@ func TestPrompt_TeamAppSelectPrompt_AllApps_Flags(t *testing.T) {
 	// Set up mocks
 	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
-	clientsMock.ApiInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.GetAppStatusResult{}, nil)
+	clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.GetAppStatusResult{}, nil)
 	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
 	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
 	clientsMock.AddDefaultMocks()
@@ -4032,7 +4032,7 @@ func TestPrompt_TeamAppSelectPrompt_AppSelectPrompt_EnterpriseWorkspaceApps_HasW
 	// Set up mocks
 	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
-	clientsMock.ApiInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.GetAppStatusResult{}, nil)
+	clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.GetAppStatusResult{}, nil)
 
 	// Auths
 	// Enterprise (org) Auth
@@ -4058,7 +4058,7 @@ func TestPrompt_TeamAppSelectPrompt_AppSelectPrompt_EnterpriseWorkspaceApps_HasW
 	// Return one auth
 	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, team1TeamID).Return(authTeam1, nil)
 	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, enterprise1TeamID).Return(authEnterprise1, nil)
-	clientsMock.ApiInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
+	clientsMock.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
 
 	//
 	// This test uses a single auth - Mock the underlying auth
@@ -4239,7 +4239,7 @@ func TestPrompt_TeamAppSelectPrompt_AppSelectPrompt_EnterpriseWorkspaceApps_Miss
 	// Set up mocks
 	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
-	clientsMock.ApiInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.GetAppStatusResult{}, nil)
+	clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.GetAppStatusResult{}, nil)
 
 	mockReauthentication(clientsMock)
 
@@ -4428,7 +4428,7 @@ func TestPrompt_TeamAppSelectPrompt_EnterpriseWorkspaceApps_MissingWorkspaceAuth
 	// Set up mocks
 	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
-	clientsMock.ApiInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.GetAppStatusResult{}, nil)
+	clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.GetAppStatusResult{}, nil)
 
 	// Auths
 	// Enterprise (org) Auth
@@ -4454,7 +4454,7 @@ func TestPrompt_TeamAppSelectPrompt_EnterpriseWorkspaceApps_MissingWorkspaceAuth
 	// For this test we want to make sure that no auth is found for team1, and a credentials not found
 	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, team1TeamID).Return(types.SlackAuth{}, slackerror.New(slackerror.ErrCredentialsNotFound))
 	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, enterprise1TeamID).Return(authEnterprise1, nil)
-	clientsMock.ApiInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
+	clientsMock.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
 
 	// This test uses a single auth - the enterprise auth
 	clientsMock.AuthInterface.On(Auths, mock.Anything).Return([]types.SlackAuth{
@@ -4606,7 +4606,7 @@ func TestPrompt_AppSelectPrompt_EnterpriseWorkspaceApps_MissingWorkspaceAuth_Has
 	// Set up mocks
 	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
-	clientsMock.ApiInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.GetAppStatusResult{}, nil)
+	clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.GetAppStatusResult{}, nil)
 
 	// Auths
 	// Enterprise (org) Auth
@@ -4632,7 +4632,7 @@ func TestPrompt_AppSelectPrompt_EnterpriseWorkspaceApps_MissingWorkspaceAuth_Has
 	// For this test we want to make sure that no auth is found for team1, and a credentials not found
 	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, team1TeamID).Return(types.SlackAuth{}, slackerror.New(slackerror.ErrCredentialsNotFound))
 	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, enterprise1TeamID).Return(authEnterprise1, nil)
-	clientsMock.ApiInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
+	clientsMock.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
 
 	// This test uses a single auth - the enterprise auth
 	clientsMock.AuthInterface.On(Auths, mock.Anything).Return([]types.SlackAuth{
@@ -4783,40 +4783,40 @@ func TestPrompt_AppSelectPrompt_EnterpriseWorkspaceApps_MissingWorkspaceAuth_Has
 func TestSortAlphaNumeric_Sorted(t *testing.T) {
 	items := []string{"alphabetical", "bordering"}
 	labels := []string{"_alphabetical_ T001", "_bordering_ T1"}
-	teamIds := []string{"T001", "T1"}
-	err := SortAlphaNumeric(items, labels, teamIds)
+	teamIDs := []string{"T001", "T1"}
+	err := SortAlphaNumeric(items, labels, teamIDs)
 	require.NoError(t, err)
 
 	require.Equal(t, items[0], "alphabetical")
 	require.Equal(t, labels[0], "_alphabetical_ T001")
-	require.Equal(t, teamIds[0], "T001")
+	require.Equal(t, teamIDs[0], "T001")
 
 	require.Equal(t, items[1], "bordering")
 	require.Equal(t, labels[1], "_bordering_ T1")
-	require.Equal(t, teamIds[1], "T1")
+	require.Equal(t, teamIDs[1], "T1")
 }
 
 func TestSortAlphaNumeric_Unsorted(t *testing.T) {
 	items := []string{"bordering", "alphabetical"}
 	labels := []string{"_bordering_ T1", "_alphabetical_ T001"}
-	teamIds := []string{"T1", "T001"}
-	err := SortAlphaNumeric(items, labels, teamIds)
+	teamIDs := []string{"T1", "T001"}
+	err := SortAlphaNumeric(items, labels, teamIDs)
 	require.NoError(t, err)
 
 	require.Equal(t, "alphabetical", items[0])
 	require.Equal(t, "_alphabetical_ T001", labels[0])
-	require.Equal(t, "T001", teamIds[0])
+	require.Equal(t, "T001", teamIDs[0])
 
 	require.Equal(t, "bordering", items[1])
 	require.Equal(t, "_bordering_ T1", labels[1])
-	require.Equal(t, "T1", teamIds[1])
+	require.Equal(t, "T1", teamIDs[1])
 }
 
 func TestSortAlphaNumeric_Unbalanced(t *testing.T) {
 	items := []string{"bordering", "alphabetical"}
 	labels := []string{"_bordering_ T1"} // oops
-	teamIds := []string{"T1"}            // also oops
-	err := SortAlphaNumeric(items, labels, teamIds)
+	teamIDs := []string{"T1"}            // also oops
+	err := SortAlphaNumeric(items, labels, teamIDs)
 	expected := slackerror.New(slackerror.ErrTeamList)
 
 	require.Equal(t, err, expected)
@@ -4898,7 +4898,7 @@ func Test_ValidateGetOrgWorkspaceGrant(t *testing.T) {
 				Auth: types.SlackAuth{IsEnterpriseInstall: true},
 			},
 			mockPrompt: func(clientsMock *shared.ClientsMock) {
-				clientsMock.ApiInterface.On("AuthTeamsList", mock.Anything, mock.Anything, mock.Anything).Return(
+				clientsMock.APIInterface.On("AuthTeamsList", mock.Anything, mock.Anything, mock.Anything).Return(
 					[]types.TeamInfo{
 						{ID: "T1", Name: "team1"},
 						{ID: "T2", Name: "team2"},
@@ -4923,7 +4923,7 @@ func Test_ValidateGetOrgWorkspaceGrant(t *testing.T) {
 				Auth: types.SlackAuth{IsEnterpriseInstall: true},
 			},
 			mockPrompt: func(clientsMock *shared.ClientsMock) {
-				clientsMock.ApiInterface.On("AuthTeamsList", mock.Anything, mock.Anything, mock.Anything).Return(
+				clientsMock.APIInterface.On("AuthTeamsList", mock.Anything, mock.Anything, mock.Anything).Return(
 					[]types.TeamInfo{
 						{ID: "T1", Name: "team1"},
 						{ID: "T2", Name: "team2"},
@@ -4948,7 +4948,7 @@ func Test_ValidateGetOrgWorkspaceGrant(t *testing.T) {
 				Auth: types.SlackAuth{IsEnterpriseInstall: true},
 			},
 			mockPrompt: func(clientsMock *shared.ClientsMock) {
-				clientsMock.ApiInterface.On("AuthTeamsList", mock.Anything, mock.Anything, mock.Anything).Return(
+				clientsMock.APIInterface.On("AuthTeamsList", mock.Anything, mock.Anything, mock.Anything).Return(
 					[]types.TeamInfo{
 						{ID: "T1", Name: "team1"},
 						{ID: "T2", Name: "team2"},
@@ -5004,7 +5004,7 @@ func Test_ValidateAuth(t *testing.T) {
 		apiGenerateAuthTicketResultError    error
 		apiValidateSessionResponse          api.AuthSession
 		apiValidateSessionError             error
-		authIsApiHostSlackProdResponse      bool
+		authIsAPIHostSlackProdResponse      bool
 		authSetAuthResponse                 types.SlackAuth
 		authSetAuthError                    error
 		ioIsTTYResponse                     bool
@@ -5019,11 +5019,11 @@ func Test_ValidateAuth(t *testing.T) {
 		},
 		"revalidates an expired authentication on a dev instance": {
 			authProvided: types.SlackAuth{
-				ApiHost: &apiHostDev,
+				APIHost: &apiHostDev,
 				Token:   "xoxb-development",
 			},
 			authExpected: types.SlackAuth{
-				ApiHost:    &apiHostDev,
+				APIHost:    &apiHostDev,
 				TeamDomain: team1TeamDomain,
 				TeamID:     team1TeamID,
 				Token:      fakeAuthsByTeamDomain[team1TeamDomain].Token,
@@ -5038,7 +5038,7 @@ func Test_ValidateAuth(t *testing.T) {
 			apiValidateSessionError:             slackerror.New(slackerror.ErrInvalidAuth),
 			authFilteredKnownAuthErrorsResponse: true,
 			authFilteredKnownAuthErrorsError:    nil,
-			authIsApiHostSlackProdResponse:      false,
+			authIsAPIHostSlackProdResponse:      false,
 			ioIsTTYResponse:                     true,
 		},
 		"returns unexpected errors from validate session": {
@@ -5085,7 +5085,7 @@ func Test_ValidateAuth(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := shared.NewClientsMock()
-			clientsMock.ApiInterface.On(
+			clientsMock.APIInterface.On(
 				"ExchangeAuthTicket",
 				mock.Anything,
 				mock.Anything,
@@ -5095,7 +5095,7 @@ func Test_ValidateAuth(t *testing.T) {
 				tt.apiExchangeAuthTicketResultResponse,
 				tt.apiExchangeAuthTicketResultError,
 			)
-			clientsMock.ApiInterface.On(
+			clientsMock.APIInterface.On(
 				"GenerateAuthTicket",
 				mock.Anything,
 				mock.Anything,
@@ -5104,18 +5104,18 @@ func Test_ValidateAuth(t *testing.T) {
 				tt.apiGenerateAuthTicketResultResponse,
 				tt.apiGenerateAuthTicketResultError,
 			)
-			if tt.authProvided.ApiHost != nil {
-				clientsMock.ApiInterface.On(
+			if tt.authProvided.APIHost != nil {
+				clientsMock.APIInterface.On(
 					"Host",
 				).Return(
-					*tt.authProvided.ApiHost,
+					*tt.authProvided.APIHost,
 				)
 			}
-			clientsMock.ApiInterface.On(
+			clientsMock.APIInterface.On(
 				"SetHost",
 				mock.Anything,
 			)
-			clientsMock.ApiInterface.On(
+			clientsMock.APIInterface.On(
 				"ValidateSession",
 				mock.Anything,
 				tt.authProvided.Token,
@@ -5132,10 +5132,10 @@ func Test_ValidateAuth(t *testing.T) {
 				tt.authFilteredKnownAuthErrorsError,
 			)
 			clientsMock.AuthInterface.On(
-				"IsApiHostSlackProd",
+				"IsAPIHostSlackProd",
 				mock.Anything,
 			).Return(
-				tt.authIsApiHostSlackProdResponse,
+				tt.authIsAPIHostSlackProdResponse,
 			)
 			clientsMock.AuthInterface.On(
 				"SetAuth",
@@ -5174,8 +5174,8 @@ func Test_ValidateAuth(t *testing.T) {
 
 			tt.authProvided.LastUpdated = time.Time{} // ignore time for this test
 			assert.Equal(t, tt.expectedErr, err)
-			if tt.authExpected.ApiHost != nil {
-				clientsMock.ApiInterface.AssertCalled(t, "SetHost", *tt.authExpected.ApiHost)
+			if tt.authExpected.APIHost != nil {
+				clientsMock.APIInterface.AssertCalled(t, "SetHost", *tt.authExpected.APIHost)
 			}
 			assert.Equal(t, tt.authExpected, tt.authProvided)
 		})
@@ -5186,22 +5186,22 @@ func Test_ValidateAuth(t *testing.T) {
 func mockReauthentication(clientsMock *shared.ClientsMock) {
 	// Default mocks
 	clientsMock.Os.AddDefaultMocks()
-	clientsMock.ApiInterface.AddDefaultMocks()
+	clientsMock.APIInterface.AddDefaultMocks()
 	// Enable interactivity
 	clientsMock.IO.On("IsTTY").Return(true)
 	clientsMock.IO.AddDefaultMocks()
 
 	// Mock invalid auth response
-	clientsMock.ApiInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, fmt.Errorf(slackerror.ErrInvalidAuth))
+	clientsMock.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, fmt.Errorf(slackerror.ErrInvalidAuth))
 	clientsMock.AuthInterface.On("FilterKnownAuthErrors", mock.Anything, mock.Anything).Return(true, nil)
 	// Mocks for reauthentication
-	clientsMock.ApiInterface.On("GenerateAuthTicket", mock.Anything, mock.Anything, mock.Anything).Return(api.GenerateAuthTicketResult{}, nil)
+	clientsMock.APIInterface.On("GenerateAuthTicket", mock.Anything, mock.Anything, mock.Anything).Return(api.GenerateAuthTicketResult{}, nil)
 	clientsMock.IO.On("InputPrompt", mock.Anything, "Enter challenge code", iostreams.InputPromptConfig{
 		Required: true,
 	}).Return("challengeCode", nil)
-	clientsMock.ApiInterface.On("ExchangeAuthTicket", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.ExchangeAuthTicketResult{Token: fakeAuthsByTeamDomain[team1TeamDomain].Token, TeamDomain: team1TeamDomain,
+	clientsMock.APIInterface.On("ExchangeAuthTicket", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.ExchangeAuthTicketResult{Token: fakeAuthsByTeamDomain[team1TeamDomain].Token, TeamDomain: team1TeamDomain,
 		TeamID: team1TeamID, UserID: "U1"}, nil)
-	clientsMock.AuthInterface.On("IsApiHostSlackProd", mock.Anything).Return(true)
+	clientsMock.AuthInterface.On("IsAPIHostSlackProd", mock.Anything).Return(true)
 	clientsMock.AuthInterface.On("SetAuth", mock.Anything, mock.Anything).Return(types.SlackAuth{}, "", nil)
 	clientsMock.AuthInterface.On("SetSelectedAuth", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 }

--- a/internal/prompts/app_select_test.go
+++ b/internal/prompts/app_select_test.go
@@ -324,7 +324,7 @@ func TestGetTokenApp(t *testing.T) {
 			appFlag:   "A01001101",
 			appStatus: api.GetAppStatusResult{},
 			appInfo:   types.App{},
-			statusErr: slackerror.New(slackerror.ErrHttpRequestFailed),
+			statusErr: slackerror.New(slackerror.ErrHTTPRequestFailed),
 		},
 		"error if no app status is returned": {
 			tokenFlag: team1Token,
@@ -5048,10 +5048,10 @@ func Test_ValidateAuth(t *testing.T) {
 			authExpected: types.SlackAuth{
 				Token: "xoxb-testing",
 			},
-			expectedErr:                         slackerror.New(slackerror.ErrHttpRequestFailed),
-			apiValidateSessionError:             slackerror.New(slackerror.ErrHttpRequestFailed),
+			expectedErr:                         slackerror.New(slackerror.ErrHTTPRequestFailed),
+			apiValidateSessionError:             slackerror.New(slackerror.ErrHTTPRequestFailed),
 			authFilteredKnownAuthErrorsResponse: false,
-			authFilteredKnownAuthErrorsError:    slackerror.New(slackerror.ErrHttpRequestFailed),
+			authFilteredKnownAuthErrorsError:    slackerror.New(slackerror.ErrHTTPRequestFailed),
 		},
 		"errors without revalidation if the terminal is not interactive": {
 			authProvided: types.SlackAuth{

--- a/internal/prompts/function_permissions.go
+++ b/internal/prompts/function_permissions.go
@@ -30,9 +30,9 @@ func AccessLabels(current types.Permission) ([]string, []types.Permission) {
 	distributions := []types.Permission{}
 	distributionLabels := []string{}
 	optionLabels := map[types.Permission]string{
-		types.APP_COLLABORATORS: "app collaborators only",
-		types.EVERYONE:          "everyone",
-		types.NAMED_ENTITIES:    "specific users",
+		types.PermissionAppCollaborators: "app collaborators only",
+		types.PermissionEveryone:         "everyone",
+		types.PermissionNamedEntities:    "specific users",
 	}
 
 	distributionLabels = append(distributionLabels, fmt.Sprintf("%s (current)", optionLabels[current]))

--- a/internal/prompts/trigger_permissions.go
+++ b/internal/prompts/trigger_permissions.go
@@ -32,9 +32,9 @@ func TriggerAccessLabels(current types.Permission) ([]string, []types.Permission
 	distributions := []types.Permission{}
 	distributionLabels := []string{}
 	optionLabels := map[types.Permission]string{
-		types.APP_COLLABORATORS: "app collaborators only",
-		types.EVERYONE:          "everyone",
-		types.NAMED_ENTITIES:    "specific entities",
+		types.PermissionAppCollaborators: "app collaborators only",
+		types.PermissionEveryone:         "everyone",
+		types.PermissionNamedEntities:    "specific entities",
 	}
 
 	distributionLabels = append(distributionLabels, fmt.Sprintf("%s (current)", optionLabels[current]))
@@ -130,7 +130,7 @@ func TriggerChooseNamedEntityPrompt(ctx context.Context, clients *shared.ClientF
 	}
 
 	shouldAddCollaborators := false
-	if strings.HasPrefix(selectedAction, "add_") && currentAccessType != types.NAMED_ENTITIES && !hasIncludeAppCollabFlag {
+	if strings.HasPrefix(selectedAction, "add_") && currentAccessType != types.PermissionNamedEntities && !hasIncludeAppCollabFlag {
 		shouldAddCollaborators, err = AddAppCollaboratorsToNamedEntitiesPrompt(ctx, clients.IO)
 		if err != nil {
 			return "", "", false, err

--- a/internal/shared/clients.go
+++ b/internal/shared/clients.go
@@ -204,7 +204,7 @@ func (c *ClientFactory) InitSDKConfig(ctx context.Context, dirPath string) error
 		hooksJSONFilePath = filepath.Join(dirPath, "slack.json")
 		info, err = c.Fs.Stat(hooksJSONFilePath)
 		if err == nil && !info.IsDir() {
-			c.IO.PrintDebug(ctx, "%s", slackerror.New(slackerror.ErrSlackJsonLocation))
+			c.IO.PrintDebug(ctx, "%s", slackerror.New(slackerror.ErrSlackJSONLocation))
 			break
 		}
 		// Next, search for the hooks files in the outdated path
@@ -214,7 +214,7 @@ func (c *ClientFactory) InitSDKConfig(ctx context.Context, dirPath string) error
 		hooksJSONFilePath = filepath.Join(dirPath, ".slack", "slack.json")
 		info, err = c.Fs.Stat(hooksJSONFilePath)
 		if err == nil && !info.IsDir() {
-			c.IO.PrintWarning(ctx, "%s", slackerror.New(slackerror.ErrSlackSlackJsonLocation))
+			c.IO.PrintWarning(ctx, "%s", slackerror.New(slackerror.ErrSlackSlackJSONLocation))
 			break
 		}
 		// Next, search for the hooks files in the outdated path

--- a/internal/shared/clients.go
+++ b/internal/shared/clients.go
@@ -46,7 +46,7 @@ import (
 type ClientFactory struct {
 	// Internal dependencies
 
-	ApiInterface func() api.ApiInterface
+	APIInterface func() api.APIInterface
 
 	AppClient    func() *app.Client
 	Config       *config.Config
@@ -100,7 +100,7 @@ func NewClientFactory(options ...func(*ClientFactory)) *ClientFactory {
 		IO: clients.IO,
 	}
 	clients.EventTracker = tracking.NewEventTracker()
-	clients.ApiInterface = clients.defaultApiInterfaceFunc
+	clients.APIInterface = clients.defaultAPIInterfaceFunc
 	clients.AppClient = clients.defaultAppClientFunc
 	clients.AuthInterface = clients.defaultAuthInterfaceFunc
 	clients.Browser = clients.defaultBrowserFunc
@@ -112,7 +112,7 @@ func NewClientFactory(options ...func(*ClientFactory)) *ClientFactory {
 
 	// TODO: Temporary hack to get around circular dependency in internal/api/client.go since that imports version
 	// Follows pattern demonstrated by the GitHub CLI here https://github.com/cli/cli/blob/5a46c1cab601a3394caa8de85adb14f909b811e9/pkg/cmd/factory/default.go#L29
-	// Used by the ApiClient for its userAgent
+	// Used by the APIClient for its userAgent
 	// Currently needed because trying to get the version of the CLI from pkg/version/version.go would cause a circular dependency
 	// We can get rid of this once we refactor the code relationship between pkg/ and internal/
 	// userAgent can get Slack CLI version from context which is defined in main.go, this approach bypass circular dependency. The clients.CliVersion is retained for future code refactor purpose and serve SetVersion function
@@ -127,24 +127,24 @@ func NewClientFactory(options ...func(*ClientFactory)) *ClientFactory {
 	return clients
 }
 
-// defaultApiClientFunc return a new API Client using the ConfigApiHost
-func (c *ClientFactory) defaultApiClientFunc() *api.Client {
-	return api.NewClient(nil, c.Config.ApiHostResolved, c.IO)
+// defaultAPIClientFunc return a new API Client using the ConfigAPIHost
+func (c *ClientFactory) defaultAPIClientFunc() *api.Client {
+	return api.NewClient(nil, c.Config.APIHostResolved, c.IO)
 }
 
-// defaultApiInterfaceFunc return a new API Client using the ConfigApiHost
-func (c *ClientFactory) defaultApiInterfaceFunc() api.ApiInterface {
-	return c.defaultApiClientFunc()
+// defaultAPIInterfaceFunc return a new API Client using the ConfigAPIHost
+func (c *ClientFactory) defaultAPIInterfaceFunc() api.APIInterface {
+	return c.defaultAPIClientFunc()
 }
 
 // defaultAppClientFunc return a new App Client
 func (c *ClientFactory) defaultAppClientFunc() *app.Client {
-	return app.NewClient(c.ApiInterface(), c.Config, c.Fs, c.Os)
+	return app.NewClient(c.APIInterface(), c.Config, c.Fs, c.Os)
 }
 
 // defaultAuthClientFunc return a new Auth Client
 func (c *ClientFactory) defaultAuthClientFunc() *auth.Client {
-	return auth.NewClient(c.ApiInterface(), c.AppClient(), c.Config, c.IO, c.Fs)
+	return auth.NewClient(c.APIInterface(), c.AppClient(), c.Config, c.IO, c.Fs)
 }
 
 // defaultAuthInterfaceFunc return a new Auth Interface
@@ -231,13 +231,13 @@ func (c *ClientFactory) InitSDKConfig(ctx context.Context, dirPath string) error
 		slackConfigDirPath := filepath.Join(dirPath, ".slack")
 		info, err = c.Fs.Stat(slackConfigDirPath)
 		if err == nil && info.IsDir() {
-			return slackerror.New(slackerror.ErrHooksJsonLocation)
+			return slackerror.New(slackerror.ErrHooksJSONLocation)
 		}
 		// Return an error if we have reached the user home directory, root directory,
 		// system root volume, or "." (returned by Dir when all path elements are removed)
 		switch dirPath {
 		case homeDir, "/", filepath.VolumeName(os.Getenv("SYSTEMROOT")) + "\\", ".":
-			return slackerror.New(slackerror.ErrHooksJsonLocation)
+			return slackerror.New(slackerror.ErrHooksJSONLocation)
 		}
 		// Move upward one directory level
 		dirPath = filepath.Dir(dirPath)
@@ -272,7 +272,7 @@ func (c *ClientFactory) InitSDKConfigFromJSON(ctx context.Context, configFileByt
 	getHooksConfig := GetHooksConfig{}
 	err := json.Unmarshal(configFileBytes, &getHooksConfig)
 	if err != nil {
-		return slackerror.JsonUnmarshalError(err, configFileBytes)
+		return slackerror.JSONUnmarshalError(err, configFileBytes)
 	}
 
 	// When GetHooks is available, load the scripts as the default values
@@ -281,7 +281,7 @@ func (c *ClientFactory) InitSDKConfigFromJSON(ctx context.Context, configFileByt
 	if getHooksConfig.Hooks.GetHooks.IsAvailable() {
 		getHooksConfig.Hooks.GetHooks.Name = "GetHooks"
 		getHooksArgs := map[string]string{}
-		if devInstanceHostname := getDevHostname(c.Config.ApiHostResolved); devInstanceHostname != "" {
+		if devInstanceHostname := getDevHostname(c.Config.APIHostResolved); devInstanceHostname != "" {
 			getHooksArgs[sdkSlackDevDomainFlag] = devInstanceHostname
 			getHooksArgs[sdkUnsafelyIgnoreCertErrorsFlag] = devInstanceHostname
 		}

--- a/internal/shared/clients_mock.go
+++ b/internal/shared/clients_mock.go
@@ -32,7 +32,7 @@ import (
 // ClientsMock defines mocks that will override aspects of clients for testing purposes.
 type ClientsMock struct {
 	mock.Mock
-	ApiInterface  *api.ApiMock
+	APIInterface  *api.APIMock
 	AuthInterface *auth.AuthMock
 	AppClient     *app.Client
 	Browser       *slackdeps.BrowserMock
@@ -52,7 +52,7 @@ func NewClientsMock() *ClientsMock {
 	clientsMock := &ClientsMock{}
 
 	// Set the mocked members
-	clientsMock.ApiInterface = &api.ApiMock{}
+	clientsMock.APIInterface = &api.APIMock{}
 	clientsMock.AuthInterface = &auth.AuthMock{}
 	clientsMock.Browser = slackdeps.NewBrowserMock()
 	clientsMock.Cobra = slackdeps.NewCobraMock()
@@ -71,7 +71,7 @@ func NewClientsMock() *ClientsMock {
 
 // AddDefaultMocks installs the default mock actions to fallback on.
 func (m *ClientsMock) AddDefaultMocks() {
-	m.ApiInterface.AddDefaultMocks()
+	m.APIInterface.AddDefaultMocks()
 	m.AuthInterface.AddDefaultMocks()
 	m.Browser.AddDefaultMocks()
 	m.Cobra.AddDefaultMocks()
@@ -91,7 +91,7 @@ func (m *ClientsMock) MockClientFactory() func(c *ClientFactory) {
 		clients.Os = m.Os
 		clients.IO = m.IO
 		clients.Fs = m.Fs
-		clients.ApiInterface = func() api.ApiInterface { return m.ApiInterface }
+		clients.APIInterface = func() api.APIInterface { return m.APIInterface }
 		clients.AuthInterface = func() auth.AuthInterface { return m.AuthInterface }
 		clients.AppClient = func() *app.Client { return m.AppClient }
 		clients.HookExecutor = &m.HookExecutor

--- a/internal/shared/clients_test.go
+++ b/internal/shared/clients_test.go
@@ -243,7 +243,7 @@ func Test_ClientFactory_InitSDKConfigFromJSON_brokenJSONFile(t *testing.T) {
 	getHooksJson := `{"hooks":{"get-hooks":`
 	err := clients.InitSDKConfigFromJSON(ctx, []byte(getHooksJson))
 	require.Error(t, err)
-	assert.Equal(t, slackerror.New(slackerror.ErrUnableToParseJson).Code, slackerror.ToSlackError(err).Code)
+	assert.Equal(t, slackerror.New(slackerror.ErrUnableToParseJSON).Code, slackerror.ToSlackError(err).Code)
 }
 
 func setupGetHooksScript(t *testing.T) string {

--- a/internal/shared/clients_test.go
+++ b/internal/shared/clients_test.go
@@ -45,7 +45,7 @@ func Test_ClientFactory_FunctionalOptions(t *testing.T) {
 	require.True(t, clients.Config.SlackDevFlag, "default should be true")
 }
 
-const GET_HOOKS_BIN = `#!/bin/sh
+const getHooksScript = `#!/bin/sh
 	echo "{\"hooks\": {\"start\": \"echo 'start' $@\"}}"
 `
 
@@ -96,19 +96,19 @@ func Test_ClientFactory_InitSDKConfig(t *testing.T) {
 			mockHooksJSONContent:  "{}",
 			mockHooksJSONFilePath: filepath.Join(slackdeps.MockHomeDirectory, "project", ".slack", "apps.json"),
 			mockWorkingDirectory:  filepath.Join(slackdeps.MockHomeDirectory, "project"),
-			expectedError:         slackerror.New(slackerror.ErrHooksJsonLocation),
+			expectedError:         slackerror.New(slackerror.ErrHooksJSONLocation),
 		},
 		"errors if no project configuration directory exists": {
 			mockHooksJSONContent:  "{}",
 			mockHooksJSONFilePath: filepath.Join(slackdeps.MockHomeDirectory, "project", "package.json"),
 			mockWorkingDirectory:  filepath.Join(slackdeps.MockHomeDirectory, "project"),
-			expectedError:         slackerror.New(slackerror.ErrHooksJsonLocation),
+			expectedError:         slackerror.New(slackerror.ErrHooksJSONLocation),
 		},
 		"errors if no project configuration directory exists and searched upward to system root directory": {
 			mockHooksJSONContent:  "{}",
 			mockHooksJSONFilePath: filepath.Join("path", "outside", "home", "to", "project", "package.json"),
 			mockWorkingDirectory:  filepath.Join("path", "outside", "home", "to", "project"),
-			expectedError:         slackerror.New(slackerror.ErrHooksJsonLocation),
+			expectedError:         slackerror.New(slackerror.ErrHooksJSONLocation),
 		},
 	}
 	for name, tt := range tests {
@@ -133,8 +133,8 @@ func Test_ClientFactory_InitSDKConfigFromJSON(t *testing.T) {
 	ctx := slackcontext.MockContext(t.Context())
 	path := setupGetHooksScript(t)
 	clients := NewClientFactory()
-	getHooksJson := fmt.Sprintf(`{"hooks":{"get-hooks": "%s"}}`, path)
-	if err := clients.InitSDKConfigFromJSON(ctx, []byte(getHooksJson)); err != nil {
+	getHooksJSON := fmt.Sprintf(`{"hooks":{"get-hooks": "%s"}}`, path)
+	if err := clients.InitSDKConfigFromJSON(ctx, []byte(getHooksJSON)); err != nil {
 		t.Errorf("error init'ing SDK from JSON %s", err)
 	}
 	require.True(t, clients.SDKConfig.Hooks.GetHooks.IsAvailable())
@@ -147,9 +147,9 @@ func Test_ClientFactory_InitSDKConfigFromJSON_reflectionSetsNameProperty(t *test
 	ctx := slackcontext.MockContext(t.Context())
 	path := setupGetHooksScript(t)
 	clients := NewClientFactory()
-	getHooksJson := fmt.Sprintf(`{"hooks":{"get-hooks": "%s", "get-trigger": "echo {}", "": "echo {}"}}`, path)
+	getHooksJSON := fmt.Sprintf(`{"hooks":{"get-hooks": "%s", "get-trigger": "echo {}", "": "echo {}"}}`, path)
 	// Execute test
-	if err := clients.InitSDKConfigFromJSON(ctx, []byte(getHooksJson)); err != nil {
+	if err := clients.InitSDKConfigFromJSON(ctx, []byte(getHooksJSON)); err != nil {
 		t.Errorf("error init'ing SDK from JSON %s", err)
 	}
 	// Check
@@ -162,9 +162,9 @@ func Test_ClientFactory_InitSDKConfigFromJSON_numberedDevInstance(t *testing.T) 
 	ctx := slackcontext.MockContext(t.Context())
 	path := setupGetHooksScript(t)
 	clients := NewClientFactory()
-	getHooksJson := fmt.Sprintf(`{"hooks":{"get-hooks": "%s"}}`, path)
-	clients.Config.ApiHostResolved = "https://dev1234.slack.com"
-	if err := clients.InitSDKConfigFromJSON(ctx, []byte(getHooksJson)); err != nil {
+	getHooksJSON := fmt.Sprintf(`{"hooks":{"get-hooks": "%s"}}`, path)
+	clients.Config.APIHostResolved = "https://dev1234.slack.com"
+	if err := clients.InitSDKConfigFromJSON(ctx, []byte(getHooksJSON)); err != nil {
 		t.Errorf("error init'ing SDK from JSON %s", err)
 	}
 	require.True(t, clients.SDKConfig.Hooks.GetHooks.IsAvailable())
@@ -176,9 +176,9 @@ func Test_ClientFactory_InitSDKConfigFromJSON_dev(t *testing.T) {
 	ctx := slackcontext.MockContext(t.Context())
 	path := setupGetHooksScript(t)
 	clients := NewClientFactory()
-	getHooksJson := fmt.Sprintf(`{"hooks":{"get-hooks": "%s"}}`, path)
-	clients.Config.ApiHostResolved = "https://dev.slack.com"
-	if err := clients.InitSDKConfigFromJSON(ctx, []byte(getHooksJson)); err != nil {
+	getHooksJSON := fmt.Sprintf(`{"hooks":{"get-hooks": "%s"}}`, path)
+	clients.Config.APIHostResolved = "https://dev.slack.com"
+	if err := clients.InitSDKConfigFromJSON(ctx, []byte(getHooksJSON)); err != nil {
 		t.Errorf("error init'ing SDK from JSON %s", err)
 	}
 	require.True(t, clients.SDKConfig.Hooks.GetHooks.IsAvailable())
@@ -190,9 +190,9 @@ func Test_ClientFactory_InitSDKConfigFromJSON_qa(t *testing.T) {
 	ctx := slackcontext.MockContext(t.Context())
 	path := setupGetHooksScript(t)
 	clients := NewClientFactory()
-	getHooksJson := fmt.Sprintf(`{"hooks":{"get-hooks": "%s"}}`, path)
-	clients.Config.ApiHostResolved = "https://qa.slack.com"
-	if err := clients.InitSDKConfigFromJSON(ctx, []byte(getHooksJson)); err != nil {
+	getHooksJSON := fmt.Sprintf(`{"hooks":{"get-hooks": "%s"}}`, path)
+	clients.Config.APIHostResolved = "https://qa.slack.com"
+	if err := clients.InitSDKConfigFromJSON(ctx, []byte(getHooksJSON)); err != nil {
 		t.Errorf("error init'ing SDK from JSON %s", err)
 	}
 	require.True(t, clients.SDKConfig.Hooks.GetHooks.IsAvailable())
@@ -204,8 +204,8 @@ func Test_ClientFactory_InitSDKConfigFromJSON_mergesExistingFile(t *testing.T) {
 	ctx := slackcontext.MockContext(t.Context())
 	path := setupGetHooksScript(t)
 	clients := NewClientFactory()
-	getHooksJson := fmt.Sprintf(`{"hooks":{"get-hooks": "%s", "start": "foobar"}}`, path)
-	if err := clients.InitSDKConfigFromJSON(ctx, []byte(getHooksJson)); err != nil {
+	getHooksJSON := fmt.Sprintf(`{"hooks":{"get-hooks": "%s", "start": "foobar"}}`, path)
+	if err := clients.InitSDKConfigFromJSON(ctx, []byte(getHooksJSON)); err != nil {
 		t.Errorf("error init'ing SDK from JSON %s", err)
 	}
 	require.True(t, clients.SDKConfig.Hooks.GetHooks.IsAvailable())
@@ -216,10 +216,10 @@ func Test_ClientFactory_InitSDKConfigFromJSON_mergesExistingFile(t *testing.T) {
 func Test_ClientFactory_InitSDKConfigFromJSON_noGetHooks(t *testing.T) {
 	ctx := slackcontext.MockContext(t.Context())
 	clients := NewClientFactory()
-	getHooksJson := `{"hooks":{"start": "foobar"}}`
-	clients.Config.ApiHostResolved = "https://dev1234.slack.com"
+	getHooksJSON := `{"hooks":{"start": "foobar"}}`
+	clients.Config.APIHostResolved = "https://dev1234.slack.com"
 	clients.Config.SlackDevFlag = true
-	if err := clients.InitSDKConfigFromJSON(ctx, []byte(getHooksJson)); err != nil {
+	if err := clients.InitSDKConfigFromJSON(ctx, []byte(getHooksJSON)); err != nil {
 		t.Errorf("error init'ing SDK from JSON %s", err)
 	}
 	require.False(t, clients.SDKConfig.Hooks.GetHooks.IsAvailable())
@@ -230,8 +230,8 @@ func Test_ClientFactory_InitSDKConfigFromJSON_noGetHooks(t *testing.T) {
 func Test_ClientFactory_InitSDKConfigFromJSON_brokenGetHooks(t *testing.T) {
 	ctx := slackcontext.MockContext(t.Context())
 	clients := NewClientFactory()
-	getHooksJson := `{"hooks":{"get-hooks": "unknown-command"}}`
-	err := clients.InitSDKConfigFromJSON(ctx, []byte(getHooksJson))
+	getHooksJSON := `{"hooks":{"get-hooks": "unknown-command"}}`
+	err := clients.InitSDKConfigFromJSON(ctx, []byte(getHooksJSON))
 	require.Error(t, err)
 	assert.Equal(t, slackerror.New(slackerror.ErrSDKHookInvocationFailed).Code, slackerror.ToSlackError(err).Code)
 	assert.Contains(t, slackerror.ToSlackError(err).Message, "Command for 'GetHooks' returned an error")
@@ -240,8 +240,8 @@ func Test_ClientFactory_InitSDKConfigFromJSON_brokenGetHooks(t *testing.T) {
 func Test_ClientFactory_InitSDKConfigFromJSON_brokenJSONFile(t *testing.T) {
 	ctx := slackcontext.MockContext(t.Context())
 	clients := NewClientFactory()
-	getHooksJson := `{"hooks":{"get-hooks":`
-	err := clients.InitSDKConfigFromJSON(ctx, []byte(getHooksJson))
+	getHooksJSON := `{"hooks":{"get-hooks":`
+	err := clients.InitSDKConfigFromJSON(ctx, []byte(getHooksJSON))
 	require.Error(t, err)
 	assert.Equal(t, slackerror.New(slackerror.ErrUnableToParseJSON).Code, slackerror.ToSlackError(err).Code)
 }
@@ -249,7 +249,7 @@ func Test_ClientFactory_InitSDKConfigFromJSON_brokenJSONFile(t *testing.T) {
 func setupGetHooksScript(t *testing.T) string {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "get-hooks.sh")
-	err := os.WriteFile(path, []byte(GET_HOOKS_BIN), 0700)
+	err := os.WriteFile(path, []byte(getHooksScript), 0700)
 	if err != nil {
 		t.Errorf("Failed to write file %s", err)
 	}

--- a/internal/shared/types/activity.go
+++ b/internal/shared/types/activity.go
@@ -15,8 +15,8 @@
 package types
 
 type ActivityArgs struct {
-	TeamId            string
-	AppId             string
+	TeamID            string
+	AppID             string
 	TailArg           bool
 	Browser           bool
 	PollingIntervalMS int
@@ -27,9 +27,9 @@ type ActivityArgs struct {
 	MinLevel          string
 	EventType         string
 	ComponentType     string
-	ComponentId       string
+	ComponentID       string
 	Source            string
-	TraceId           string
+	TraceID           string
 }
 
 type ActivityLevel string
@@ -46,31 +46,31 @@ const (
 type EventType string
 
 const (
-	DATASTORE_REQUEST_RESULT            EventType = "datastore_request_result"
-	EXTERNAL_AUTH_MISSING_FUNCTION      EventType = "external_auth_missing_function"
-	EXTERNAL_AUTH_MISSING_SELECTED_AUTH EventType = "external_auth_missing_oauth_token_or_selected_auth"
-	EXTERNAL_AUTH_RESULT                EventType = "external_auth_result"
-	EXTERNAL_AUTH_STARTED               EventType = "external_auth_started"
-	EXTERNAL_AUTH_TOKEN_FETCH_RESULT    EventType = "external_auth_token_fetch_result"
-	FUNCTION_DEPLOYMENT                 EventType = "function_deployment"
-	FUNCTION_EXECUTION_OUTPUT           EventType = "function_execution_output"
-	TRIGGER_PAYLOAD_RECEIVED            EventType = "trigger_payload_received"
-	FUNCTION_EXECUTION_RESULT           EventType = "function_execution_result"
-	FUNCTION_EXECUTION_STARTED          EventType = "function_execution_started"
-	TRIGGER_EXECUTED                    EventType = "trigger_executed"
-	WORKFLOW_BILLING_RESULT             EventType = "workflow_billing_result"
-	WORKFLOW_BOT_INVITED                EventType = "workflow_bot_invited"
-	WORKFLOW_CREATED_FROM_TEMPLATE      EventType = "workflow_created_from_template"
-	WORKFLOW_EXECUTION_RESULT           EventType = "workflow_execution_result"
-	WORKFLOW_EXECUTION_STARTED          EventType = "workflow_execution_started"
-	WORKFLOW_PUBLISHED                  EventType = "workflow_published"
-	WORKFLOW_STEP_EXECUTION_RESULT      EventType = "workflow_step_execution_result"
-	WORKFLOW_STEP_STARTED               EventType = "workflow_step_started"
-	WORKFLOW_UNPUBLISHED                EventType = "workflow_unpublished"
+	DatastoreRequestResult          EventType = "datastore_request_result"
+	ExternalAuthMissingFunction     EventType = "external_auth_missing_function"
+	ExternalAuthMissingSelectedAuth EventType = "external_auth_missing_oauth_token_or_selected_auth"
+	ExternalAuthResult              EventType = "external_auth_result"
+	ExternalAuthStarted             EventType = "external_auth_started"
+	ExternalAuthTokenFetchResult    EventType = "external_auth_token_fetch_result"
+	FunctionDeployment              EventType = "function_deployment"
+	FunctionExecutionOutput         EventType = "function_execution_output"
+	FunctionExecutionResult         EventType = "function_execution_result"
+	FunctionExecutionStarted        EventType = "function_execution_started"
+	TriggerExecuted                 EventType = "trigger_executed"
+	TriggerPayloadReceived          EventType = "trigger_payload_received"
+	WorkflowBillingResult           EventType = "workflow_billing_result"
+	WorkflowBotInvited              EventType = "workflow_bot_invited"
+	WorkflowCreatedFromTemplate     EventType = "workflow_created_from_template"
+	WorkflowExecutionResult         EventType = "workflow_execution_result"
+	WorkflowExecutionStarted        EventType = "workflow_execution_started"
+	WorkflowPublished               EventType = "workflow_published"
+	WorkflowStepExecutionResult     EventType = "workflow_step_execution_result"
+	WorkflowStepStarted             EventType = "workflow_step_started"
+	WorkflowUnpublished             EventType = "workflow_unpublished"
 )
 
 type ActivityRequest struct {
-	AppId              string `json:"app_id"`
+	AppID              string `json:"app_id"`
 	NextCursor         string `json:"cursor,omitempty"`
 	Limit              int    `json:"limit,omitempty"`
 	MinimumDateCreated int64  `json:"min_date_created,omitempty"`
@@ -78,7 +78,7 @@ type ActivityRequest struct {
 	MinimumLogLevel    string `json:"min_log_level,omitempty"`
 	EventType          string `json:"log_event_type,omitempty"`
 	ComponentType      string `json:"component_type,omitempty"`
-	ComponentId        string `json:"component_id,omitempty"`
+	ComponentID        string `json:"component_id,omitempty"`
 	Source             string `json:"source,omitempty"`
-	TraceId            string `json:"trace_id,omitempty"`
+	TraceID            string `json:"trace_id,omitempty"`
 }

--- a/internal/shared/types/app_manifest.go
+++ b/internal/shared/types/app_manifest.go
@@ -20,7 +20,7 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-const SCHEMA_VERSION = 1
+const SchemaVersion = 1
 
 // omitempty should be consistent across yaml and json marshalling
 // for yaml, are we always using flow style? most properties have it, but when
@@ -99,7 +99,7 @@ type AppSettings struct {
 	Interactivity          *ManifestInteractivity      `json:"interactivity,omitempty" yaml:"interactivity,omitempty"`
 	IncomingWebhooks       *IncomingWebhooks           `json:"incoming_webhooks,omitempty" yaml:"incoming_webhooks,flow,omitempty"`
 	EventSubscriptions     *ManifestEventSubscriptions `json:"event_subscriptions,omitempty" yaml:"event_subscriptions,flow,omitempty"`
-	AllowedIpAddressRanges []string                    `json:"allowed_ip_address_ranges,omitempty" yaml:"allowed_ip_address_ranges,flow,omitempty"`
+	AllowedIPAddressRanges []string                    `json:"allowed_ip_address_ranges,omitempty" yaml:"allowed_ip_address_ranges,flow,omitempty"`
 	FunctionRuntime        FunctionRuntime             `json:"function_runtime,omitempty" yaml:"function_runtime,flow,omitempty"`
 	TokenRotationEnabled   *bool                       `json:"token_rotation_enabled,omitempty" yaml:"token_rotation_enabled,omitempty"`
 	SiwsLinks              *SiwsLinks                  `json:"siws_links,omitempty" yaml:"siws_links,flow,omitempty"`
@@ -219,7 +219,7 @@ type ManifestEventSubscriptions struct {
 }
 
 type MetadataSubscription struct {
-	AppId     string `json:"app_id" yaml:"app_id"`
+	AppID     string `json:"app_id" yaml:"app_id"`
 	EventType string `json:"event_type" yaml:"event_type"`
 }
 
@@ -284,23 +284,18 @@ type Constraint struct {
 }
 
 type SiwsLinks struct {
-	InitiateUri string `json:"initiate_uri,omitempty" yaml:"initiate_uri,omitempty"`
+	InitiateURI string `json:"initiate_uri,omitempty" yaml:"initiate_uri,omitempty"`
 }
 
 type FunctionRuntime string
 
 const (
-	SLACK_HOSTED FunctionRuntime = "slack"
-	LOCALLY_RUN  FunctionRuntime = "local"
-	REMOTE       FunctionRuntime = "remote"
+	LocallyRun  FunctionRuntime = "local"
+	Remote      FunctionRuntime = "remote"
+	SlackHosted FunctionRuntime = "slack"
 )
 
 type ShortcutScopeType string
-
-const (
-	MESSAGE string = "message"
-	GLOBAL  string = "global"
-)
 
 // Methods
 
@@ -315,11 +310,11 @@ func (manifest *AppManifest) FunctionRuntime() FunctionRuntime {
 // IsFunctionRuntimeSlackHosted returns true when the function runtime setting
 // is slack hosted
 func (manifest *AppManifest) IsFunctionRuntimeSlackHosted() bool {
-	return manifest.Settings != nil && manifest.Settings.FunctionRuntime == SLACK_HOSTED
+	return manifest.Settings != nil && manifest.Settings.FunctionRuntime == SlackHosted
 }
 
-// ToRawJson converts a string to types.RawJSON
-func ToRawJson(obj string) *RawJSON {
+// ToRawJSON converts a string to types.RawJSON
+func ToRawJSON(obj string) *RawJSON {
 	b := []byte(obj)
 	return &RawJSON{JSONData: (*json.RawMessage)(&b)}
 }

--- a/internal/shared/types/app_manifest_test.go
+++ b/internal/shared/types/app_manifest_test.go
@@ -110,7 +110,7 @@ func Test_AppManifest_ConvertDataForRawJSON(t *testing.T) {
 	}
 }
 
-func Test_AppManifest_ToRawJson(t *testing.T) {
+func Test_AppManifest_ToRawJSON(t *testing.T) {
 	tests := map[string]struct {
 		have string
 		want *RawJSON
@@ -122,10 +122,10 @@ func Test_AppManifest_ToRawJson(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			if got := ToRawJson(tt.have); !reflect.DeepEqual(got, tt.want) {
+			if got := ToRawJSON(tt.have); !reflect.DeepEqual(got, tt.want) {
 				t.Log(got.Data)
 				t.Log(got.JSONData)
-				t.Errorf("ToRawJson() = %v, want %v", got, tt.want)
+				t.Errorf("ToRawJSON() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -178,22 +178,22 @@ func Test_AppManifest_AppFeatures(t *testing.T) {
 
 func Test_AppManifest_AppSettings_SiwsLinks(t *testing.T) {
 	expectedSiws := SiwsLinks{
-		InitiateUri: "an initiate uri",
+		InitiateURI: "an initiate uri",
 	}
 	tests := map[string]struct {
 		settings          *AppSettings
 		expectedSiwsLinks *SiwsLinks
-		expectedJson      string
+		expectedJSON      string
 	}{
 		"undefined incoming webhooks have no siws links": {
 			settings:          &AppSettings{},
 			expectedSiwsLinks: nil,
-			expectedJson:      `{}`,
+			expectedJSON:      `{}`,
 		},
 		"defined siws links have siws links": {
 			settings:          &AppSettings{SiwsLinks: &expectedSiws},
 			expectedSiwsLinks: &expectedSiws,
-			expectedJson:      `{"siws_links":{"initiate_uri":"an initiate uri"}}`,
+			expectedJSON:      `{"siws_links":{"initiate_uri":"an initiate uri"}}`,
 		},
 	}
 	for name, tt := range tests {
@@ -202,9 +202,9 @@ func Test_AppManifest_AppSettings_SiwsLinks(t *testing.T) {
 				Settings: tt.settings,
 			}
 			if tt.settings != nil {
-				actualJson, err := json.Marshal(tt.settings)
+				actualJSON, err := json.Marshal(tt.settings)
 				require.NoError(t, err)
-				assert.Equal(t, tt.expectedJson, string(actualJson))
+				assert.Equal(t, tt.expectedJSON, string(actualJSON))
 				assert.Equal(t, tt.expectedSiwsLinks, manifest.Settings.SiwsLinks)
 			} else {
 				assert.Nil(t, manifest.Settings)
@@ -221,17 +221,17 @@ func Test_AppManifest_AppSettings_IncomingWebhooks(t *testing.T) {
 	tests := map[string]struct {
 		settings                      *AppSettings
 		expectedIncomingWebhooksLinks *IncomingWebhooks
-		expectedJson                  string
+		expectedJSON                  string
 	}{
 		"undefined incoming webhooks have no webhooks": {
 			settings:                      &AppSettings{},
 			expectedIncomingWebhooksLinks: nil,
-			expectedJson:                  `{}`,
+			expectedJSON:                  `{}`,
 		},
 		"defined incoming webhooks have webhooks": {
 			settings:                      &AppSettings{IncomingWebhooks: &expectedIncomingWebhooks},
 			expectedIncomingWebhooksLinks: &expectedIncomingWebhooks,
-			expectedJson:                  `{"incoming_webhooks":{"incoming_webhooks_enabled":false}}`,
+			expectedJSON:                  `{"incoming_webhooks":{"incoming_webhooks_enabled":false}}`,
 		},
 	}
 	for name, tt := range tests {
@@ -240,9 +240,9 @@ func Test_AppManifest_AppSettings_IncomingWebhooks(t *testing.T) {
 				Settings: tt.settings,
 			}
 			if tt.settings != nil {
-				actualJson, err := json.Marshal(tt.settings)
+				actualJSON, err := json.Marshal(tt.settings)
 				require.NoError(t, err)
-				assert.Equal(t, tt.expectedJson, string(actualJson))
+				assert.Equal(t, tt.expectedJSON, string(actualJSON))
 				assert.Equal(t, tt.expectedIncomingWebhooksLinks, manifest.Settings.IncomingWebhooks)
 			} else {
 				assert.Nil(t, manifest.Settings)
@@ -270,17 +270,17 @@ func Test_AppManifest_AppSettings_FunctionRuntime(t *testing.T) {
 		"setting the function runtime to slack is hosted": {
 			settings:        &AppSettings{FunctionRuntime: "slack"},
 			expectedHosted:  true,
-			expectedRuntime: SLACK_HOSTED,
+			expectedRuntime: SlackHosted,
 		},
 		"setting the function runtime to remote is not hosted": {
 			settings:        &AppSettings{FunctionRuntime: "remote"},
 			expectedHosted:  false,
-			expectedRuntime: REMOTE,
+			expectedRuntime: Remote,
 		},
 		"setting the function runtime to local is not hosted": {
 			settings:        &AppSettings{FunctionRuntime: "local"},
 			expectedHosted:  false,
-			expectedRuntime: LOCALLY_RUN,
+			expectedRuntime: LocallyRun,
 		},
 		"setting the function runtime to random is not hosted": {
 			settings:        &AppSettings{FunctionRuntime: "sparkling-butterflies"},

--- a/internal/shared/types/auth.go
+++ b/internal/shared/types/auth.go
@@ -35,7 +35,7 @@ type SlackAuth struct {
 	EnterpriseID        string    `json:"enterprise_id,omitempty"`
 	UserID              string    `json:"user_id"`
 	LastUpdated         time.Time `json:"last_updated,omitempty"`
-	ApiHost             *string   `json:"api_host,omitempty"`
+	APIHost             *string   `json:"api_host,omitempty"`
 	RefreshToken        string    `json:"refresh_token,omitempty"`
 	ExpiresAt           int       `json:"exp,omitempty"`
 	IsEnterpriseInstall bool      `json:"is_enterprise_install,omitempty"`

--- a/internal/shared/types/auth.go
+++ b/internal/shared/types/auth.go
@@ -74,10 +74,10 @@ type AuthByTeamID map[string]SlackAuth
 type InstallState string
 
 const (
-	SUCCESS           InstallState = "SUCCESS"
-	REQUEST_PENDING   InstallState = "REQUEST_PENDING"
-	REQUEST_CANCELLED InstallState = "REQUEST_CANCELLED"
-	REQUEST_NOT_SENT  InstallState = "REQUEST_NOT_SENT"
+	InstallSuccess          InstallState = "SUCCESS"
+	InstallRequestPending   InstallState = "REQUEST_PENDING"
+	InstallRequestCancelled InstallState = "REQUEST_CANCELLED"
+	InstallRequestNotSent   InstallState = "REQUEST_NOT_SENT"
 )
 
 // ShouldRotateToken returns true if an auth credential can be rotated and also expires in <= 5min

--- a/internal/shared/types/external_auth.go
+++ b/internal/shared/types/external_auth.go
@@ -35,7 +35,7 @@ type ExternalAuthorizationInfo struct {
 	ClientId           string              `json:"client_id" yaml:"client_id,flow"`
 	ClientSecretExists bool                `json:"client_secret_exists" yaml:"client_secret_exists,flow"`
 	ValidTokenExists   bool                `json:"valid_token_exists" yaml:"valid_token_exists,flow"`
-	ExternalTokenIds   []string            `json:"external_token_ids,omitempty" yaml:"external_token_ids,omitempty,flow"`
+	ExternalTokenIDs   []string            `json:"external_token_ids,omitempty" yaml:"external_token_ids,omitempty,flow"`
 	ExternalTokens     []ExternalTokenInfo `json:"external_tokens,omitempty" yaml:"external_tokens,omitempty,flow"`
 }
 
@@ -52,7 +52,7 @@ type ProvidersInfo struct {
 }
 
 type ExternalTokenInfo struct {
-	ExternalTokenId string `json:"external_token_id" yaml:"external_token_id,flow"`
+	ExternalTokenID string `json:"external_token_id" yaml:"external_token_id,flow"`
 	ExternalUserId  string `json:"external_user_id" yaml:"external_user_id,flow"`
 	DateUpdated     int    `json:"date_updated" yaml:"date_updated,flow"`
 }
@@ -75,7 +75,7 @@ type ProviderExternalAuthorizationInfo struct {
 }
 
 type SelectedAuthInfo struct {
-	ExternalTokenId string `json:"external_token_id" yaml:"external_token_id,flow"`
+	ExternalTokenID string `json:"external_token_id" yaml:"external_token_id,flow"`
 	ExternalUserId  string `json:"external_user_id" yaml:"external_user_id,flow"`
 	DateUpdated     string `json:"date_updated" yaml:"date_updated,flow"`
 }

--- a/internal/shared/types/external_auth.go
+++ b/internal/shared/types/external_auth.go
@@ -20,19 +20,19 @@ type ProviderData struct {
 }
 
 type ManifestOAuth2ProviderOptions struct {
-	AuthorizationUrl       string            `json:"authorization_url" yaml:"authorization_url,flow"`
-	ClientId               string            `json:"client_id" yaml:"client_id,flow"`
-	TokenUrl               string            `json:"token_url" yaml:"token_url,flow"`
+	AuthorizationURL       string            `json:"authorization_url" yaml:"authorization_url,flow"`
+	ClientID               string            `json:"client_id" yaml:"client_id,flow"`
+	TokenURL               string            `json:"token_url" yaml:"token_url,flow"`
 	Scope                  []string          `json:"scope" yaml:"scope,flow"`
 	ProviderName           string            `json:"provider_name" yaml:"provider_name,flow"`
 	IdentityConfig         *RawJSON          `json:"identity_config" yaml:"identity_config,flow"`
-	AuthorizationUrlExtras map[string]string `json:"authorization_url_extras,omitempty" yaml:"authorization_url_extras,omitempty,flow"`
+	AuthorizationURLExtras map[string]string `json:"authorization_url_extras,omitempty" yaml:"authorization_url_extras,omitempty,flow"`
 }
 
 type ExternalAuthorizationInfo struct {
 	ProviderName       string              `json:"provider_name" yaml:"provider_name,flow"`
 	ProviderKey        string              `json:"provider_key" yaml:"provider_key,flow"`
-	ClientId           string              `json:"client_id" yaml:"client_id,flow"`
+	ClientID           string              `json:"client_id" yaml:"client_id,flow"`
 	ClientSecretExists bool                `json:"client_secret_exists" yaml:"client_secret_exists,flow"`
 	ValidTokenExists   bool                `json:"valid_token_exists" yaml:"valid_token_exists,flow"`
 	ExternalTokenIDs   []string            `json:"external_token_ids,omitempty" yaml:"external_token_ids,omitempty,flow"`
@@ -40,8 +40,8 @@ type ExternalAuthorizationInfo struct {
 }
 
 type WorkflowsInfo struct {
-	WorkflowId string          `json:"workflow_id" yaml:"workflow_id,flow"`
-	CallBackId string          `json:"callback_id" yaml:"callback_id,flow"`
+	WorkflowID string          `json:"workflow_id" yaml:"workflow_id,flow"`
+	CallBackID string          `json:"callback_id" yaml:"callback_id,flow"`
 	Providers  []ProvidersInfo `json:"providers" yaml:"providers,flow"`
 }
 
@@ -53,7 +53,7 @@ type ProvidersInfo struct {
 
 type ExternalTokenInfo struct {
 	ExternalTokenID string `json:"external_token_id" yaml:"external_token_id,flow"`
-	ExternalUserId  string `json:"external_user_id" yaml:"external_user_id,flow"`
+	ExternalUserID  string `json:"external_user_id" yaml:"external_user_id,flow"`
 	DateUpdated     int    `json:"date_updated" yaml:"date_updated,flow"`
 }
 
@@ -63,8 +63,8 @@ type ExternalAuthorizationInfoLists struct {
 }
 
 type WorkflowExternalAuthorizationInfo struct {
-	WorkflowId string                              `json:"workflow_id" yaml:"workflow_id,flow"`
-	CallbackId string                              `json:"callback_id" yaml:"callback_id,flow"`
+	WorkflowID string                              `json:"workflow_id" yaml:"workflow_id,flow"`
+	CallbackID string                              `json:"callback_id" yaml:"callback_id,flow"`
 	Providers  []ProviderExternalAuthorizationInfo `json:"providers" yaml:"providers,flow"`
 }
 
@@ -76,6 +76,6 @@ type ProviderExternalAuthorizationInfo struct {
 
 type SelectedAuthInfo struct {
 	ExternalTokenID string `json:"external_token_id" yaml:"external_token_id,flow"`
-	ExternalUserId  string `json:"external_user_id" yaml:"external_user_id,flow"`
+	ExternalUserID  string `json:"external_user_id" yaml:"external_user_id,flow"`
 	DateUpdated     string `json:"date_updated" yaml:"date_updated,flow"`
 }

--- a/internal/shared/types/permissions.go
+++ b/internal/shared/types/permissions.go
@@ -58,9 +58,9 @@ type Permission string
 // Consumed in function distribution ACLs and trigger run ACLs
 // distribution type or access/permission type: 'everyone' | 'app_collaborators' | 'named_entities';
 const (
-	NAMED_ENTITIES    Permission = "named_entities"
-	APP_COLLABORATORS Permission = "app_collaborators"
-	EVERYONE          Permission = "everyone"
+	PermissionNamedEntities    Permission = "named_entities"
+	PermissionAppCollaborators Permission = "app_collaborators"
+	PermissionEveryone         Permission = "everyone"
 )
 
 // FunctionPermissions holds information for setting multiple function distributions
@@ -73,7 +73,7 @@ type FunctionPermissions struct {
 
 func (d Permission) IsValid() bool {
 	switch d {
-	case APP_COLLABORATORS, NAMED_ENTITIES, EVERYONE:
+	case PermissionAppCollaborators, PermissionNamedEntities, PermissionEveryone:
 		return true
 	}
 	return false
@@ -81,11 +81,11 @@ func (d Permission) IsValid() bool {
 
 func (d Permission) ToString() (userFriendlyString string) {
 	switch d {
-	case NAMED_ENTITIES:
+	case PermissionNamedEntities:
 		userFriendlyString = "specific entities"
-	case APP_COLLABORATORS:
+	case PermissionAppCollaborators:
 		userFriendlyString = "app collaborators"
-	case EVERYONE:
+	case PermissionEveryone:
 		userFriendlyString = "everyone"
 	}
 	return

--- a/internal/shared/types/permissions_test.go
+++ b/internal/shared/types/permissions_test.go
@@ -96,18 +96,18 @@ func Test_Permission_IsValid(t *testing.T) {
 		expectedIsValid bool
 	}{
 		{
-			name:            "APP_COLLABORATORS",
-			permission:      APP_COLLABORATORS,
+			name:            "Permission App Collaborators",
+			permission:      PermissionAppCollaborators,
 			expectedIsValid: true,
 		},
 		{
-			name:            "EVERYONE",
-			permission:      EVERYONE,
+			name:            "Permission Everyone",
+			permission:      PermissionEveryone,
 			expectedIsValid: true,
 		},
 		{
-			name:            "NAMED_ENTITIES",
-			permission:      NAMED_ENTITIES,
+			name:            "Permission Named Entities",
+			permission:      PermissionNamedEntities,
 			expectedIsValid: true,
 		},
 		{
@@ -142,18 +142,18 @@ func Test_Permission_ToString(t *testing.T) {
 		expectedString string
 	}{
 		{
-			name:           "APP_COLLABORATORS",
-			permission:     APP_COLLABORATORS,
+			name:           "Permission App Collaborators",
+			permission:     PermissionAppCollaborators,
 			expectedString: "app collaborators",
 		},
 		{
-			name:           "EVERYONE",
-			permission:     EVERYONE,
+			name:           "Permission Everyone",
+			permission:     PermissionEveryone,
 			expectedString: "everyone",
 		},
 		{
-			name:           "NAMED_ENTITIES",
-			permission:     NAMED_ENTITIES,
+			name:           "Permission Named Entities",
+			permission:     PermissionNamedEntities,
 			expectedString: "specific entities",
 		},
 		{

--- a/internal/shared/types/triggers.go
+++ b/internal/shared/types/triggers.go
@@ -136,7 +136,7 @@ type DeployedTrigger struct {
 	Description string          `json:"description"`
 	Usage       string          `json:"usage"`
 	Webhook     string          `json:"webhook_url"`
-	ShortcutUrl string          `json:"shortcut_url"`
+	ShortcutURL string          `json:"shortcut_url"`
 	Workflow    TriggerWorkflow `json:"workflow"`
 	Inputs      *RawJSON        `json:"inputs"`
 }

--- a/internal/slackerror/error.go
+++ b/internal/slackerror/error.go
@@ -422,7 +422,7 @@ func JsonUnmarshalError(err error, data []byte) *Error {
 	}
 
 	contentToParse := style.Secondary(string(data[:]))
-	jsonErr := New(ErrUnableToParseJson)
+	jsonErr := New(ErrUnableToParseJSON)
 	jsonErr.Message = strings.Replace(jsonErr.Message, "<json>", contentToParse, 1)
 
 	transformedErr := ToSlackError(err)

--- a/internal/slackerror/error.go
+++ b/internal/slackerror/error.go
@@ -49,7 +49,7 @@ type Error struct {
 	Cause       error        // TODO - Refactor 'Cause' to be 'Error' so that native Go error unwrapping works with a slackerror
 
 	// useful for api errors
-	ApiEndpoint string
+	APIEndpoint string
 }
 
 type constraint struct {
@@ -143,8 +143,8 @@ func (e *Error) Error() string {
 
 	var errStr, apiErr string
 
-	if err.ApiEndpoint != "" {
-		apiMethodText := style.Secondary("The following error was returned by the " + err.ApiEndpoint + " Slack API method")
+	if err.APIEndpoint != "" {
+		apiMethodText := style.Secondary("The following error was returned by the " + err.APIEndpoint + " Slack API method")
 		apiErr = fmt.Sprintf("%s\n\n%s", apiMethodText, style.Emoji("prohibited"))
 	}
 
@@ -158,13 +158,13 @@ func (e *Error) Error() string {
 	return errStr
 }
 
-// AddApiMethod will set the api endpoint for a slack error
+// AddAPIMethod will set the api endpoint for a slack error
 // It is useful for rendering API errors
-func (e *Error) AddApiMethod(endpoint string) *Error {
+func (e *Error) AddAPIMethod(endpoint string) *Error {
 	if e == nil {
 		return e
 	}
-	e.ApiEndpoint = endpoint
+	e.APIEndpoint = endpoint
 	return e
 }
 
@@ -363,8 +363,8 @@ func Wrapf(err error, format string, args ...interface{}) error {
 	}
 }
 
-// NewApiError returns an API error with details and error code
-func NewApiError(errorCode string, description string, details ErrorDetails, apiEndpoint string) *Error {
+// NewAPIError returns an API error with details and error code
+func NewAPIError(errorCode string, description string, details ErrorDetails, apiEndpoint string) *Error {
 	err := getErrorIfKnown(errorCode)
 	if err == nil {
 		if errorCode == "" {
@@ -375,7 +375,7 @@ func NewApiError(errorCode string, description string, details ErrorDetails, api
 	}
 	err.Description = description
 	err.Details = append(err.Details, details...)
-	err.ApiEndpoint = apiEndpoint
+	err.APIEndpoint = apiEndpoint
 	return err
 }
 
@@ -412,11 +412,11 @@ func Is(err error, errorCode string) bool {
 	return strings.Contains(err.Error(), errorCode)
 }
 
-// JsonUnmarshalError returns a human readable json unmarshal error for CLI users
+// JSONUnmarshalError returns a human readable json unmarshal error for CLI users
 // Simply displaying the json.Unmarshal errors have proven to be very confusing already.
 // This attempts to ensure the user understands that the CLI is trying to parse a JSON
 // but is running into some issues.
-func JsonUnmarshalError(err error, data []byte) *Error {
+func JSONUnmarshalError(err error, data []byte) *Error {
 	if err == nil {
 		return nil
 	}

--- a/internal/slackerror/error_test.go
+++ b/internal/slackerror/error_test.go
@@ -124,7 +124,7 @@ func Test_JsonUnmarshalErrorTest(t *testing.T) {
 			if tt.err == nil {
 				require.Nil(t, err)
 			} else {
-				require.Equal(t, ErrUnableToParseJson, err.Code)
+				require.Equal(t, ErrUnableToParseJSON, err.Code)
 				require.Contains(t, err.Error(), string(tt.data[:]))
 
 				transformedErr := ToSlackError(tt.err)

--- a/internal/slackerror/error_test.go
+++ b/internal/slackerror/error_test.go
@@ -21,28 +21,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func Test_AddApiMethod(t *testing.T) {
+func Test_AddAPIMethod(t *testing.T) {
 	tests := map[string]struct {
 		err         Error
 		newEndpoint string
 	}{
 		"previously empty endpoint": {
-			err:         Error{ApiEndpoint: ""},
+			err:         Error{APIEndpoint: ""},
 			newEndpoint: "http://example2.com",
 		},
 		"previously non-empty endpoint": {
-			err:         Error{ApiEndpoint: "http://example1.com"},
+			err:         Error{APIEndpoint: "http://example1.com"},
 			newEndpoint: "http://example2.com",
 		},
 		"empty endpoint being set": {
-			err:         Error{ApiEndpoint: "http://example1.com"},
+			err:         Error{APIEndpoint: "http://example1.com"},
 			newEndpoint: "",
 		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			_ = tt.err.AddApiMethod(tt.newEndpoint)
-			require.Equal(t, tt.newEndpoint, tt.err.ApiEndpoint)
+			_ = tt.err.AddAPIMethod(tt.newEndpoint)
+			require.Equal(t, tt.newEndpoint, tt.err.APIEndpoint)
 		})
 	}
 }
@@ -99,7 +99,7 @@ func Test_AppendRemediation(t *testing.T) {
 	}
 }
 
-func Test_JsonUnmarshalErrorTest(t *testing.T) {
+func Test_JSONUnmarshalErrorTest(t *testing.T) {
 	tests := map[string]struct {
 		data     []byte
 		err      error
@@ -120,7 +120,7 @@ func Test_JsonUnmarshalErrorTest(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			err := JsonUnmarshalError(tt.err, tt.data)
+			err := JSONUnmarshalError(tt.err, tt.data)
 			if tt.err == nil {
 				require.Nil(t, err)
 			} else {
@@ -162,7 +162,7 @@ func Test_New(t *testing.T) {
 	}
 }
 
-func Test_NewApiError(t *testing.T) {
+func Test_NewAPIError(t *testing.T) {
 	testErr := ErrorCodeMap[ErrInternal]
 
 	tests := map[string]struct {
@@ -187,30 +187,30 @@ func Test_NewApiError(t *testing.T) {
 			code:        "fake",
 			description: "fake",
 			apiMethod:   "fakeMethod",
-			expected:    Error{Code: "fake", Description: "fake", ApiEndpoint: "fakeMethod"},
+			expected:    Error{Code: "fake", Description: "fake", APIEndpoint: "fakeMethod"},
 		},
 		"error code  + description + details + api endpoint": {
 			code:        "fake",
 			description: "fake",
 			details:     ErrorDetails{{Code: "c1", Message: "m1"}},
 			apiMethod:   "fakeMethod",
-			expected:    Error{Code: "fake", Description: "fake", ApiEndpoint: "fakeMethod", Details: ErrorDetails{{Code: "c1", Message: "m1"}}},
+			expected:    Error{Code: "fake", Description: "fake", APIEndpoint: "fakeMethod", Details: ErrorDetails{{Code: "c1", Message: "m1"}}},
 		},
 		"known error + add details": {
 			code:      ErrInternal,
 			details:   ErrorDetails{{Code: "c1", Message: "m1"}},
 			apiMethod: "fakeMethod",
-			expected:  *testErr.AddApiMethod("fakeMethod").WithDetails(ErrorDetails{{Code: "c1", Message: "m1"}}),
+			expected:  *testErr.AddAPIMethod("fakeMethod").WithDetails(ErrorDetails{{Code: "c1", Message: "m1"}}),
 		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			err := NewApiError(tt.code, tt.description, tt.details, tt.apiMethod)
+			err := NewAPIError(tt.code, tt.description, tt.details, tt.apiMethod)
 			require.Equal(t, tt.expected.Code, err.Code)
 			require.Equal(t, tt.expected.Description, err.Description)
 			require.Equal(t, tt.expected.Message, err.Message)
 			require.Equal(t, tt.expected.Details, err.Details)
-			require.Equal(t, tt.expected.ApiEndpoint, err.ApiEndpoint)
+			require.Equal(t, tt.expected.APIEndpoint, err.APIEndpoint)
 			require.Equal(t, tt.expected.Error(), err.Error())
 		})
 	}
@@ -236,10 +236,10 @@ func Test_Error(t *testing.T) {
 			err: &Error{Code: "code", Message: "msg", Remediation: "remediation"},
 		},
 		"code + message + remediation + api endpoint only": {
-			err: &Error{Code: "code", Message: "msg", Remediation: "remediation", ApiEndpoint: "host"},
+			err: &Error{Code: "code", Message: "msg", Remediation: "remediation", APIEndpoint: "host"},
 		},
 		"code + message + remediation + api endpoint + details": {
-			err: &Error{Code: "code", Message: "msg", Remediation: "remediation", ApiEndpoint: "host", Details: ErrorDetails{{Message: "m1", Code: "c1", Remediation: "r1", Pointer: "p1"}}},
+			err: &Error{Code: "code", Message: "msg", Remediation: "remediation", APIEndpoint: "host", Details: ErrorDetails{{Message: "m1", Code: "c1", Remediation: "r1", Pointer: "p1"}}},
 		},
 	}
 
@@ -252,7 +252,7 @@ func Test_Error(t *testing.T) {
 			} else {
 				require.Contains(t, res, tt.err.Code)
 				require.Contains(t, res, tt.err.Message)
-				require.Contains(t, res, tt.err.ApiEndpoint)
+				require.Contains(t, res, tt.err.APIEndpoint)
 				require.Contains(t, res, tt.err.Remediation)
 				for _, d := range tt.err.Details {
 					require.Contains(t, res, d.Message)

--- a/internal/slackerror/errors.go
+++ b/internal/slackerror/errors.go
@@ -114,7 +114,7 @@ const (
 	ErrHomeDirectoryAccessFailed                     = "home_directory_access_failed"
 	ErrHooksJsonLocation                             = "hooks_json_location_error"
 	ErrHostAppsDisallowUserScopes                    = "hosted_apps_disallow_user_scopes"
-	ErrHttpRequestFailed                             = "http_request_failed"
+	ErrHTTPRequestFailed                             = "http_request_failed"
 	ErrHTTPResponseInvalid                           = "http_response_invalid"
 	ErrInsecureRequest                               = "insecure_request"
 	ErrInstallationDenied                            = "installation_denied"
@@ -770,8 +770,8 @@ Otherwise start your app for local development with: %s`,
 		Message: "Hosted apps do not support user scopes",
 	},
 
-	ErrHttpRequestFailed: {
-		Code:    ErrHttpRequestFailed,
+	ErrHTTPRequestFailed: {
+		Code:    ErrHTTPRequestFailed,
 		Message: "HTTP request failed",
 	},
 

--- a/internal/slackerror/errors.go
+++ b/internal/slackerror/errors.go
@@ -112,7 +112,7 @@ const (
 	ErrGitClone                                      = "git_clone_error"
 	ErrGitZipDownload                                = "git_zip_download_error"
 	ErrHomeDirectoryAccessFailed                     = "home_directory_access_failed"
-	ErrHooksJsonLocation                             = "hooks_json_location_error"
+	ErrHooksJSONLocation                             = "hooks_json_location_error"
 	ErrHostAppsDisallowUserScopes                    = "hosted_apps_disallow_user_scopes"
 	ErrHTTPRequestFailed                             = "http_request_failed"
 	ErrHTTPResponseInvalid                           = "http_response_invalid"
@@ -140,7 +140,7 @@ const (
 	ErrInvalidParameters                             = "invalid_parameters"
 	ErrInvalidPermissionType                         = "invalid_permission_type"
 	ErrInvalidRefreshToken                           = "invalid_refresh_token"
-	ErrInvalidRequestId                              = "invalid_request_id"
+	ErrInvalidRequestID                              = "invalid_request_id"
 	ErrInvalidResourceID                             = "invalid_resource_id"
 	ErrInvalidResourceType                           = "invalid_resource_type"
 	ErrInvalidS3Key                                  = "invalid_s3_key"
@@ -759,8 +759,8 @@ Otherwise start your app for local development with: %s`,
 		Remediation: "A Slack directory is required for retrieving/storing auth credentials and config data. Check permissions on your system.",
 	},
 
-	ErrHooksJsonLocation: {
-		Code:        ErrHooksJsonLocation,
+	ErrHooksJSONLocation: {
+		Code:        ErrHooksJSONLocation,
 		Message:     "Missing the Slack hooks file from project configurations",
 		Remediation: fmt.Sprintf("A `%s` file must be present in the project's `.slack` directory.", filepath.Join(".slack", "hooks.json")),
 	},
@@ -920,8 +920,8 @@ Otherwise start your app for local development with: %s`,
 		Message: "The given refresh token is invalid",
 	},
 
-	ErrInvalidRequestId: {
-		Code:    ErrInvalidRequestId,
+	ErrInvalidRequestID: {
+		Code:    ErrInvalidRequestID,
 		Message: "The request_id passed is invalid",
 	},
 

--- a/internal/slackerror/errors.go
+++ b/internal/slackerror/errors.go
@@ -115,7 +115,7 @@ const (
 	ErrHooksJsonLocation                             = "hooks_json_location_error"
 	ErrHostAppsDisallowUserScopes                    = "hosted_apps_disallow_user_scopes"
 	ErrHttpRequestFailed                             = "http_request_failed"
-	ErrHttpResponseInvalid                           = "http_response_invalid"
+	ErrHTTPResponseInvalid                           = "http_response_invalid"
 	ErrInsecureRequest                               = "insecure_request"
 	ErrInstallationDenied                            = "installation_denied"
 	ErrInstallationFailed                            = "installation_failed"
@@ -124,13 +124,13 @@ const (
 	ErrInvalidApp                                    = "invalid_app"
 	ErrInvalidAppDirectory                           = "invalid_app_directory"
 	ErrInvalidAppFlag                                = "invalid_app_flag"
-	ErrInvalidAppId                                  = "invalid_app_id"
+	ErrInvalidAppID                                  = "invalid_app_id"
 	ErrInvalidArgs                                   = "invalid_args"
 	ErrInvalidArgumentsCustomizableInputs            = "invalid_arguments_customizable_inputs"
 	ErrInvalidArguments                              = "invalid_arguments"
 	ErrInvalidAuth                                   = "invalid_auth"
 	ErrInvalidChallenge                              = "invalid_challenge"
-	ErrInvalidChannelId                              = "invalid_channel_id"
+	ErrInvalidChannelID                              = "invalid_channel_id"
 	ErrInvalidCursor                                 = "invalid_cursor"
 	ErrInvalidDistributionType                       = "invalid_distribution_type"
 	ErrInvalidFlag                                   = "invalid_flag"
@@ -141,7 +141,7 @@ const (
 	ErrInvalidPermissionType                         = "invalid_permission_type"
 	ErrInvalidRefreshToken                           = "invalid_refresh_token"
 	ErrInvalidRequestId                              = "invalid_request_id"
-	ErrInvalidResourceId                             = "invalid_resource_id"
+	ErrInvalidResourceID                             = "invalid_resource_id"
 	ErrInvalidResourceType                           = "invalid_resource_type"
 	ErrInvalidS3Key                                  = "invalid_s3_key"
 	ErrInvalidScopes                                 = "invalid_scopes"
@@ -156,11 +156,11 @@ const (
 	ErrInvalidTriggerEventType                       = "invalid_trigger_event_type"
 	ErrInvalidTriggerInputs                          = "invalid_trigger_inputs"
 	ErrInvalidTriggerType                            = "invalid_trigger_type"
-	ErrInvalidUserId                                 = "invalid_user_id"
+	ErrInvalidUserID                                 = "invalid_user_id"
 	ErrInvalidWebhookConfig                          = "invalid_webhook_config"
 	ErrInvalidWebhookSchemaRef                       = "invalid_webhook_schema_ref"
-	ErrInvalidWorkflowAppId                          = "invalid_workflow_app_id"
-	ErrInvalidWorkflowId                             = "invalid_workflow_id"
+	ErrInvalidWorkflowAppID                          = "invalid_workflow_app_id"
+	ErrInvalidWorkflowID                             = "invalid_workflow_id"
 	ErrIsRestricted                                  = "is_restricted"
 	ErrLocalAppNotFound                              = "local_app_not_found"
 	ErrLocalAppNotSupported                          = "local_app_not_supported"
@@ -169,7 +169,7 @@ const (
 	ErrLocalAppRunCleanExit                          = "local_app_run_clean_exit"
 	ErrMethodNotSupported                            = "method_not_supported"
 	ErrMismatchedFlags                               = "mismatched_flags"
-	ErrMissingAppId                                  = "missing_app_id"
+	ErrMissingAppID                                  = "missing_app_id"
 	ErrMissingAppTeamID                              = "missing_app_team_id"
 	ErrMissingChallenge                              = "missing_challenge"
 	ErrMissingExperiment                             = "missing_experiment"
@@ -204,7 +204,7 @@ const (
 	ErrProviderNotFound                              = "provider_not_found"
 	ErrPrompt                                        = "prompt_error"
 	ErrPublishedAppOnly                              = "published_app_only"
-	ErrRequestIdOrAppIdIsRequired                    = "request_id_or_app_id_is_required"
+	ErrRequestIDOrAppIDIsRequired                    = "request_id_or_app_id_is_required"
 	ErrRatelimited                                   = "ratelimited"
 	ErrRestrictedPlanLevel                           = "restricted_plan_level"
 	ErrRuntimeNotSupported                           = "runtime_not_supported"
@@ -216,8 +216,8 @@ const (
 	ErrServiceLimitsExceeded                         = "service_limits_exceeded"
 	ErrSharedChannelDenied                           = "shared_channel_denied"
 	ErrSlackAuth                                     = "slack_auth_error"
-	ErrSlackJsonLocation                             = "slack_json_location_error"
-	ErrSlackSlackJsonLocation                        = "slack_slack_json_location_error"
+	ErrSlackJSONLocation                             = "slack_json_location_error"
+	ErrSlackSlackJSONLocation                        = "slack_slack_json_location_error"
 	ErrSocketConnection                              = "socket_connection_error"
 	ErrScopesExceedAppConfig                         = "scopes_exceed_app_config"
 	ErrStreamingActivityLogs                         = "streaming_activity_logs_error"
@@ -245,19 +245,19 @@ const (
 	ErrTriggerUpdate                                 = "trigger_update_error"
 	ErrUnableToDelete                                = "unable_to_delete"
 	ErrUnableToOpenFile                              = "unable_to_open_file"
-	ErrUnableToParseJson                             = "unable_to_parse_json"
+	ErrUnableToParseJSON                             = "unable_to_parse_json"
 	ErrUninstallHalted                               = "uninstall_halted"
 	ErrUnknownFileType                               = "unknown_file_type"
-	ErrUnknownFunctionId                             = "unknown_function_id"
+	ErrUnknownFunctionID                             = "unknown_function_id"
 	ErrUnknownMethod                                 = "unknown_method"
 	ErrUnknownWebhookSchemaRef                       = "unknown_webhook_schema_ref"
-	ErrUnknownWorkflowId                             = "unknown_workflow_id"
+	ErrUnknownWorkflowID                             = "unknown_workflow_id"
 	ErrUntrustedSource                               = "untrusted_source"
 	ErrUnsupportedFileName                           = "unsupported_file_name"
 	ErrUserAlreadyOwner                              = "user_already_owner"
 	ErrUserAlreadyRequested                          = "user_already_requested"
 	ErrUserCannotManageApp                           = "user_cannot_manage_app"
-	ErrUserIdIsRequired                              = "user_id_is_required"
+	ErrUserIDIsRequired                              = "user_id_is_required"
 	ErrUserNotFound                                  = "user_not_found"
 	ErrUserRemovedFromTeam                           = "user_removed_from_team"
 	ErrWorkflowNotFound                              = "workflow_not_found"
@@ -775,8 +775,8 @@ Otherwise start your app for local development with: %s`,
 		Message: "HTTP request failed",
 	},
 
-	ErrHttpResponseInvalid: {
-		Code:    ErrHttpResponseInvalid,
+	ErrHTTPResponseInvalid: {
+		Code:    ErrHTTPResponseInvalid,
 		Message: "Received an invalid response from the server",
 	},
 
@@ -829,8 +829,8 @@ Otherwise start your app for local development with: %s`,
 		Remediation: fmt.Sprintf("Specify the environment with %s or %s\nOr choose a specific app with %s", style.Highlight("--app local"), style.Highlight("--app deployed"), style.Highlight("--app <app_id>")),
 	},
 
-	ErrInvalidAppId: {
-		Code:        ErrInvalidAppId,
+	ErrInvalidAppID: {
+		Code:        ErrInvalidAppID,
 		Message:     "App ID may be invalid for this user account and workspace",
 		Remediation: "Check to make sure you are signed into the correct workspace for this app and you have the required permissions to perform this action.",
 	},
@@ -865,8 +865,8 @@ Otherwise start your app for local development with: %s`,
 		Remediation: fmt.Sprintf("The previous slash command and challenge code have now expired. To retry, use %s, paste the slash command in any Slack channel, and enter the challenge code displayed by Slack. It is easiest to copy & paste the challenge code.", style.Commandf("login", false)),
 	},
 
-	ErrInvalidChannelId: {
-		Code:        ErrInvalidChannelId,
+	ErrInvalidChannelID: {
+		Code:        ErrInvalidChannelID,
 		Message:     "Channel ID specified doesn't exist or you do not have permissions to access it",
 		Remediation: "Channel ID appears to be formatted correctly. Check if this channel exists on the current team and that you have permissions to access it.",
 	},
@@ -925,8 +925,8 @@ Otherwise start your app for local development with: %s`,
 		Message: "The request_id passed is invalid",
 	},
 
-	ErrInvalidResourceId: {
-		Code:    ErrInvalidResourceId,
+	ErrInvalidResourceID: {
+		Code:    ErrInvalidResourceID,
 		Message: "The resource_id for the given resource_type is invalid",
 	},
 
@@ -1006,8 +1006,8 @@ Otherwise start your app for local development with: %s`,
 		Message: "The provided trigger type is not recognized",
 	},
 
-	ErrInvalidUserId: {
-		Code:    ErrInvalidUserId,
+	ErrInvalidUserID: {
+		Code:    ErrInvalidUserID,
 		Message: "A value passed as a user_id is invalid",
 	},
 
@@ -1021,13 +1021,13 @@ Otherwise start your app for local development with: %s`,
 		Message: "Unable to parse the schema ref",
 	},
 
-	ErrInvalidWorkflowAppId: {
-		Code:    ErrInvalidWorkflowAppId,
+	ErrInvalidWorkflowAppID: {
+		Code:    ErrInvalidWorkflowAppID,
 		Message: "A value passed as workflow_app_id is invalid or missing",
 	},
 
-	ErrInvalidWorkflowId: {
-		Code:    ErrInvalidWorkflowId,
+	ErrInvalidWorkflowID: {
+		Code:    ErrInvalidWorkflowID,
 		Message: "A value passed as a workflow ID is invalid",
 	},
 
@@ -1066,8 +1066,8 @@ Otherwise start your app for local development with: %s`,
 		Message: "The provided flags cannot be used together",
 	},
 
-	ErrMissingAppId: {
-		Code:    ErrMissingAppId,
+	ErrMissingAppID: {
+		Code:    ErrMissingAppID,
 		Message: "workflow_app_id is required to update via workflow reference",
 	},
 
@@ -1253,8 +1253,8 @@ Otherwise start your app for local development with: %s`,
 		Message: "This action is only permitted for published app IDs",
 	},
 
-	ErrRequestIdOrAppIdIsRequired: {
-		Code:    ErrRequestIdOrAppIdIsRequired,
+	ErrRequestIDOrAppIDIsRequired: {
+		Code:    ErrRequestIDOrAppIDIsRequired,
 		Message: "Must include a request_id or app_id",
 	},
 
@@ -1329,8 +1329,8 @@ Otherwise start your app for local development with: %s`,
 		Remediation: fmt.Sprintf("Use the command %s to login and %s to install your app", style.Commandf("login", false), style.Commandf("install", false)),
 	},
 
-	ErrSlackJsonLocation: {
-		Code:    ErrSlackJsonLocation,
+	ErrSlackJSONLocation: {
+		Code:    ErrSlackJSONLocation,
 		Message: "The slack.json configuration file is deprecated",
 		Remediation: strings.Join([]string{
 			"Next major version of the CLI will no longer support this configuration file.",
@@ -1338,8 +1338,8 @@ Otherwise start your app for local development with: %s`,
 		}, "\n"),
 	},
 
-	ErrSlackSlackJsonLocation: {
-		Code:    ErrSlackSlackJsonLocation,
+	ErrSlackSlackJSONLocation: {
+		Code:    ErrSlackSlackJSONLocation,
 		Message: fmt.Sprintf("The %s configuration file is deprecated", filepath.Join(".slack", "slack.json")),
 		Remediation: strings.Join([]string{
 			"Next major version of the CLI will no longer support this configuration file.",
@@ -1486,8 +1486,8 @@ Otherwise start your app for local development with: %s`,
 		Message: "Error with file upload",
 	},
 
-	ErrUnableToParseJson: {
-		Code:    ErrUnableToParseJson,
+	ErrUnableToParseJSON: {
+		Code:    ErrUnableToParseJSON,
 		Message: "`<json>` Couldn't be parsed as a json object",
 	},
 
@@ -1501,8 +1501,8 @@ Otherwise start your app for local development with: %s`,
 		Message: "Unknown file type, must be application/zip",
 	},
 
-	ErrUnknownFunctionId: {
-		Code:    ErrUnknownFunctionId,
+	ErrUnknownFunctionID: {
+		Code:    ErrUnknownFunctionID,
 		Message: "The provided function_id was not found",
 	},
 
@@ -1522,13 +1522,13 @@ Otherwise start your app for local development with: %s`,
 		Remediation: "Use --force flag or set trust_unknown_sources: true in config.json file to disable warning",
 	},
 
-	ErrUnknownWorkflowId: {
-		Code:    ErrUnknownWorkflowId,
+	ErrUnknownWorkflowID: {
+		Code:    ErrUnknownWorkflowID,
 		Message: "The provided workflow_id was not found for this app",
 	},
 
-	ErrUserIdIsRequired: {
-		Code:    ErrUserIdIsRequired,
+	ErrUserIDIsRequired: {
+		Code:    ErrUserIDIsRequired,
 		Message: "Must include a user_id to cancel request for an app with app_id",
 	},
 

--- a/internal/tracking/tracking.go
+++ b/internal/tracking/tracking.go
@@ -162,8 +162,8 @@ func (e *EventTracker) FlushToLogstash(ctx context.Context, cfg *config.Config, 
 	if cfg.DisableTelemetryFlag {
 		return nil
 	}
-	postUrl := cfg.LogstashHostResolved
-	if postUrl == "" {
+	postURL := cfg.LogstashHostResolved
+	if postURL == "" {
 		// Root command initialization was not run; we might get here if user ran `slack --version`.
 		// In this case, the root command was not initialized, so none of the bootup routine executed (flags weren't parsed, config not initialized, etc.).
 		return nil
@@ -210,10 +210,10 @@ func (e *EventTracker) FlushToLogstash(ctx context.Context, cfg *config.Config, 
 		return err
 	}
 
-	ioStream.PrintDebug(ctx, "FlushToLogstash will POST %s payload: %s", postUrl, string(postBody))
+	ioStream.PrintDebug(ctx, "FlushToLogstash will POST %s payload: %s", postURL, string(postBody))
 	responseBody := bytes.NewBuffer(postBody)
 
-	request, err := http.NewRequest("POST", postUrl, responseBody)
+	request, err := http.NewRequest("POST", postURL, responseBody)
 	if err != nil {
 		return err
 	}

--- a/internal/update/autoupdate_test.go
+++ b/internal/update/autoupdate_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const SCRIPT_TEMPLATE = "#!/bin/bash\necho %s\n"
+const scriptTemplate = "#!/bin/bash\necho %s\n"
 
 type testFile struct {
 	path    string
@@ -42,10 +42,10 @@ type testData struct {
 }
 
 func TestDownload(t *testing.T) {
-	badCLIDownloadUrl := "https://downloads.slack-edge.com/slack-cli/fake.zip"
+	badCLIDownloadURL := "https://downloads.slack-edge.com/slack-cli/fake.zip"
 	dir := t.TempDir()
 	dstFilePath := filepath.Join(dir, "slack")
-	err := download(badCLIDownloadUrl, dstFilePath)
+	err := download(badCLIDownloadURL, dstFilePath)
 	require.Error(t, err, "Should return an error")
 }
 
@@ -56,7 +56,7 @@ func TestUpgradeFromLocalFile_multiFile(t *testing.T) {
 	filesToArchive := []testFile{
 		{
 			path:    "bin/slack",
-			content: fmt.Sprintf(SCRIPT_TEMPLATE, newVersion),
+			content: fmt.Sprintf(scriptTemplate, newVersion),
 		},
 		{
 			path:    "README.md",
@@ -123,7 +123,7 @@ func TestUpgradeFromLocalFile_singleFile(t *testing.T) {
 	filesToArchive := []testFile{
 		{
 			path:    "slack",
-			content: fmt.Sprintf(SCRIPT_TEMPLATE, newVersion),
+			content: fmt.Sprintf(scriptTemplate, newVersion),
 		},
 	}
 
@@ -178,7 +178,7 @@ func TestUpgradeFromLocalFile_restoresAfterBadUpgrade(t *testing.T) {
 	filesToArchive := []testFile{
 		{
 			path:    "slack",
-			content: fmt.Sprintf(SCRIPT_TEMPLATE, "vBadVersion"),
+			content: fmt.Sprintf(scriptTemplate, "vBadVersion"),
 		},
 	}
 	dir := t.TempDir()

--- a/internal/update/cli.go
+++ b/internal/update/cli.go
@@ -49,7 +49,7 @@ func NewCLIDependency(clients *shared.ClientFactory, version string) *CLIDepende
 // the latest update available directly to the CLIDependency instance
 // Synchronous version of CheckForUpdateInBackground
 func (c *CLIDependency) CheckForUpdate(ctx context.Context) error {
-	httpClient, err := newHttpClient()
+	httpClient, err := newHTTPClient()
 	if err != nil {
 		return err
 	}

--- a/internal/update/cli.go
+++ b/internal/update/cli.go
@@ -24,7 +24,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const metaDataUrl = "https://api.slack.com/slackcli/metadata.json"
+const metaDataURL = "https://api.slack.com/slackcli/metadata.json"
 
 // CLIDependency contains information about the
 // current version and the latest CLI release version
@@ -55,7 +55,7 @@ func (c *CLIDependency) CheckForUpdate(ctx context.Context) error {
 	}
 
 	metadata := Metadata{httpClient: httpClient}
-	c.releaseInfo, err = metadata.CheckForUpdate(ctx, metaDataUrl, c.version)
+	c.releaseInfo, err = metadata.CheckForUpdate(ctx, metaDataURL, c.version)
 	if err != nil {
 		return err
 	}

--- a/internal/update/cli_metadata_test.go
+++ b/internal/update/cli_metadata_test.go
@@ -39,7 +39,7 @@ func (m *HTTPClientMock) Do(req *http.Request) (*http.Response, error) {
 
 // Test_CLI_Metadata_CheckForUpdate tests different responses from Slack CLI metadata.
 func Test_CLI_Metadata_CheckForUpdate(t *testing.T) {
-	const metaDataUrl = "https://api.slack.com/slackcli/metadata.json"
+	const metaDataURL = "https://api.slack.com/slackcli/metadata.json"
 
 	scenarios := map[string]struct {
 		CurrentVersion string
@@ -86,7 +86,7 @@ func Test_CLI_Metadata_CheckForUpdate(t *testing.T) {
 
 			// Check for an update
 			md := Metadata{httpClient: httpClientMock}
-			releaseInfo, err := md.CheckForUpdate(ctx, metaDataUrl, s.CurrentVersion)
+			releaseInfo, err := md.CheckForUpdate(ctx, metaDataURL, s.CurrentVersion)
 
 			// Assert expected results
 			if s.ExpectsResult {

--- a/internal/update/sdk.go
+++ b/internal/update/sdk.go
@@ -137,7 +137,7 @@ func CheckUpdateHook(ctx context.Context, clients *shared.ClientFactory) (SDKRel
 	}
 	err = json.Unmarshal([]byte(checkUpdateResponse), &checkUpdate)
 	if err != nil {
-		return SDKReleaseInfo{}, slackerror.New(slackerror.ErrUnableToParseJson).
+		return SDKReleaseInfo{}, slackerror.New(slackerror.ErrUnableToParseJSON).
 			WithMessage("Failed to parse response from check-update hook").
 			WithRootCause(err)
 	}

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -247,7 +247,7 @@ func (u *UpdateNotification) isLastUpdateCheckedAtGreaterThan(ctx context.Contex
 	return false
 }
 
-// newHttpClient returns an http.Client for checking the latest release on github.com.
-func newHttpClient() (*http.Client, error) {
-	return api.NewHttpClient(api.HttpClientOptions{TotalTimeOut: 60 * time.Second}), nil
+// newHTTPClient returns an http.Client for checking the latest release on github.com.
+func newHTTPClient() (*http.Client, error) {
+	return api.NewHTTPClient(api.HTTPClientOptions{TotalTimeOut: 60 * time.Second}), nil
 }

--- a/main.go
+++ b/main.go
@@ -41,7 +41,7 @@ func main() {
 
 	// TODO - Could we refactor this to cmd/root.go to initialize open tracing after the CLI flags are parsed?
 	//      - This would allow us to choose the correct API host based on flags
-	//      - Uncomment `isDevTarget` if we refactor to cmd/root.go and update to call `ResolveApiHost`
+	//      - Uncomment `isDevTarget` if we refactor to cmd/root.go and update to call `ResolveAPIHost`
 	// var isDevTarget = shared.NewClientFactory().AuthClient().UserDefaultAuthIsProd(ctx) // TODO - hack, remove shared.clients
 	var jaegerCloser, tracer = tracer.SetupTracer(false) // Always setup open tracing on prod
 	defer jaegerCloser.Close()
@@ -86,7 +86,7 @@ func recoveryFunc() {
 		ctx = slackcontext.SetSessionID(ctx, uuid.New().String())
 
 		// set host for logging
-		clients.Config.LogstashHostResolved = clients.AuthInterface().ResolveLogstashHost(ctx, clients.Config.ApiHostResolved, clients.Config.Version)
+		clients.Config.LogstashHostResolved = clients.AuthInterface().ResolveLogstashHost(ctx, clients.Config.APIHostResolved, clients.Config.Version)
 		clients.IO.PrintError(ctx, "Recovered from panic: %s\n%s", r, string(debug.Stack()))
 		os.Exit(int(iostreams.ExitError))
 	}


### PR DESCRIPTION
### Summary

This pull request enables the Linter Rule ST1003 "Poorly Chosen Identifier" and updates all identifiers to match the new rule.

For the most part, this changing `Id → ID`, `Http → HTTP`, `SOME_CONSTANT → SomeConstant`, etc.

There is no change to functionality. 🚳 

### Reviewers

I'm so so so so sorry for the HUGE PR. I think this will be a common theme as we enable more of the default linter rules. 😆 

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).