### PR TITLE
refactor: enable linter rule ST1006 for 'poorly chosen receiver names'

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,7 +35,6 @@ linters:
         - all
         - '-ST1003' # disable rule 'Poorly chosen identifier'
         - '-ST1005' # disable rule 'Incorrectly formatted error string'
-        - '-ST1006' # disable rule 'Poorly chosen receiver name'
         - '-ST1008' # disable rule 'Function’s error value should be its last return value'
         - '-ST1023' # disable rule 'Redundant type in variable declaration'
         - '-QF1001' # disable rule 'Apply De Morgan’s law'

--- a/internal/hooks/shell.go
+++ b/internal/hooks/shell.go
@@ -40,7 +40,7 @@ type ShellCommand interface {
 type ShellExec struct{}
 
 // command sets arguments for the shell supported by the current operating system
-func (_ ShellExec) command(name string, arg ...string) *exec.Cmd {
+func (ShellExec) command(name string, arg ...string) *exec.Cmd {
 	script := fmt.Sprintf("%s %s", name, strings.Join(arg, " "))
 	switch {
 	case runtime.GOOS == "windows":


### PR DESCRIPTION
### Summary

This pull request enables the linter `staticcheck` rule [ST1006: 'Poorly chosen receiver name'](https://staticcheck.dev/docs/checks#ST1006).

🧠 🧠 🧠

> The name of a method’s receiver should be a reflection of its identity; often a one or two letter abbreviation of its type suffices (such as “c” or “cl” for “Client”). Don’t use generic names such as “me”, “this” or “self”, identifiers typical of object-oriented languages that place more emphasis on methods as opposed to functions. 

For this PR, the only change required was to remove the `_` receiver name, which was used to represent an unused variable.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).