### PR TITLE
feat: add support for 'feedback --name slack-platform'

### DIFF
--- a/cmd/feedback/feedback.go
+++ b/cmd/feedback/feedback.go
@@ -90,7 +90,7 @@ var SurveyStore = map[string]SlackSurvey{
 			clients.IO.PrintInfo(ctx, false, fmt.Sprintf(
 				"%s\n%s\n",
 				style.Secondary("You can send us a message at "+style.Highlight(email)),
-				style.Secondary("Or, survey your experiences at "+style.Highlight("https://docs.slack.dev/developer-support")),
+				style.Secondary("Or, share your experiences at "+style.Highlight("https://docs.slack.dev/developer-support")),
 			))
 		},
 		Trace: slacktrace.FeedbackMessage,
@@ -206,7 +206,8 @@ func NewFeedbackCommand(clients *shared.ClientFactory) *cobra.Command {
 		Short:   "Share feedback about your experience or project",
 		Long:    "Help us make the Slack Platform better with your feedback",
 		Example: style.ExampleCommandsf([]style.ExampleCommand{
-			{Command: "feedback", Meaning: "Open a feedback survey in your browser"},
+			{Command: "feedback", Meaning: "Choose to give feedback on part of the Slack Platform"},
+			{Command: "feedback --name slack-cli-feedback", Meaning: "Give feedback on the Slack CLI"},
 		}),
 		PreRun: func(cmd *cobra.Command, args []string) {
 			clients.Config.SetFlags(cmd)
@@ -225,7 +226,7 @@ func NewFeedbackCommand(clients *shared.ClientFactory) *cobra.Command {
 	}
 	sort.Strings(surveyNames)
 	nameFlagDescription := style.Sectionf(style.TextSection{
-		Text:      "name of the survey:",
+		Text:      "name of the feedback:",
 		Secondary: surveyNames,
 	})
 	cmd.Flags().StringVar(&surveyNameFlag, "name", "", nameFlagDescription)
@@ -238,7 +239,7 @@ func NewFeedbackCommand(clients *shared.ClientFactory) *cobra.Command {
 // runFeedbackCommand will open the user's browser to the feedback survey webpage.
 func runFeedbackCommand(ctx context.Context, clients *shared.ClientFactory, cmd *cobra.Command) error {
 	if len(SurveyStore) == 0 {
-		clients.IO.PrintInfo(ctx, false, "No surveys currently available; please try again later")
+		clients.IO.PrintInfo(ctx, false, "No feedback options currently available; please try again later")
 		return nil
 	}
 
@@ -246,14 +247,14 @@ func runFeedbackCommand(ctx context.Context, clients *shared.ClientFactory, cmd 
 
 	if _, ok := SurveyStore[surveyNameFlag]; !ok && surveyNameFlag != "" {
 		return slackerror.New("invalid_survey_name").
-			WithMessage("Invalid survey name provided: %s", surveyNameFlag).
-			WithRemediation("View survey options with %s", style.Commandf("feedback --help", false))
+			WithMessage("Invalid feedback name provided: %s", surveyNameFlag).
+			WithRemediation("View the feedback options with %s", style.Commandf("feedback --help", false))
 	}
 
 	if surveyNameFlag == "" && noPromptFlag {
 		return slackerror.New("survey_name_required").
-			WithMessage("Please provide a survey name or remove the --no-prompt flag").
-			WithRemediation("View survey options with %s", style.Commandf("feedback --help", false))
+			WithMessage("Please provide a feedback name or remove the --no-prompt flag").
+			WithRemediation("View feedback options with %s", style.Commandf("feedback --help", false))
 	}
 
 	clients.IO.PrintInfo(ctx, false, style.Sectionf(style.TextSection{
@@ -339,7 +340,7 @@ func executeSurvey(ctx context.Context, clients *shared.ClientFactory, s SlackSu
 	var err error
 	var ok bool
 	if !noPromptFlag {
-		ok, err = clients.IO.ConfirmPrompt(ctx, "Open survey in browser?", true)
+		ok, err = clients.IO.ConfirmPrompt(ctx, "Open in browser?", true)
 		if err != nil {
 			return err
 		}
@@ -353,7 +354,7 @@ func executeSurvey(ctx context.Context, clients *shared.ClientFactory, s SlackSu
 	if ok { // Open survey in browser
 		clients.Browser().OpenURL(u)
 	} else { // Print survey URL
-		clients.IO.PrintInfo(ctx, false, fmt.Sprint("Survey URL: \n", style.Secondary(u)))
+		clients.IO.PrintInfo(ctx, false, fmt.Sprint("Feedback URL: \n", style.Secondary(u)))
 	}
 
 	// Record completion

--- a/cmd/feedback/feedback.go
+++ b/cmd/feedback/feedback.go
@@ -40,7 +40,7 @@ type SlackSurvey struct {
 	PromptDisplayText string
 	// PromptDescription is displayed beneath the `feedback` command prompt option
 	PromptDescription string
-	// SkipQueryParams is a flag to skip adding query params to the survey URL
+	// SkipQueryParams is a flag to skip adding query params to the survey URL (optional, default false)
 	SkipQueryParams bool
 	// URL is the survey URL
 	URL url.URL

--- a/cmd/feedback/feedback.go
+++ b/cmd/feedback/feedback.go
@@ -68,8 +68,8 @@ const (
 
 // Supported survey names
 const (
-	PlatformSurvey   = "platform-improvements"
-	SlackCLIFeedback = "slack-cli-feedback"
+	SlackCLIFeedback      = "slack-cli-feedback"
+	SlackPlatformFeedback = "platform-improvements"
 )
 
 type SurveyConfigInterface interface {
@@ -80,35 +80,6 @@ type SurveyConfigInterface interface {
 // SurveyStore stores all available surveys.
 // New surveys should be added here.
 var SurveyStore = map[string]SlackSurvey{
-	// PlatformSurvey asks for general developer experience feedback
-	PlatformSurvey: {
-		Name:              PlatformSurvey,
-		PromptDisplayText: "Help make the Slack platform better",
-		PromptDescription: "Tell us about your experience as a Slack developer",
-		URL:               url.URL{RawPath: "https://docs.slack.dev/developer-support"},
-		Info: func(ctx context.Context, clients *shared.ClientFactory) {
-			clients.IO.PrintInfo(ctx, false, fmt.Sprintf(
-				"%s\n%s\n",
-				style.Secondary("You can send us a message at "+style.Highlight(email)),
-				style.Secondary("Or, share your experiences at "+style.Highlight("https://docs.slack.dev/developer-support")),
-			))
-		},
-		Trace: slacktrace.FeedbackMessage,
-		Ask: func(ctx context.Context, clients *shared.ClientFactory) (bool, error) {
-			clients.IO.PrintInfo(ctx, false, style.Sectionf(style.TextSection{
-				Emoji: "love_letter",
-				Text:  "We would love to know how things are going",
-				Secondary: []string{
-					"Share your development experience with " + style.Commandf("feedback", false),
-				},
-			}))
-			return false, nil
-		},
-		Frequency: Always,
-		Config: func(clients *shared.ClientFactory) SurveyConfigInterface {
-			return clients.Config.SystemConfig
-		},
-	},
 	// SlackCLIFeedback asks for Slack CLI feedback using GitHub Issues
 	SlackCLIFeedback: {
 		Name:              SlackCLIFeedback,
@@ -136,6 +107,35 @@ var SurveyStore = map[string]SlackSurvey{
 			return false, nil
 		},
 		Frequency: Never,
+		Config: func(clients *shared.ClientFactory) SurveyConfigInterface {
+			return clients.Config.SystemConfig
+		},
+	},
+	// SlackPlatformFeedback asks for general developer experience feedback
+	SlackPlatformFeedback: {
+		Name:              SlackPlatformFeedback,
+		PromptDisplayText: "Slack Platform",
+		PromptDescription: "Developer support for the Slack Platform, Slack API, Block Kit, and more",
+		URL:               url.URL{RawPath: "https://docs.slack.dev/developer-support"},
+		Info: func(ctx context.Context, clients *shared.ClientFactory) {
+			clients.IO.PrintInfo(ctx, false, fmt.Sprintf(
+				"%s\n%s\n",
+				style.Secondary("You can send us a message at "+style.Highlight(email)),
+				style.Secondary("Or, share your experiences at "+style.Highlight("https://docs.slack.dev/developer-support")),
+			))
+		},
+		Trace: slacktrace.FeedbackMessage,
+		Ask: func(ctx context.Context, clients *shared.ClientFactory) (bool, error) {
+			clients.IO.PrintInfo(ctx, false, style.Sectionf(style.TextSection{
+				Emoji: "love_letter",
+				Text:  "We would love to know how things are going",
+				Secondary: []string{
+					"Share your development experience with " + style.Commandf("feedback", false),
+				},
+			}))
+			return false, nil
+		},
+		Frequency: Always,
 		Config: func(clients *shared.ClientFactory) SurveyConfigInterface {
 			return clients.Config.SystemConfig
 		},

--- a/cmd/feedback/feedback.go
+++ b/cmd/feedback/feedback.go
@@ -246,6 +246,7 @@ func runFeedbackCommand(ctx context.Context, clients *shared.ClientFactory, cmd 
 	// DEPRECATED(semver:major): Support the deprecated survey name for backwards compatibility
 	if surveyNameFlag == SlackPlatformFeedbackDeprecated {
 		surveyNameFlag = SlackPlatformFeedback
+		clients.IO.PrintDebug(ctx, "DEPRECATED: The '--name %s' flag is deprecated; use '--name %s' instead", SlackPlatformFeedbackDeprecated, SlackPlatformFeedback)
 	}
 
 	surveyNames, surveyPromptOptions := initSurveyOpts(ctx, clients, SurveyStore)

--- a/cmd/feedback/feedback.go
+++ b/cmd/feedback/feedback.go
@@ -245,15 +245,12 @@ func runFeedbackCommand(ctx context.Context, clients *shared.ClientFactory, cmd 
 	surveyNames, surveyPromptOptions := initSurveyOpts(ctx, clients, SurveyStore)
 
 	if _, ok := SurveyStore[surveyNameFlag]; !ok && surveyNameFlag != "" {
-		return slackerror.New("invalid_survey_name").
-			WithMessage("Invalid feedback name provided: %s", surveyNameFlag).
-			WithRemediation("View the feedback options with %s", style.Commandf("feedback --help", false))
+		return slackerror.New(slackerror.ErrFeedbackNameInvalid).
+			WithMessage("Invalid feedback name provided: %s", surveyNameFlag)
 	}
 
 	if surveyNameFlag == "" && noPromptFlag {
-		return slackerror.New("survey_name_required").
-			WithMessage("Please provide a feedback name or remove the --no-prompt flag").
-			WithRemediation("View feedback options with %s", style.Commandf("feedback --help", false))
+		return slackerror.New(slackerror.ErrFeedbackNameRequired)
 	}
 
 	clients.IO.PrintInfo(ctx, false, style.Sectionf(style.TextSection{

--- a/cmd/feedback/feedback.go
+++ b/cmd/feedback/feedback.go
@@ -338,7 +338,7 @@ func executeSurvey(ctx context.Context, clients *shared.ClientFactory, s SlackSu
 	if s.Info != nil {
 		s.Info(ctx, clients)
 	}
-	clients.IO.PrintTrace(ctx, s.Trace)
+	clients.IO.PrintTrace(ctx, s.Trace, s.Name)
 
 	var err error
 	var ok bool

--- a/cmd/feedback/feedback.go
+++ b/cmd/feedback/feedback.go
@@ -68,8 +68,9 @@ const (
 
 // Supported survey names
 const (
-	SlackCLIFeedback      = "slack-cli"
-	SlackPlatformFeedback = "platform-improvements"
+	SlackCLIFeedback                = "slack-cli"
+	SlackPlatformFeedback           = "slack-platform"
+	SlackPlatformFeedbackDeprecated = "platform-improvements" // DEPRECATED(semver:major)
 )
 
 type SurveyConfigInterface interface {
@@ -92,7 +93,7 @@ var SurveyStore = map[string]SlackSurvey{
 		Info: func(ctx context.Context, clients *shared.ClientFactory) {
 			clients.IO.PrintInfo(ctx, false, fmt.Sprintf(
 				"%s\n%s\n",
-				style.Secondary("Ask questions, submit issues, or suggest features for the SLack CLI:"),
+				style.Secondary("Ask questions, submit issues, or suggest features for the Slack CLI:"),
 				style.Secondary(style.Highlight("https://github.com/slackapi/slack-cli/issues")),
 			))
 		},
@@ -240,6 +241,11 @@ func runFeedbackCommand(ctx context.Context, clients *shared.ClientFactory, cmd 
 	if len(SurveyStore) == 0 {
 		clients.IO.PrintInfo(ctx, false, "No feedback options currently available; please try again later")
 		return nil
+	}
+
+	// DEPRECATED(semver:major): Support the deprecated survey name for backwards compatibility
+	if surveyNameFlag == SlackPlatformFeedbackDeprecated {
+		surveyNameFlag = SlackPlatformFeedback
 	}
 
 	surveyNames, surveyPromptOptions := initSurveyOpts(ctx, clients, SurveyStore)

--- a/cmd/feedback/feedback.go
+++ b/cmd/feedback/feedback.go
@@ -51,8 +51,6 @@ type SlackSurvey struct {
 	// Info prints additional information about the survey; displayed when the option is selected in `feedback`
 	// Info is optional
 	Info func(ctx context.Context, clients *shared.ClientFactory)
-	// Trace is a string consumed by tests to confirm that the Info text was displayed
-	Trace string
 	// Ask either prints text or prompts the user to complete the survey
 	// Potentially displayed after `run`/`deploy`/`doctor` (or other places where ShowSurveyMessages is called)
 	Ask func(ctx context.Context, clients *shared.ClientFactory) (bool, error)
@@ -98,7 +96,6 @@ var SurveyStore = map[string]SlackSurvey{
 				style.Secondary(style.Highlight("https://github.com/slackapi/slack-cli/issues")),
 			))
 		},
-		Trace: slacktrace.FeedbackMessage,
 		Ask: func(ctx context.Context, clients *shared.ClientFactory) (bool, error) {
 			clients.IO.PrintInfo(ctx, false, style.Sectionf(style.TextSection{
 				Emoji: "love_letter",
@@ -127,7 +124,6 @@ var SurveyStore = map[string]SlackSurvey{
 				style.Secondary("Or, share your experiences at "+style.Highlight("https://docs.slack.dev/developer-support")),
 			))
 		},
-		Trace: slacktrace.FeedbackMessage,
 		Ask: func(ctx context.Context, clients *shared.ClientFactory) (bool, error) {
 			clients.IO.PrintInfo(ctx, false, style.Sectionf(style.TextSection{
 				Emoji: "love_letter",
@@ -338,7 +334,8 @@ func executeSurvey(ctx context.Context, clients *shared.ClientFactory, s SlackSu
 	if s.Info != nil {
 		s.Info(ctx, clients)
 	}
-	clients.IO.PrintTrace(ctx, s.Trace, s.Name)
+
+	clients.IO.PrintTrace(ctx, slacktrace.FeedbackMessage, s.Name)
 
 	var err error
 	var ok bool

--- a/cmd/feedback/feedback.go
+++ b/cmd/feedback/feedback.go
@@ -246,7 +246,7 @@ func runFeedbackCommand(ctx context.Context, clients *shared.ClientFactory, cmd 
 	// DEPRECATED(semver:major): Support the deprecated survey name for backwards compatibility
 	if surveyNameFlag == SlackPlatformFeedbackDeprecated {
 		surveyNameFlag = SlackPlatformFeedback
-		clients.IO.PrintDebug(ctx, "DEPRECATED: The '--name %s' flag is deprecated; use '--name %s' instead", SlackPlatformFeedbackDeprecated, SlackPlatformFeedback)
+		clients.IO.PrintWarning(ctx, "DEPRECATED: The '--name %s' flag is deprecated; use '--name %s' instead", SlackPlatformFeedbackDeprecated, SlackPlatformFeedback)
 	}
 
 	surveyNames, surveyPromptOptions := initSurveyOpts(ctx, clients, SurveyStore)

--- a/cmd/feedback/feedback_test.go
+++ b/cmd/feedback/feedback_test.go
@@ -36,8 +36,8 @@ func TestFeedbackCommand(t *testing.T) {
 	t.Run("when there is only one survey option", func(t *testing.T) {
 
 		surveys := map[string]SlackSurvey{
-			PlatformSurvey: {
-				Name:              PlatformSurvey,
+			SlackPlatformFeedback: {
+				Name:              SlackPlatformFeedback,
 				PromptDisplayText: "Please complete this survey",
 				URL:               url.URL{RawPath: "https://survey.com"},
 				Config: func(clients *shared.ClientFactory) SurveyConfigInterface {
@@ -53,11 +53,11 @@ func TestFeedbackCommand(t *testing.T) {
 
 		pcm := &config.ProjectConfigMock{}
 		pcm.On("GetProjectID", mock.Anything).Return("projectID", nil)
-		pcm.On("GetSurveyConfig", mock.Anything, PlatformSurvey).Return(config.SurveyConfig{}, nil)
+		pcm.On("GetSurveyConfig", mock.Anything, SlackPlatformFeedback).Return(config.SurveyConfig{}, nil)
 		clientsMock.Config.ProjectConfig = pcm
 
 		scm := &config.SystemConfigMock{}
-		scm.On("GetSurveyConfig", mock.Anything, PlatformSurvey).Return(config.SurveyConfig{}, nil)
+		scm.On("GetSurveyConfig", mock.Anything, SlackPlatformFeedback).Return(config.SurveyConfig{}, nil)
 		scm.On("GetSystemID", mock.Anything).Return("systemID", nil)
 		scm.On("SetSurveyConfig", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		clientsMock.Config.SystemConfig = scm
@@ -87,8 +87,8 @@ func TestFeedbackCommand(t *testing.T) {
 					return clients.Config.SystemConfig
 				},
 			},
-			PlatformSurvey: {
-				Name:              PlatformSurvey,
+			SlackPlatformFeedback: {
+				Name:              SlackPlatformFeedback,
 				PromptDisplayText: "PlatformSurvey survey",
 				URL:               url.URL{RawPath: "https://survey.com"},
 				Config: func(clients *shared.ClientFactory) SurveyConfigInterface {

--- a/cmd/feedback/feedback_test.go
+++ b/cmd/feedback/feedback_test.go
@@ -68,7 +68,9 @@ func TestFeedbackCommand(t *testing.T) {
 
 		clients := shared.NewClientFactory(clientsMock.MockClientFactory())
 
+		_surveys := SurveyStore
 		SurveyStore = surveys
+		defer func() { SurveyStore = _surveys }()
 
 		// Execute test
 		cmd := NewFeedbackCommand(clients)
@@ -136,7 +138,9 @@ func TestFeedbackCommand(t *testing.T) {
 
 		clients := shared.NewClientFactory(clientsMock.MockClientFactory())
 
+		_surveys := SurveyStore
 		SurveyStore = surveys
+		defer func() { SurveyStore = _surveys }()
 
 		// Execute test
 		cmd := NewFeedbackCommand(clients)
@@ -245,7 +249,9 @@ func TestShowSurveyMessages(t *testing.T) {
 
 		clients := shared.NewClientFactory(clientsMock.MockClientFactory())
 
+		_surveys := SurveyStore
 		SurveyStore = surveys
+		defer func() { SurveyStore = _surveys }()
 
 		// Execute test
 		err := ShowSurveyMessages(ctx, clients)

--- a/cmd/feedback/feedback_test.go
+++ b/cmd/feedback/feedback_test.go
@@ -62,7 +62,7 @@ func TestFeedbackCommand(t *testing.T) {
 		scm.On("SetSurveyConfig", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 		clientsMock.Config.SystemConfig = scm
 
-		clientsMock.IO.On("ConfirmPrompt", mock.Anything, "Open survey in browser?", mock.Anything).Return(true)
+		clientsMock.IO.On("ConfirmPrompt", mock.Anything, "Open in browser?", mock.Anything).Return(true)
 		clientsMock.Browser.On("OpenURL", "https://survey.com?project_id=projectID&system_id=systemID&utm_medium=cli&utm_source=cli").Return(nil)
 
 		clients := shared.NewClientFactory(clientsMock.MockClientFactory())
@@ -128,7 +128,7 @@ func TestFeedbackCommand(t *testing.T) {
 			Index:  2,
 		}, nil)
 
-		clientsMock.IO.On("ConfirmPrompt", mock.Anything, "Open survey in browser?", mock.Anything).Return(true)
+		clientsMock.IO.On("ConfirmPrompt", mock.Anything, "Open in browser?", mock.Anything).Return(true)
 		clientsMock.Browser.On("OpenURL", "https://survey.com?project_id=projectID&system_id=systemID&utm_medium=cli&utm_source=cli").Return(nil)
 
 		clients := shared.NewClientFactory(clientsMock.MockClientFactory())
@@ -217,7 +217,7 @@ func TestShowSurveyMessages(t *testing.T) {
 		clientsMock.IO.On("ConfirmPrompt", mock.Anything, "Would you like to take a minute to tell us about B?", mock.Anything).Return(true)
 		scm.On("GetSystemID", mock.Anything).Return("systemID", nil).Once()
 		pcm.On("GetProjectID", mock.Anything).Return("projectID", nil).Once()
-		clientsMock.IO.On("ConfirmPrompt", mock.Anything, "Open survey in browser?", mock.Anything).Return(true).Once()
+		clientsMock.IO.On("ConfirmPrompt", mock.Anything, "Open in browser?", mock.Anything).Return(true).Once()
 		clientsMock.Browser.On("OpenURL", "https://B.com?project_id=projectID&system_id=systemID&utm_medium=cli&utm_source=cli").Return(nil).Once()
 		pcm.On("SetSurveyConfig", mock.Anything, "B", mock.Anything).Return(nil).Once()
 
@@ -226,7 +226,7 @@ func TestShowSurveyMessages(t *testing.T) {
 		clientsMock.IO.On("ConfirmPrompt", mock.Anything, "Would you like to take a minute to tell us about C?", mock.Anything).Return(true)
 		scm.On("GetSystemID", mock.Anything).Return("systemID", nil).Once()
 		pcm.On("GetProjectID", mock.Anything).Return("projectID", nil).Once()
-		clientsMock.IO.On("ConfirmPrompt", mock.Anything, "Open survey in browser?", mock.Anything).Return(true).Once()
+		clientsMock.IO.On("ConfirmPrompt", mock.Anything, "Open in browser?", mock.Anything).Return(true).Once()
 		clientsMock.Browser.On("OpenURL", "https://C.com?project_id=projectID&system_id=systemID&utm_medium=cli&utm_source=cli").Return(nil).Once()
 		scm.On("SetSurveyConfig", mock.Anything, "C", mock.Anything).Return(nil).Once()
 

--- a/cmd/feedback/feedback_test.go
+++ b/cmd/feedback/feedback_test.go
@@ -26,15 +26,14 @@ import (
 	"github.com/slackapi/slack-cli/internal/shared"
 	"github.com/slackapi/slack-cli/internal/slackcontext"
 	"github.com/slackapi/slack-cli/internal/slackerror"
+	"github.com/slackapi/slack-cli/internal/slacktrace"
 	"github.com/slackapi/slack-cli/internal/style"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
 
 func TestFeedbackCommand(t *testing.T) {
-
 	t.Run("when there is only one survey option", func(t *testing.T) {
-
 		surveys := map[string]SlackSurvey{
 			SlackPlatformFeedback: {
 				Name:              SlackPlatformFeedback,
@@ -72,12 +71,14 @@ func TestFeedbackCommand(t *testing.T) {
 		// Execute test
 		cmd := NewFeedbackCommand(clients)
 		err := runFeedbackCommand(ctx, clients, cmd)
+
+		// Assertions
 		assert.NoError(t, err)
 		clientsMock.Browser.AssertCalled(t, "OpenURL", "https://survey.com?project_id=projectID&system_id=systemID&utm_medium=cli&utm_source=cli")
+		clientsMock.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.FeedbackMessage, []string{SlackPlatformFeedback})
 	})
 
 	t.Run("when there are multiple survey options", func(t *testing.T) {
-
 		surveys := map[string]SlackSurvey{
 			"A_test": {
 				Name:              "A_test",
@@ -139,12 +140,14 @@ func TestFeedbackCommand(t *testing.T) {
 		cmd := NewFeedbackCommand(clients)
 		err := runFeedbackCommand(ctx, clients, cmd)
 		assert.NoError(t, err)
+
+		// Assertions
 		clientsMock.Browser.AssertCalled(t, "OpenURL", "https://survey.com?project_id=projectID&system_id=systemID&utm_medium=cli&utm_source=cli")
+		clientsMock.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.FeedbackMessage, []string{SlackPlatformFeedback})
 	})
 }
 
 func TestShowSurveyMessages(t *testing.T) {
-
 	t.Run("surveys asked or not asked based on the stored config", func(t *testing.T) {
 		surveys := map[string]SlackSurvey{
 			// Should be asked once; already asked
@@ -248,5 +251,4 @@ func TestShowSurveyMessages(t *testing.T) {
 		clientsMock.Browser.AssertCalled(t, "OpenURL", "https://B.com?project_id=projectID&system_id=systemID&utm_medium=cli&utm_source=cli")
 		clientsMock.Browser.AssertCalled(t, "OpenURL", "https://C.com?project_id=projectID&system_id=systemID&utm_medium=cli&utm_source=cli")
 	})
-
 }

--- a/cmd/feedback/feedback_test.go
+++ b/cmd/feedback/feedback_test.go
@@ -28,6 +28,8 @@ import (
 	"github.com/slackapi/slack-cli/internal/slackerror"
 	"github.com/slackapi/slack-cli/internal/slacktrace"
 	"github.com/slackapi/slack-cli/internal/style"
+	"github.com/slackapi/slack-cli/test/testutil"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -251,4 +253,61 @@ func TestShowSurveyMessages(t *testing.T) {
 		clientsMock.Browser.AssertCalled(t, "OpenURL", "https://B.com?project_id=projectID&system_id=systemID&utm_medium=cli&utm_source=cli")
 		clientsMock.Browser.AssertCalled(t, "OpenURL", "https://C.com?project_id=projectID&system_id=systemID&utm_medium=cli&utm_source=cli")
 	})
+}
+
+func Test_Feedback_FeedbackCommand(t *testing.T) {
+	testutil.TableTestCommand(t, testutil.CommandTests{
+		// DEPRECATED(semver:major): Support the deprecated survey name for backwards compatibility
+		"supports deprecated --name platform-improvements": {
+			CmdArgs: []string{"--name", "platform-improvements"},
+			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
+				setupFeedbackCommandMocks(t, ctx, cm, cf)
+			},
+			ExpectedOutputs: []string{
+				"feedback@slack.com",
+				"https://docs.slack.dev/developer-support",
+			},
+		},
+		"supports --name slack-cli": {
+			CmdArgs: []string{"--name", "slack-cli"},
+			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
+				setupFeedbackCommandMocks(t, ctx, cm, cf)
+			},
+			ExpectedOutputs: []string{
+				"Ask questions, submit issues, or suggest features for the Slack CLI",
+				"https://github.com/slackapi/slack-cli/issues",
+			},
+		},
+		"supports --name slack-platform": {
+			CmdArgs: []string{"--name", "slack-platform"},
+			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
+				setupFeedbackCommandMocks(t, ctx, cm, cf)
+			},
+			ExpectedOutputs: []string{
+				"feedback@slack.com",
+				"https://docs.slack.dev/developer-support",
+			},
+		},
+	}, func(cf *shared.ClientFactory) *cobra.Command {
+		cmd := NewFeedbackCommand(cf)
+		return cmd
+	})
+}
+
+// setupFeedbackCommandMocks prepares common mocks for these tests
+func setupFeedbackCommandMocks(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
+	cm.AddDefaultMocks()
+
+	scm := &config.SystemConfigMock{}
+	scm.On("GetSurveyConfig", mock.Anything, mock.Anything).Return(config.SurveyConfig{}, nil)
+	scm.On("GetSystemID", mock.Anything).Return("systemID", nil)
+	scm.On("SetSurveyConfig", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	cm.Config.SystemConfig = scm
+
+	pcm := &config.ProjectConfigMock{}
+	pcm.On("GetSurveyConfig", mock.Anything, mock.Anything).Return(config.SurveyConfig{}, nil)
+	pcm.On("GetProjectID", mock.Anything).Return("projectID", nil)
+	cm.Config.ProjectConfig = pcm
+
+	cm.IO.On("ConfirmPrompt", mock.Anything, "Open in browser?", mock.Anything).Return(false)
 }

--- a/internal/slackerror/errors.go
+++ b/internal/slackerror/errors.go
@@ -103,6 +103,8 @@ const (
 	ErrFailedToGetUser                               = "failed_to_get_user"
 	ErrFailedToSaveExtensionLogs                     = "failed_to_save_extension_logs"
 	ErrFailToGetTeamsForRestrictedUser               = "fail_to_get_teams_for_restricted_user"
+	ErrFeedbackNameInvalid                           = "feedback_name_invalid"
+	ErrFeedbackNameRequired                          = "feedback_name_required"
 	ErrFileRejected                                  = "file_rejected"
 	ErrForbiddenTeam                                 = "forbidden_team"
 	ErrFreeTeamNotAllowed                            = "free_team_not_allowed"
@@ -709,6 +711,18 @@ Otherwise start your app for local development with: %s`,
 	ErrFailToGetTeamsForRestrictedUser: {
 		Code:    ErrFailToGetTeamsForRestrictedUser,
 		Message: "Failed to get teams for restricted user",
+	},
+
+	ErrFeedbackNameInvalid: {
+		Code:        ErrFeedbackNameInvalid,
+		Message:     "Invalid feedback name provided",
+		Remediation: fmt.Sprintf("View the feedback options with %s", style.Commandf("feedback --help", false)),
+	},
+
+	ErrFeedbackNameRequired: {
+		Code:        ErrFeedbackNameRequired,
+		Message:     "Please provide a feedback name or remove the --no-prompt flag",
+		Remediation: fmt.Sprintf("View feedback options with %s", style.Commandf("feedback --help", false)),
 	},
 
 	ErrFileRejected: {

--- a/internal/slackerror/errors.go
+++ b/internal/slackerror/errors.go
@@ -721,7 +721,7 @@ Otherwise start your app for local development with: %s`,
 
 	ErrFeedbackNameRequired: {
 		Code:        ErrFeedbackNameRequired,
-		Message:     "Please provide a feedback name or remove the --no-prompt flag",
+		Message:     "Please provide a feedback --name flag or remove the --no-prompt flag",
 		Remediation: fmt.Sprintf("View feedback options with %s", style.Commandf("feedback --help", false)),
 	},
 


### PR DESCRIPTION
### CHANGELOG

> Replaces `feedback --name platform-improvements` with `feedback --name slack-platform` as the flag name for Slack Platform support. You can continue to use `--name platform-improvements` until the next major version release.

### Summary

This pull request replaces `feedback --name platform-improvements` with `feedback --name slack-platform`:

* Deprecates `feedback --name platform-improvements`
* Removes `platform-improvements` from the help documentation
* Adds `feedback --name slack-platform`
* Backwards compatible with `--name platform-improvements` continues to work until the next semver:major update

### Preview

#### `slack feedback --help` displays `slack-platform`:
![image](https://github.com/user-attachments/assets/d2939ff0-3a71-4e0a-b08e-9df7a3044a8e)

#### `slack feedback --name slack-platform`:
<img width="762" alt="image" src="https://github.com/user-attachments/assets/b0a1c7b6-45cc-4592-b4d8-087ce75da180" />

#### `slack feedback --name platform-improvements` is backwards compatible:
<img width="762" alt="image" src="https://github.com/user-attachments/assets/129cd09d-7e99-4939-a33b-03fc5c4b381d" />

### `slack feedback --name platform-improvements --verbose` deprecation message:
![image](https://github.com/user-attachments/assets/975bc5ce-9b19-44c9-bfa5-a5de3606ee22)

### Reviewers

```bash
# Test Help
$ slack feedback --help
# → Confirm the option "slack-platform" exists
# → Confirm the option "platform-improvements" does not exist

$ slack feedback --name slack-platform
# → Should prompt to open the browser

$ slack feedback --name platform-improvements
# → Should prompt to open the browser

$ slack feedback --name platform-improvements --verbose
# → Confirm DEPRECATED message
```

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).