### PR TITLE
docs: add docs for deprecating a feature

### DIFF
--- a/.github/MAINTAINERS_GUIDE.md
+++ b/.github/MAINTAINERS_GUIDE.md
@@ -586,7 +586,7 @@ When commands or flags need to be removed, follow these steps:
   - Print a warning `PrintWarning("DEPRECATED: Description about the deprecation and migration path")`
 - Internal functionality can be deprecated anytime
   - Add the comment `// DEPRECATED: Description about the deprecation and migration path`
-- Please add deprecation comments generously to help the person completely remove the feature and tests
+- Please add deprecation comments generously to help the next person completely remove the feature and tests
 
 </details>
 

--- a/.github/MAINTAINERS_GUIDE.md
+++ b/.github/MAINTAINERS_GUIDE.md
@@ -579,6 +579,18 @@ Many good things come to an end. This can sometimes include commands and flags.
 When commands or flags need to be removed, follow these steps:
 
 <details>
+<summary>Deprecating features</summary>
+
+- Public functionality should be deprecated on the next `semver:major` version
+  - Add the comment `// DEPRECATED(semver:major): Description about the deprecation and migration path`
+  - Print a warning `PrintWarning("DEPRECATED: Description about the deprecation and migration path")`
+- Internal functionality can be deprecated anytime
+  - Add the comment `// DEPRECATED: Description about the deprecation and migration path`
+- Please add deprecation comments generously to help the person completely remove the feature and tests
+
+</details>
+
+<details>
 <summary>Deprecating commands</summary>
 
 - Display a deprecation notice on the command with the `Deprecated` attribute

--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -316,7 +316,7 @@ func (c *ProjectConfig) GetProjectDirPath() (string, error) {
 	if _, err := c.fs.Stat(projectHooksJSONPath); os.IsNotExist(err) {
 
 		// Fallback check for slack.json and .slack/slack.json file
-		// TODO(semver:major): remove both fallbacks next major release
+		// DEPRECATED(semver:major): remove both fallbacks next major release
 		projectSlackJSONPath := filepath.Join(currentDir, "slack.json")
 		if _, err := c.fs.Stat(projectSlackJSONPath); err == nil {
 			return currentDir, nil

--- a/internal/pkg/create/create_test.go
+++ b/internal/pkg/create/create_test.go
@@ -129,7 +129,7 @@ func Test_Create_installProjectDependencies(t *testing.T) {
 			},
 			unexpectedOutputs: []string{
 				"Found project-name/.slack/hooks.json", // Behind bolt experiment
-				"project-name/slack.json",              // TODO(semver:major) Deprecated
+				"project-name/slack.json",              // DEPRECATED(semver:major): Now use hooks.json
 			},
 			expectedVerboseOutputs: []string{
 				"Detected a project using Deno",
@@ -137,7 +137,7 @@ func Test_Create_installProjectDependencies(t *testing.T) {
 		},
 		"When no bolt experiment and slack.json exists, should output adding .slack and caching steps": {
 			existingFiles: map[string]string{
-				"slack.json": "{}", // TODO(semver:major) Included with the template (deprecated path)
+				"slack.json": "{}", // DEPRECATED(semver:major): Included with the template (deprecated path)
 			},
 			expectedOutputs: []string{
 				"Added project-name/.slack",
@@ -188,7 +188,7 @@ func Test_Create_installProjectDependencies(t *testing.T) {
 			},
 			expectedOutputs: []string{
 				"Added project-name/.slack",
-				"Found project-name/slack.json", // TODO(semver:major) Deprecated
+				"Found project-name/slack.json", // DEPRECATED(semver:major): Now use hooks.json
 				"Cached dependencies with deno cache import_map.json",
 			},
 			expectedVerboseOutputs: []string{

--- a/internal/shared/clients.go
+++ b/internal/shared/clients.go
@@ -200,7 +200,7 @@ func (c *ClientFactory) InitSDKConfig(ctx context.Context, dirPath string) error
 			break
 		}
 		// Then, fallback to hooks in the deprecated project slack.json file
-		// TODO(semver:major) - Drop support on the next major
+		// DEPRECATED(semver:major) - Drop support on the next major
 		hooksJSONFilePath = filepath.Join(dirPath, "slack.json")
 		info, err = c.Fs.Stat(hooksJSONFilePath)
 		if err == nil && !info.IsDir() {
@@ -210,7 +210,7 @@ func (c *ClientFactory) InitSDKConfig(ctx context.Context, dirPath string) error
 		// Next, search for the hooks files in the outdated path
 		// .slack/slack.json and display an error that this path
 		// is deprecated
-		// TODO(semver:major) - Drop support on the next major
+		// DEPRECATED(semver:major) - Drop support on the next major
 		hooksJSONFilePath = filepath.Join(dirPath, ".slack", "slack.json")
 		info, err = c.Fs.Stat(hooksJSONFilePath)
 		if err == nil && !info.IsDir() {
@@ -220,7 +220,7 @@ func (c *ClientFactory) InitSDKConfig(ctx context.Context, dirPath string) error
 		// Next, search for the hooks files in the outdated path
 		// .slack/cli.json and display an error that this path
 		// is deprecated
-		// TODO(semver:major) - Drop support on the next major
+		// DEPRECATED(semver:major) - Drop support on the next major
 		hooksJSONFilePath = filepath.Join(dirPath, ".slack", "cli.json")
 		info, err = c.Fs.Stat(hooksJSONFilePath)
 		if err == nil && !info.IsDir() {


### PR DESCRIPTION
### Summary

This pull request is a follow-up from PR #70 that adds documentation around deprecating a feature in code:

* Updates `MAINTAINERS_GUIDE.md` explaining how to deprecate a public and internal feature
* Updates `// TODO(semver:major):` to `// DEPRECATED(semver:major):`

We're aligning on `// DEPRECATED:` and `// DEPRECATED(semver:major):` because [Golang appears to use a similar convention](https://cs.opensource.google/search?q=Deprecated:%20language:go&ss=go%2Fgo). If anyone thinks we should use a different convention, happy to hear it! 👂🏻 

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).