### PR TITLE
refactor: enable linter rule ST1005 for error string formatting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,7 +34,6 @@ linters:
       checks:
         - all
         - '-ST1003' # disable rule 'Poorly chosen identifier'
-        - '-ST1005' # disable rule 'Incorrectly formatted error string'
         - '-ST1006' # disable rule 'Poorly chosen receiver name'
         - '-ST1008' # disable rule 'Function’s error value should be its last return value'
         - '-ST1023' # disable rule 'Redundant type in variable declaration'

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -294,7 +294,7 @@ func (c *Client) DoWithRetry(ctx context.Context, request *http.Request, span op
 	span.SetTag("status_code", r.StatusCode)
 
 	if r.StatusCode != http.StatusOK {
-		return nil, errors.WithStack(fmt.Errorf("Slack API unexpected status code %d returned from url %s", r.StatusCode, sURL))
+		return nil, errors.WithStack(fmt.Errorf("unexpected status code %d returned from url %s", r.StatusCode, sURL))
 	}
 
 	var bytes []byte

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -374,7 +374,7 @@ func (c *Client) SetAuth(ctx context.Context, auth types.SlackAuth) (types.Slack
 
 	allAuths, err := c.auths(ctx)
 	if err != nil {
-		return types.SlackAuth{}, "", fmt.Errorf("Failed to fetch user authorizations %s", err)
+		return types.SlackAuth{}, "", fmt.Errorf("failed to fetch user authorizations %s", err)
 	}
 	allAuths[auth.TeamID] = auth
 

--- a/internal/pkg/create/create.go
+++ b/internal/pkg/create/create.go
@@ -169,7 +169,7 @@ func getAppDirName(appName string) (string, error) {
 
 	// name cannot be a reserved word
 	if goutils.Contains(reserved, appName, false) {
-		return "", fmt.Errorf("The app name you entered is reserved. Please try a different name.")
+		return "", fmt.Errorf("the app name you entered is reserved")
 	}
 	return appName, nil
 }

--- a/internal/pkg/platform/localserver.go
+++ b/internal/pkg/platform/localserver.go
@@ -428,7 +428,7 @@ type SocketEvent struct {
 func sendWebSocketMessage(c WebSocketConnection, linkResponse *LinkResponse) error {
 	// Validate the response
 	if linkResponse == nil {
-		return slackerror.Wrap(fmt.Errorf("Websocket response message cannot be empty"), slackerror.ErrSocketConnection)
+		return slackerror.Wrap(fmt.Errorf("websocket response message cannot be empty"), slackerror.ErrSocketConnection)
 	}
 
 	// Prepare response for websocket

--- a/internal/style/template.go
+++ b/internal/style/template.go
@@ -111,7 +111,7 @@ func getTemplateFuncs() template.FuncMap {
 func PrintTemplate(w io.Writer, tmpl string, data any) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			err = fmt.Errorf("Failed to create the template! %+v", r)
+			err = fmt.Errorf("failed to create the template: %+v", r)
 		}
 	}()
 	t := template.New("template")

--- a/internal/update/cli_metadata.go
+++ b/internal/update/cli_metadata.go
@@ -98,7 +98,7 @@ func (md *Metadata) httpClientRequest(method string, host string, data interface
 	}
 
 	if res.StatusCode != http.StatusOK {
-		return errors.WithStack(fmt.Errorf("Slack CLI metadata responded with an unexpected status code %d from url %s", res.StatusCode, host))
+		return errors.WithStack(fmt.Errorf("CLI metadata responded with an unexpected status code %d from url %s", res.StatusCode, host))
 	}
 
 	var bytes []byte


### PR DESCRIPTION
### Summary

This pull request enables the linter `staticcheck` rule [`ST1005: 'Incorrectly formatted error string'`](https://staticcheck.dev/docs/checks#ST1005).

In general, it's enforces the following:

* Error strings must start with a lowercase letter, unless a proper name or initialism
  * Unfortunately, I couldn't figure out how to make "Slack" a recognized noun
* Error strings cannot end with punctuation (e.g. periods `.`)

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).