### PR TITLE
refactor: enable linter rule ST1008 for 'error should be last return value'

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,7 +36,6 @@ linters:
         - '-ST1003' # disable rule 'Poorly chosen identifier'
         - '-ST1005' # disable rule 'Incorrectly formatted error string'
         - '-ST1006' # disable rule 'Poorly chosen receiver name'
-        - '-ST1008' # disable rule 'Function’s error value should be its last return value'
         - '-ST1023' # disable rule 'Redundant type in variable declaration'
         - '-QF1001' # disable rule 'Apply De Morgan’s law'
         - '-QF1012' # disable rule 'Use fmt.Fprintf instead of x.Write(fmt.Sprintf(...))'

--- a/cmd/auth/login.go
+++ b/cmd/auth/login.go
@@ -146,7 +146,7 @@ func printAuthSuccess(cmd *cobra.Command, IO iostreams.IOStreamer, credentialsPa
 
 // printAuthNextSteps suggests possible commands to run after logging in
 func printAuthNextSteps(ctx context.Context, clients *shared.ClientFactory) {
-	_, project := clients.SDKConfig.Exists()
+	project, _ := clients.SDKConfig.Exists()
 	if !project {
 		clients.IO.PrintInfo(ctx, false, style.Sectionf(style.TextSection{
 			Emoji: "bulb",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -406,7 +406,7 @@ func ExecuteContext(ctx context.Context, rootCmd *cobra.Command, clients *shared
 func cleanup(ctx context.Context, clients *shared.ClientFactory) {
 	clients.IO.PrintDebug(ctx, "Starting root command cleanup routine")
 	// clean up any json in project .slack folder if needed
-	if _, sdkConfigExists := clients.SDKConfig.Exists(); sdkConfigExists {
+	if sdkConfigExists, _ := clients.SDKConfig.Exists(); sdkConfigExists {
 		clients.AppClient().CleanUp()
 	}
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -237,7 +237,7 @@ func Test_Aliases(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			err, output := testExecCmd(ctx, strings.Fields(tt.args))
+			output, err := testExecCmd(ctx, strings.Fields(tt.args))
 			require.NoError(t, err)
 			require.Contains(t, output, tt.expected)
 		})
@@ -245,7 +245,7 @@ func Test_Aliases(t *testing.T) {
 }
 
 // testExecCmd will execute the root cobra command with args and return the output
-func testExecCmd(ctx context.Context, args []string) (error, string) {
+func testExecCmd(ctx context.Context, args []string) (string, error) {
 	// Get command
 	cmd, clients := Init(ctx)
 
@@ -258,7 +258,7 @@ func testExecCmd(ctx context.Context, args []string) (error, string) {
 	cmd.SetArgs(args)
 	err := cmd.ExecuteContext(ctx)
 	if err != nil {
-		return err, ""
+		return "", err
 	}
-	return nil, clientsMock.GetCombinedOutput()
+	return clientsMock.GetCombinedOutput(), nil
 }

--- a/internal/cmdutil/project.go
+++ b/internal/cmdutil/project.go
@@ -53,7 +53,7 @@ func IsSlackHostedProject(ctx context.Context, clients *shared.ClientFactory) er
 
 // IsValidProjectDirectory verifies that a command is run in a valid project directory and returns nil, otherwise returns an error
 func IsValidProjectDirectory(clients *shared.ClientFactory) error {
-	if err, _ := clients.SDKConfig.Exists(); err != nil {
+	if _, err := clients.SDKConfig.Exists(); err != nil {
 		return slackerror.New(slackerror.ErrInvalidAppDirectory)
 	}
 	return nil

--- a/internal/hooks/sdk_config.go
+++ b/internal/hooks/sdk_config.go
@@ -46,11 +46,11 @@ type SDKCLIConfig struct {
 }
 
 // Exists returns true when the SDKCLIConfig was successfully loaded, otherwise false with an error
-func (s *SDKCLIConfig) Exists() (error, bool) {
+func (s *SDKCLIConfig) Exists() (bool, error) {
 	if strings.TrimSpace(s.WorkingDirectory) == "" {
-		return slackerror.New(slackerror.ErrInvalidSlackProjectDirectory), false
+		return false, slackerror.New(slackerror.ErrInvalidSlackProjectDirectory)
 	}
-	return nil, true
+	return true, nil
 }
 
 type ProtocolVersions []Protocol

--- a/internal/hooks/sdk_config_test.go
+++ b/internal/hooks/sdk_config_test.go
@@ -40,7 +40,7 @@ func Test_SDKCLIConfig_Exists(t *testing.T) {
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
-			err, exists := tt.sdkCLIConfig.Exists()
+			exists, err := tt.sdkCLIConfig.Exists()
 			require.Equal(t, tt.expectedError, err)
 			require.Equal(t, tt.exists, exists)
 		})


### PR DESCRIPTION
### Summary

This pull request enables the linter `staticcheck` rule [ST1008: 'A function’s error value should be its last return value'](https://staticcheck.dev/docs/checks/#ST1008).

✅ `func HelloWorld (string, error)`
❌ `func HelloWorld (error, string)`

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).