### PR TITLE
refactor: rename clients.APIInterface() to clients.API()

### DIFF
--- a/cmd/app/add_test.go
+++ b/cmd/app/add_test.go
@@ -144,24 +144,24 @@ func TestAppAddCommand(t *testing.T) {
 				appSelectMock.On("TeamAppSelectPrompt").Return(prompts.SelectedApp{Auth: mockAuthTeam1}, nil)
 
 				// Mock valid session for team1
-				cm.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{
+				cm.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{
 					UserID:   &mockAuthTeam1.UserID,
 					TeamID:   &mockAuthTeam1.TeamID,
 					TeamName: &mockAuthTeam1.TeamDomain,
 				}, nil)
 
 				// Mock a clean ValidateAppManifest result
-				cm.APIInterface.On("ValidateAppManifest", mock.Anything, mockAuthTeam1.Token, mock.Anything, mock.Anything).Return(
+				cm.API.On("ValidateAppManifest", mock.Anything, mockAuthTeam1.Token, mock.Anything, mock.Anything).Return(
 					api.ValidateAppManifestResult{
 						Warnings: slackerror.Warnings{},
 					}, nil,
 				)
 
 				// Mock Host
-				cm.APIInterface.On("Host").Return("")
+				cm.API.On("Host").Return("")
 
 				// Mock a successful CreateApp call and return our mocked AppID
-				cm.APIInterface.On("CreateApp", mock.Anything, mockAuthTeam1.Token, mock.Anything, mock.Anything).Return(
+				cm.API.On("CreateApp", mock.Anything, mockAuthTeam1.Token, mock.Anything, mock.Anything).Return(
 					api.CreateAppResult{
 						AppID: mockAppTeam1.AppID,
 					},
@@ -169,7 +169,7 @@ func TestAppAddCommand(t *testing.T) {
 				)
 
 				// Mock a successful DeveloperAppInstall
-				cm.APIInterface.On("DeveloperAppInstall", mock.Anything, mock.Anything, mockAuthTeam1.Token, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+				cm.API.On("DeveloperAppInstall", mock.Anything, mock.Anything, mockAuthTeam1.Token, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 					api.DeveloperAppInstallResult{
 						AppID: mockAppTeam1.AppID,
 						APIAccessTokens: struct {
@@ -183,7 +183,7 @@ func TestAppAddCommand(t *testing.T) {
 				)
 
 				// Mock existing and updated cache
-				cm.APIInterface.On(
+				cm.API.On(
 					"ExportAppManifest",
 					mock.Anything,
 					mock.Anything,
@@ -216,21 +216,21 @@ func TestAppAddCommand(t *testing.T) {
 				appSelectMock.On("TeamAppSelectPrompt").Return(prompts.SelectedApp{App: mockAppTeam1, Auth: mockAuthTeam1}, nil)
 
 				// Mock valid session for team1
-				cm.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{
+				cm.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{
 					UserID:   &mockAuthTeam1.UserID,
 					TeamID:   &mockAuthTeam1.TeamID,
 					TeamName: &mockAuthTeam1.TeamDomain,
 				}, nil)
 
 				// Mock a clean ValidateAppManifest result
-				cm.APIInterface.On("ValidateAppManifest", mock.Anything, mockAuthTeam1.Token, mock.Anything, mock.Anything).Return(
+				cm.API.On("ValidateAppManifest", mock.Anything, mockAuthTeam1.Token, mock.Anything, mock.Anything).Return(
 					api.ValidateAppManifestResult{
 						Warnings: slackerror.Warnings{},
 					}, nil,
 				)
 
 				// Mock Host
-				cm.APIInterface.On("Host").Return("")
+				cm.API.On("Host").Return("")
 
 				// Mock to ensure that an existing deployed app is found
 				appClientMock := &app.AppClientMock{}
@@ -241,7 +241,7 @@ func TestAppAddCommand(t *testing.T) {
 				cf.AppClient().AppClientInterface = appClientMock
 
 				// Mock to ensure that the existing deployed app is updated successfully
-				cm.APIInterface.On("UpdateApp", mock.Anything, mockAuthTeam1.Token, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+				cm.API.On("UpdateApp", mock.Anything, mockAuthTeam1.Token, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 					api.UpdateAppResult{
 						AppID:             mockAppTeam1.AppID,
 						Credentials:       api.Credentials{},
@@ -251,7 +251,7 @@ func TestAppAddCommand(t *testing.T) {
 				)
 
 				// Mock a successful DeveloperAppInstall
-				cm.APIInterface.On("DeveloperAppInstall", mock.Anything, mock.Anything, mockAuthTeam1.Token, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+				cm.API.On("DeveloperAppInstall", mock.Anything, mock.Anything, mockAuthTeam1.Token, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 					api.DeveloperAppInstallResult{
 						AppID: mockAppTeam1.AppID,
 						APIAccessTokens: struct {
@@ -265,7 +265,7 @@ func TestAppAddCommand(t *testing.T) {
 				)
 
 				// Mock existing and updated cache
-				cm.APIInterface.On(
+				cm.API.On(
 					"ExportAppManifest",
 					mock.Anything,
 					mock.Anything,
@@ -306,24 +306,24 @@ func TestAppAddCommand(t *testing.T) {
 				teamAppSelectPromptFunc = appSelectMock.TeamAppSelectPrompt
 				appSelectMock.On("TeamAppSelectPrompt").Return(prompts.SelectedApp{App: types.NewApp(), Auth: mockOrgAuth}, nil)
 				// Mock calls
-				cm.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{
+				cm.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{
 					UserID:   &mockOrgAuth.UserID,
 					TeamID:   &mockOrgAuth.TeamID,
 					TeamName: &mockOrgAuth.TeamDomain,
 				}, nil)
-				cm.APIInterface.On("ValidateAppManifest", mock.Anything, mockOrgAuth.Token, mock.Anything, mock.Anything).Return(
+				cm.API.On("ValidateAppManifest", mock.Anything, mockOrgAuth.Token, mock.Anything, mock.Anything).Return(
 					api.ValidateAppManifestResult{}, nil,
 				)
-				cm.APIInterface.On("Host").Return("")
+				cm.API.On("Host").Return("")
 				// Return mocked AppID
-				cm.APIInterface.On("CreateApp", mock.Anything, mockOrgAuth.Token, mock.Anything, mock.Anything).Return(
+				cm.API.On("CreateApp", mock.Anything, mockOrgAuth.Token, mock.Anything, mock.Anything).Return(
 					api.CreateAppResult{
 						AppID: mockOrgApp.AppID,
 					},
 					nil,
 				)
 				// Mock call to apps.developerInstall
-				cm.APIInterface.On("DeveloperAppInstall", mock.Anything, mock.Anything, mockOrgAuth.Token, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+				cm.API.On("DeveloperAppInstall", mock.Anything, mock.Anything, mockOrgAuth.Token, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 					api.DeveloperAppInstallResult{
 						AppID: mockOrgApp.AppID,
 					},
@@ -332,7 +332,7 @@ func TestAppAddCommand(t *testing.T) {
 				)
 
 				// Mock existing and updated cache
-				cm.APIInterface.On(
+				cm.API.On(
 					"ExportAppManifest",
 					mock.Anything,
 					mock.Anything,
@@ -353,7 +353,7 @@ func TestAppAddCommand(t *testing.T) {
 				cm.Config.ProjectConfig = mockProjectConfig
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
-				cm.APIInterface.AssertCalled(t, "DeveloperAppInstall", mock.Anything, mock.Anything, mockOrgAuth.Token, mock.Anything, mock.Anything, mock.Anything, "T123", mock.Anything)
+				cm.API.AssertCalled(t, "DeveloperAppInstall", mock.Anything, mock.Anything, mockOrgAuth.Token, mock.Anything, mock.Anything, mock.Anything, "T123", mock.Anything)
 			},
 		},
 		"When admin approval request is pending, outputs instructions": {
@@ -366,24 +366,24 @@ func TestAppAddCommand(t *testing.T) {
 				teamAppSelectPromptFunc = appSelectMock.TeamAppSelectPrompt
 				appSelectMock.On("TeamAppSelectPrompt").Return(prompts.SelectedApp{App: types.NewApp(), Auth: mockOrgAuth}, nil)
 				// Mock calls
-				cm.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{
+				cm.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{
 					UserID:   &mockOrgAuth.UserID,
 					TeamID:   &mockOrgAuth.TeamID,
 					TeamName: &mockOrgAuth.TeamDomain,
 				}, nil)
-				cm.APIInterface.On("ValidateAppManifest", mock.Anything, mockOrgAuth.Token, mock.Anything, mock.Anything).Return(
+				cm.API.On("ValidateAppManifest", mock.Anything, mockOrgAuth.Token, mock.Anything, mock.Anything).Return(
 					api.ValidateAppManifestResult{}, nil,
 				)
-				cm.APIInterface.On("Host").Return("")
+				cm.API.On("Host").Return("")
 				// Return mocked AppID
-				cm.APIInterface.On("CreateApp", mock.Anything, mockOrgAuth.Token, mock.Anything, mock.Anything).Return(
+				cm.API.On("CreateApp", mock.Anything, mockOrgAuth.Token, mock.Anything, mock.Anything).Return(
 					api.CreateAppResult{
 						AppID: mockOrgApp.AppID,
 					},
 					nil,
 				)
 				// Mock call to apps.developerInstall
-				cm.APIInterface.On("DeveloperAppInstall", mock.Anything, mock.Anything, mockOrgAuth.Token, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+				cm.API.On("DeveloperAppInstall", mock.Anything, mock.Anything, mockOrgAuth.Token, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 					api.DeveloperAppInstallResult{
 						AppID: mockOrgApp.AppID,
 					},
@@ -391,7 +391,7 @@ func TestAppAddCommand(t *testing.T) {
 					nil,
 				)
 				// Mock existing and updated cache
-				cm.APIInterface.On(
+				cm.API.On(
 					"ExportAppManifest",
 					mock.Anything,
 					mock.Anything,
@@ -422,24 +422,24 @@ func TestAppAddCommand(t *testing.T) {
 				teamAppSelectPromptFunc = appSelectMock.TeamAppSelectPrompt
 				appSelectMock.On("TeamAppSelectPrompt").Return(prompts.SelectedApp{App: types.NewApp(), Auth: mockOrgAuth}, nil)
 				// Mock calls
-				cm.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{
+				cm.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{
 					UserID:   &mockOrgAuth.UserID,
 					TeamID:   &mockOrgAuth.TeamID,
 					TeamName: &mockOrgAuth.TeamDomain,
 				}, nil)
-				cm.APIInterface.On("ValidateAppManifest", mock.Anything, mockOrgAuth.Token, mock.Anything, mock.Anything).Return(
+				cm.API.On("ValidateAppManifest", mock.Anything, mockOrgAuth.Token, mock.Anything, mock.Anything).Return(
 					api.ValidateAppManifestResult{}, nil,
 				)
-				cm.APIInterface.On("Host").Return("")
+				cm.API.On("Host").Return("")
 				// Return mocked AppID
-				cm.APIInterface.On("CreateApp", mock.Anything, mockOrgAuth.Token, mock.Anything, mock.Anything).Return(
+				cm.API.On("CreateApp", mock.Anything, mockOrgAuth.Token, mock.Anything, mock.Anything).Return(
 					api.CreateAppResult{
 						AppID: mockOrgApp.AppID,
 					},
 					nil,
 				)
 				// Mock call to apps.developerInstall
-				cm.APIInterface.On("DeveloperAppInstall", mock.Anything, mock.Anything, mockOrgAuth.Token, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+				cm.API.On("DeveloperAppInstall", mock.Anything, mock.Anything, mockOrgAuth.Token, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 					api.DeveloperAppInstallResult{
 						AppID: mockOrgApp.AppID,
 					},
@@ -447,7 +447,7 @@ func TestAppAddCommand(t *testing.T) {
 					nil,
 				)
 				// Mock existing and updated cache
-				cm.APIInterface.On(
+				cm.API.On(
 					"ExportAppManifest",
 					mock.Anything,
 					mock.Anything,

--- a/cmd/app/delete_test.go
+++ b/cmd/app/delete_test.go
@@ -61,12 +61,12 @@ func TestAppsDeleteCommand(t *testing.T) {
 				}, nil)
 				// Mock delete confirmation prompt
 				cm.IO.On("ConfirmPrompt", mock.Anything, "Are you sure you want to delete the app?", mock.Anything).Return(true, nil)
-				cm.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{
+				cm.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{
 					TeamName: &fakeDeployedApp.TeamDomain,
 					TeamID:   &fakeDeployedApp.TeamID,
 				}, nil)
 				// Mock delete API call
-				cm.APIInterface.On("DeleteApp", mock.Anything, mock.Anything, fakeDeployedApp.AppID).Return(nil)
+				cm.API.On("DeleteApp", mock.Anything, mock.Anything, fakeDeployedApp.AppID).Return(nil)
 				// Mock AppClient calls
 				appClientMock := &app.AppClientMock{}
 				appClientMock.On("GetDeployed", mock.Anything, mock.Anything).Return(fakeDeployedApp, nil)
@@ -75,7 +75,7 @@ func TestAppsDeleteCommand(t *testing.T) {
 				cf.AppClient().AppClientInterface = appClientMock
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
-				cm.APIInterface.AssertCalled(t, "DeleteApp", mock.Anything, mock.Anything, fakeDeployedApp.AppID)
+				cm.API.AssertCalled(t, "DeleteApp", mock.Anything, mock.Anything, fakeDeployedApp.AppID)
 			},
 			ExpectedStdoutOutputs: []string{
 				fmt.Sprintf(`Uninstalled the app "%s" from "%s"`, fakeDeployedApp.AppID, fakeDeployedApp.TeamDomain),
@@ -95,12 +95,12 @@ func TestAppsDeleteCommand(t *testing.T) {
 				}, nil)
 				// Mock delete confirmation prompt
 				cm.IO.On("ConfirmPrompt", mock.Anything, "Are you sure you want to delete the app?", mock.Anything).Return(true, nil)
-				cm.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{
+				cm.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{
 					TeamName: &fakeLocalApp.TeamDomain,
 					TeamID:   &fakeLocalApp.TeamID,
 				}, nil)
 				// Mock delete API call
-				cm.APIInterface.On("DeleteApp", mock.Anything, mock.Anything, fakeLocalApp.AppID).Return(nil)
+				cm.API.On("DeleteApp", mock.Anything, mock.Anything, fakeLocalApp.AppID).Return(nil)
 				// Mock AppClient calls
 				appClientMock := &app.AppClientMock{}
 				appClientMock.On("GetLocal", mock.Anything, mock.Anything).Return(fakeLocalApp, nil)
@@ -108,7 +108,7 @@ func TestAppsDeleteCommand(t *testing.T) {
 				cf.AppClient().AppClientInterface = appClientMock
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
-				cm.APIInterface.AssertCalled(t, "DeleteApp", mock.Anything, mock.Anything, fakeLocalApp.AppID)
+				cm.API.AssertCalled(t, "DeleteApp", mock.Anything, mock.Anything, fakeLocalApp.AppID)
 			},
 			ExpectedStdoutOutputs: []string{
 				fmt.Sprintf(`Uninstalled the app "%s" from "%s"`, fakeLocalApp.AppID, fakeLocalApp.TeamDomain),
@@ -128,12 +128,12 @@ func TestAppsDeleteCommand(t *testing.T) {
 				}, nil)
 				// Mock delete confirmation prompt
 				cm.IO.On("ConfirmPrompt", mock.Anything, "Are you sure you want to delete the app?", mock.Anything).Return(true, nil)
-				cm.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{
+				cm.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{
 					TeamName: &fakeDeployedApp.TeamDomain,
 					TeamID:   &fakeDeployedApp.TeamID,
 				}, nil)
 				// Mock delete API call
-				cm.APIInterface.On("DeleteApp", mock.Anything, mock.Anything, fakeDeployedApp.AppID).Return(fmt.Errorf("something went terribly wrong"))
+				cm.API.On("DeleteApp", mock.Anything, mock.Anything, fakeDeployedApp.AppID).Return(fmt.Errorf("something went terribly wrong"))
 				// Mock AppClient calls
 				appClientMock := &app.AppClientMock{}
 				appClientMock.On("GetDeployed", mock.Anything, mock.Anything).Return(fakeDeployedApp, nil)
@@ -146,7 +146,7 @@ func TestAppsDeleteCommand(t *testing.T) {
 			ExpectedError: slackerror.New(slackerror.ErrCredentialsNotFound),
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
 				prepareCommonDeleteMocks(t, cf, cm)
-				cm.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
+				cm.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
 				appSelectMock := prompts.NewAppSelectMock()
 				deleteAppSelectPromptFunc = appSelectMock.AppSelectPrompt
 				appSelectMock.On("AppSelectPrompt").Return(prompts.SelectedApp{App: fakeDeployedApp}, nil)

--- a/cmd/app/link.go
+++ b/cmd/app/link.go
@@ -225,7 +225,7 @@ func LinkExistingApp(ctx context.Context, clients *shared.ClientFactory, app *ty
 	}
 
 	appIDs := []string{app.AppID}
-	_, err = clients.APIInterface().GetAppStatus(ctx, auth.Token, appIDs, app.TeamID)
+	_, err = clients.API().GetAppStatus(ctx, auth.Token, appIDs, app.TeamID)
 	if err != nil {
 		return err
 	}

--- a/cmd/app/link_test.go
+++ b/cmd/app/link_test.go
@@ -88,7 +88,7 @@ func Test_Apps_Link(t *testing.T) {
 					Flag:   true,
 					Option: "deployed",
 				}, nil)
-				cm.APIInterface.On(
+				cm.API.On(
 					"GetAppStatus",
 					mock.Anything,
 					mockLinkSlackAuth1.Token,
@@ -146,7 +146,7 @@ func Test_Apps_Link(t *testing.T) {
 					Prompt: true,
 					Option: "local",
 				}, nil)
-				cm.APIInterface.On(
+				cm.API.On(
 					"GetAppStatus",
 					mock.Anything,
 					mockLinkSlackAuth2.Token,
@@ -213,7 +213,7 @@ func Test_Apps_Link(t *testing.T) {
 					Prompt: true,
 					Option: "deployed",
 				}, nil)
-				cm.APIInterface.On(
+				cm.API.On(
 					"GetAppStatus",
 					mock.Anything,
 					mockLinkSlackAuth1.Token,
@@ -282,7 +282,7 @@ func Test_Apps_Link(t *testing.T) {
 					Prompt: true,
 					Option: "local",
 				}, nil)
-				cm.APIInterface.On(
+				cm.API.On(
 					"GetAppStatus",
 					mock.Anything,
 					mockLinkSlackAuth1.Token,
@@ -358,7 +358,7 @@ func Test_Apps_Link(t *testing.T) {
 					Prompt: true,
 					Option: "local",
 				}, nil)
-				cm.APIInterface.On(
+				cm.API.On(
 					"GetAppStatus",
 					mock.Anything,
 					mockLinkSlackAuth2.Token,
@@ -417,7 +417,7 @@ func Test_Apps_Link(t *testing.T) {
 					Prompt: true,
 					Option: "Deployed",
 				}, nil)
-				cm.APIInterface.On(
+				cm.API.On(
 					"GetAppStatus",
 					mock.Anything,
 					mockLinkSlackAuth1.Token,
@@ -474,7 +474,7 @@ func Test_Apps_Link(t *testing.T) {
 					Flag:   true,
 					Option: "deployed",
 				}, nil)
-				cm.APIInterface.On(
+				cm.API.On(
 					"GetAppStatus",
 					mock.Anything,
 					mockLinkSlackAuth1.Token,
@@ -585,7 +585,7 @@ func Test_Apps_Link(t *testing.T) {
 					Flag:   true,
 					Option: "deployed",
 				}, nil)
-				cm.APIInterface.On(
+				cm.API.On(
 					"GetAppStatus",
 					mock.Anything,
 					mockLinkSlackAuth1.Token,
@@ -661,7 +661,7 @@ func Test_Apps_Link(t *testing.T) {
 					Flag:   true,
 					Option: "deployed",
 				}, nil)
-				cm.APIInterface.On(
+				cm.API.On(
 					"GetAppStatus",
 					mock.Anything,
 					mockLinkSlackAuth1.Token,

--- a/cmd/app/uninstall_test.go
+++ b/cmd/app/uninstall_test.go
@@ -48,7 +48,7 @@ func TestAppsUninstall(t *testing.T) {
 		"Successfully uninstall": {
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				prepareCommonUninstallMocks(ctx, clients, clientsMock)
-				clientsMock.APIInterface.On("UninstallApp", mock.Anything, mock.Anything, fakeAppID, fakeAppTeamID).
+				clientsMock.API.On("UninstallApp", mock.Anything, mock.Anything, fakeAppID, fakeAppTeamID).
 					Return(nil).Once()
 			},
 			ExpectedStdoutOutputs: []string{
@@ -58,7 +58,7 @@ func TestAppsUninstall(t *testing.T) {
 		"Successfully uninstall with a get-manifest hook error": {
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				prepareCommonUninstallMocks(ctx, clients, clientsMock)
-				clientsMock.APIInterface.On("UninstallApp", mock.Anything, mock.Anything, fakeAppID, fakeAppTeamID).
+				clientsMock.API.On("UninstallApp", mock.Anything, mock.Anything, fakeAppID, fakeAppTeamID).
 					Return(nil).Once()
 				manifestMock := &app.ManifestMockObject{}
 				manifestMock.On("GetManifestLocal", mock.Anything, mock.Anything, mock.Anything).
@@ -73,7 +73,7 @@ func TestAppsUninstall(t *testing.T) {
 			ExpectedError: slackerror.New("something went wrong"),
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				prepareCommonUninstallMocks(ctx, clients, clientsMock)
-				clientsMock.APIInterface.On("UninstallApp", mock.Anything, mock.Anything, fakeAppID, fakeAppTeamID).
+				clientsMock.API.On("UninstallApp", mock.Anything, mock.Anything, fakeAppID, fakeAppTeamID).
 					Return(slackerror.New("something went wrong")).Once()
 			},
 		},
@@ -107,7 +107,7 @@ func prepareCommonUninstallMocks(ctx context.Context, clients *shared.ClientFact
 	clientsMock.AuthInterface.On("ResolveLogstashHost", mock.Anything, mock.Anything, mock.Anything).
 		Return("logstash host")
 
-	clientsMock.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{
+	clientsMock.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{
 		TeamName: &fakeApp.TeamDomain,
 		TeamID:   &fakeApp.TeamID,
 	}, nil)

--- a/cmd/auth/login_test.go
+++ b/cmd/auth/login_test.go
@@ -54,7 +54,7 @@ func TestLoginCommand(t *testing.T) {
 			CmdArgs:         []string{"--auth", "xoxp-example"},
 			ExpectedOutputs: []string{deprecatedUserTokenMessage},
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
-				cm.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{
+				cm.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{
 					UserID:   &mockOrgAuth.UserID,
 					TeamID:   &mockOrgAuth.TeamID,
 					TeamName: &mockOrgAuth.TeamDomain,
@@ -81,7 +81,7 @@ func TestLoginCommand(t *testing.T) {
 			CmdArgs:               []string{"--ticket=example", "--challenge=tictactoe"},
 			ExpectedStdoutOutputs: []string{"Get started by creating a new app"},
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
-				cm.APIInterface.On(
+				cm.API.On(
 					"ExchangeAuthTicket",
 					mock.Anything,
 					mock.Anything,
@@ -111,7 +111,7 @@ func TestLoginCommand(t *testing.T) {
 			CmdArgs:               []string{"--ticket", "example", "--challenge", "tictactoe"},
 			ExpectedStdoutOutputs: []string{"Review existing installations of the app"},
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
-				cm.APIInterface.On(
+				cm.API.On(
 					"ExchangeAuthTicket",
 					mock.Anything,
 					mock.Anything,
@@ -141,11 +141,11 @@ func TestLoginCommand(t *testing.T) {
 		"happy path login with prompt flow should pass challenge code to ExchangeAuthTicket API": {
 			CmdArgs: []string{},
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
-				cm.APIInterface.On("GenerateAuthTicket", mock.Anything, mock.Anything, mock.Anything).Return(api.GenerateAuthTicketResult{}, nil)
+				cm.API.On("GenerateAuthTicket", mock.Anything, mock.Anything, mock.Anything).Return(api.GenerateAuthTicketResult{}, nil)
 				cm.IO.On("InputPrompt", mock.Anything, "Enter challenge code", iostreams.InputPromptConfig{
 					Required: true,
 				}).Return(mockChallengeCode, nil)
-				cm.APIInterface.On("ExchangeAuthTicket", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.ExchangeAuthTicketResult{}, nil)
+				cm.API.On("ExchangeAuthTicket", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.ExchangeAuthTicketResult{}, nil)
 				cm.AuthInterface.On("IsAPIHostSlackProd", mock.Anything).Return(true)
 				cm.AuthInterface.On(
 					"SetAuth",
@@ -158,17 +158,17 @@ func TestLoginCommand(t *testing.T) {
 				)
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
-				cm.APIInterface.AssertCalled(t, "ExchangeAuthTicket", mock.Anything, mock.Anything, mockChallengeCode, mock.Anything)
+				cm.API.AssertCalled(t, "ExchangeAuthTicket", mock.Anything, mock.Anything, mockChallengeCode, mock.Anything)
 			},
 		},
 		"should explode if ExchangeAuthTicket API fails": {
 			CmdArgs: []string{},
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
-				cm.APIInterface.On("GenerateAuthTicket", mock.Anything, mock.Anything, mock.Anything).Return(api.GenerateAuthTicketResult{}, nil)
+				cm.API.On("GenerateAuthTicket", mock.Anything, mock.Anything, mock.Anything).Return(api.GenerateAuthTicketResult{}, nil)
 				cm.IO.On("InputPrompt", mock.Anything, "Enter challenge code", iostreams.InputPromptConfig{
 					Required: true,
 				}).Return(mockChallengeCode, nil)
-				cm.APIInterface.On("ExchangeAuthTicket", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.ExchangeAuthTicketResult{}, slackerror.New(slackerror.ErrHTTPResponseInvalid))
+				cm.API.On("ExchangeAuthTicket", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.ExchangeAuthTicketResult{}, slackerror.New(slackerror.ErrHTTPResponseInvalid))
 			},
 			ExpectedError: slackerror.New(slackerror.ErrHTTPResponseInvalid),
 		},

--- a/cmd/auth/token_test.go
+++ b/cmd/auth/token_test.go
@@ -30,7 +30,7 @@ func TestTokenCommand(t *testing.T) {
 	ctx := slackcontext.MockContext(t.Context())
 
 	clientsMock := shared.NewClientsMock()
-	clientsMock.APIInterface.On("ValidateSession", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.AuthSession{UserID: &mockOrgAuth.UserID,
+	clientsMock.API.On("ValidateSession", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.AuthSession{UserID: &mockOrgAuth.UserID,
 		TeamID:   &mockOrgAuth.TeamID,
 		TeamName: &mockOrgAuth.TeamDomain,
 		URL:      &mockOrgAuthURL}, nil)

--- a/cmd/collaborators/add.go
+++ b/cmd/collaborators/add.go
@@ -85,7 +85,7 @@ func runAddCommandFunc(ctx context.Context, clients *shared.ClientFactory, cmd *
 	if err != nil {
 		return err
 	}
-	err = clients.APIInterface().AddCollaborator(ctx, selection.Auth.Token, selection.App.AppID, slackUser)
+	err = clients.API().AddCollaborator(ctx, selection.Auth.Token, selection.App.AppID, slackUser)
 	if err != nil {
 		if clients.Config.WithExperimentOn(experiment.ReadOnlyAppCollaborators) && strings.Contains(err.Error(), "user_already_owner") {
 			cmd.Println()

--- a/cmd/collaborators/add_test.go
+++ b/cmd/collaborators/add_test.go
@@ -41,12 +41,12 @@ func TestAddCommand(t *testing.T) {
 				cm.Config.ExperimentsFlag = append(cm.Config.ExperimentsFlag, "read-only-collaborators")
 				cm.Config.LoadExperiments(ctx, cm.IO.PrintDebug)
 				// Mock API call
-				cm.APIInterface.On("AddCollaborator", mock.Anything, mock.Anything,
+				cm.API.On("AddCollaborator", mock.Anything, mock.Anything,
 					"A123",
 					types.SlackUser{ID: "U123", PermissionType: types.READER}).Return(nil)
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
-				cm.APIInterface.AssertCalled(t, "AddCollaborator", mock.Anything, mock.Anything,
+				cm.API.AssertCalled(t, "AddCollaborator", mock.Anything, mock.Anything,
 					"A123",
 					types.SlackUser{ID: "U123", PermissionType: types.READER})
 				cm.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.CollaboratorAddSuccess, mock.Anything)
@@ -65,13 +65,13 @@ func TestAddCommand(t *testing.T) {
 				cm.Config.ExperimentsFlag = append(cm.Config.ExperimentsFlag, "read-only-collaborators")
 				cm.Config.LoadExperiments(ctx, cm.IO.PrintDebug)
 				// Mock API call
-				cm.APIInterface.On("AddCollaborator", mock.Anything, mock.Anything,
+				cm.API.On("AddCollaborator", mock.Anything, mock.Anything,
 					"A123",
 					types.SlackUser{Email: "joe.smith@company.com", PermissionType: types.OWNER}).Return(nil)
 				addFlags.permissionType = "owner"
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
-				cm.APIInterface.AssertCalled(t, "AddCollaborator", mock.Anything, mock.Anything,
+				cm.API.AssertCalled(t, "AddCollaborator", mock.Anything, mock.Anything,
 					"A123",
 					types.SlackUser{Email: "joe.smith@company.com", PermissionType: types.OWNER})
 				cm.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.CollaboratorAddSuccess, mock.Anything)
@@ -87,11 +87,11 @@ func TestAddCommand(t *testing.T) {
 				teamAppSelectPromptFunc = appSelectMock.TeamAppSelectPrompt
 				appSelectMock.On("TeamAppSelectPrompt").Return(prompts.SelectedApp{App: types.App{AppID: "A123"}, Auth: types.SlackAuth{}}, nil)
 				// Mock API call
-				cm.APIInterface.On("AddCollaborator", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+				cm.API.On("AddCollaborator", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(nil)
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
-				cm.APIInterface.AssertCalled(t, "AddCollaborator", mock.Anything, mock.Anything,
+				cm.API.AssertCalled(t, "AddCollaborator", mock.Anything, mock.Anything,
 					"A123",
 					types.SlackUser{Email: "joe.smith@company.com", PermissionType: types.OWNER})
 				cm.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.CollaboratorAddSuccess, mock.Anything)

--- a/cmd/collaborators/collaborators_test.go
+++ b/cmd/collaborators/collaborators_test.go
@@ -106,7 +106,7 @@ func TestCollaboratorsCommand(t *testing.T) {
 			appSelectMock.On("TeamAppSelectPrompt").Return(prompts.SelectedApp{App: tt.app, Auth: types.SlackAuth{}}, nil)
 			clientsMock := shared.NewClientsMock()
 			clientsMock.AddDefaultMocks()
-			clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).
+			clientsMock.API.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).
 				Return(tt.collaborators, nil)
 			clients := shared.NewClientFactory(clientsMock.MockClientFactory(), func(clients *shared.ClientFactory) {
 				clients.SDKConfig = hooks.NewSDKConfigMock()
@@ -114,7 +114,7 @@ func TestCollaboratorsCommand(t *testing.T) {
 
 			err := NewCommand(clients).ExecuteContext(ctx)
 			require.NoError(t, err)
-			clientsMock.APIInterface.AssertCalled(t, "ListCollaborators", mock.Anything, mock.Anything, tt.app.AppID)
+			clientsMock.API.AssertCalled(t, "ListCollaborators", mock.Anything, mock.Anything, tt.app.AppID)
 			clientsMock.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.CollaboratorListSuccess, mock.Anything)
 			clientsMock.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.CollaboratorListCount, []string{
 				fmt.Sprintf("%d", len(tt.collaborators)),

--- a/cmd/collaborators/list.go
+++ b/cmd/collaborators/list.go
@@ -66,7 +66,7 @@ func runListCommand(cmd *cobra.Command, clients *shared.ClientFactory) error {
 	if err = cmdutil.AppExists(app, selection.Auth); err != nil {
 		return err
 	}
-	collaborators, err := clients.APIInterface().ListCollaborators(ctx, selection.Auth.Token, app.AppID)
+	collaborators, err := clients.API().ListCollaborators(ctx, selection.Auth.Token, app.AppID)
 	if err != nil {
 		return slackerror.Wrap(err, "Error listing collaborators")
 	}

--- a/cmd/collaborators/list_test.go
+++ b/cmd/collaborators/list_test.go
@@ -106,7 +106,7 @@ func TestListCommand(t *testing.T) {
 			appSelectMock.On("TeamAppSelectPrompt").Return(prompts.SelectedApp{App: tt.app, Auth: types.SlackAuth{}}, nil)
 			clientsMock := shared.NewClientsMock()
 			clientsMock.AddDefaultMocks()
-			clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).
+			clientsMock.API.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).
 				Return(tt.collaborators, nil)
 			clients := shared.NewClientFactory(clientsMock.MockClientFactory(), func(clients *shared.ClientFactory) {
 				clients.SDKConfig = hooks.NewSDKConfigMock()
@@ -114,7 +114,7 @@ func TestListCommand(t *testing.T) {
 
 			err := NewListCommand(clients).ExecuteContext(ctx)
 			require.NoError(t, err)
-			clientsMock.APIInterface.AssertCalled(t, "ListCollaborators", mock.Anything, mock.Anything, tt.app.AppID)
+			clientsMock.API.AssertCalled(t, "ListCollaborators", mock.Anything, mock.Anything, tt.app.AppID)
 			clientsMock.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.CollaboratorListSuccess, mock.Anything)
 			clientsMock.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.CollaboratorListCount, []string{
 				fmt.Sprintf("%d", len(tt.collaborators)),

--- a/cmd/collaborators/remove.go
+++ b/cmd/collaborators/remove.go
@@ -70,7 +70,7 @@ func runRemoveCommandFunc(ctx context.Context, clients *shared.ClientFactory, cm
 	if err = cmdutil.AppExists(selection.App, selection.Auth); err != nil {
 		return err
 	}
-	warnings, err := clients.APIInterface().RemoveCollaborator(ctx, selection.Auth.Token, selection.App.AppID, slackUser)
+	warnings, err := clients.API().RemoveCollaborator(ctx, selection.Auth.Token, selection.App.AppID, slackUser)
 	if err != nil {
 		return err
 	}
@@ -120,7 +120,7 @@ func promptCollaboratorsRemoveSlackUserPrompts(
 	slackUser types.SlackUser,
 	err error,
 ) {
-	collaborators, err := clients.APIInterface().ListCollaborators(ctx, selection.Auth.Token, selection.App.AppID)
+	collaborators, err := clients.API().ListCollaborators(ctx, selection.Auth.Token, selection.App.AppID)
 	if err != nil {
 		return types.SlackUser{}, err
 	}

--- a/cmd/collaborators/remove_test.go
+++ b/cmd/collaborators/remove_test.go
@@ -56,14 +56,14 @@ func TestRemoveCommand(t *testing.T) {
 				teamAppSelectPromptFunc = appSelectMock.TeamAppSelectPrompt
 				appSelectMock.On("TeamAppSelectPrompt").
 					Return(mockSelection, nil)
-				cm.APIInterface.On("RemoveCollaborator", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+				cm.API.On("RemoveCollaborator", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(nil)
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
 				collaborator := types.SlackUser{
 					ID: "USLACKBOT",
 				}
-				cm.APIInterface.AssertCalled(t, "RemoveCollaborator", mock.Anything, mock.Anything, "A001", collaborator)
+				cm.API.AssertCalled(t, "RemoveCollaborator", mock.Anything, mock.Anything, "A001", collaborator)
 				cm.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.CollaboratorRemoveSuccess, mock.Anything)
 				cm.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.CollaboratorRemoveCollaborator, []string{"USLACKBOT"})
 			},
@@ -75,16 +75,16 @@ func TestRemoveCommand(t *testing.T) {
 				teamAppSelectPromptFunc = appSelectMock.TeamAppSelectPrompt
 				appSelectMock.On("TeamAppSelectPrompt").
 					Return(mockSelection, nil)
-				cm.APIInterface.On("RemoveCollaborator", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+				cm.API.On("RemoveCollaborator", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(nil)
 				cm.IO.On("IsTTY").Return(true)
-				cm.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).
+				cm.API.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).
 					Return(mockCollaborators, nil)
 				cm.IO.On("SelectPrompt", mock.Anything, "Remove a collaborator", mock.Anything, mock.Anything).
 					Return(iostreams.SelectPromptResponse{Prompt: true, Index: 1}, nil)
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
-				cm.APIInterface.AssertCalled(t, "RemoveCollaborator", mock.Anything, mock.Anything, "A001", mockCollaborators[1])
+				cm.API.AssertCalled(t, "RemoveCollaborator", mock.Anything, mock.Anything, "A001", mockCollaborators[1])
 				cm.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.CollaboratorRemoveSuccess, mock.Anything)
 				cm.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.CollaboratorRemoveCollaborator, []string{"reader@slack.com"})
 			},
@@ -96,10 +96,10 @@ func TestRemoveCommand(t *testing.T) {
 				teamAppSelectPromptFunc = appSelectMock.TeamAppSelectPrompt
 				appSelectMock.On("TeamAppSelectPrompt").
 					Return(mockSelection, nil)
-				cm.APIInterface.On("RemoveCollaborator", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+				cm.API.On("RemoveCollaborator", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(nil)
 				cm.IO.On("IsTTY").Return(true)
-				cm.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).
+				cm.API.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).
 					Return(mockCollaborators, nil)
 				cm.IO.On("SelectPrompt", mock.Anything, "Remove a collaborator", mock.Anything, mock.Anything).
 					Return(iostreams.SelectPromptResponse{Prompt: true, Index: 0}, nil)
@@ -107,7 +107,7 @@ func TestRemoveCommand(t *testing.T) {
 					Return(false, nil)
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
-				cm.APIInterface.AssertNotCalled(t, "RemoveCollaborator", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+				cm.API.AssertNotCalled(t, "RemoveCollaborator", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 			},
 			ExpectedError: slackerror.New(slackerror.ErrProcessInterrupted),
 		},

--- a/cmd/collaborators/update.go
+++ b/cmd/collaborators/update.go
@@ -108,7 +108,7 @@ func runUpdateCommand(cmd *cobra.Command, clients *shared.ClientFactory, args []
 		return err
 	}
 
-	err = clients.APIInterface().UpdateCollaborator(ctx, selection.Auth.Token, app.AppID, slackUser)
+	err = clients.API().UpdateCollaborator(ctx, selection.Auth.Token, app.AppID, slackUser)
 	if err != nil {
 		return slackerror.Wrap(err, "Error updating collaborator")
 	}

--- a/cmd/collaborators/update_test.go
+++ b/cmd/collaborators/update_test.go
@@ -41,7 +41,7 @@ func TestUpdateCommand(t *testing.T) {
 				clientsMock.Config.ExperimentsFlag = append(clientsMock.Config.ExperimentsFlag, "read-only-collaborators")
 				clientsMock.Config.LoadExperiments(ctx, clientsMock.IO.PrintDebug)
 				// Mock APi call
-				clientsMock.APIInterface.On("UpdateCollaborator", mock.Anything, mock.Anything,
+				clientsMock.API.On("UpdateCollaborator", mock.Anything, mock.Anything,
 					"A123",
 					types.SlackUser{ID: "U123", PermissionType: types.READER}).Return(nil)
 			},
@@ -59,7 +59,7 @@ func TestUpdateCommand(t *testing.T) {
 				clientsMock.Config.ExperimentsFlag = append(clientsMock.Config.ExperimentsFlag, "read-only-collaborators")
 				clientsMock.Config.LoadExperiments(ctx, clientsMock.IO.PrintDebug)
 				// Mock APi call
-				clientsMock.APIInterface.On("UpdateCollaborator", mock.Anything, mock.Anything,
+				clientsMock.API.On("UpdateCollaborator", mock.Anything, mock.Anything,
 					"A123",
 					types.SlackUser{Email: "joe.smith@company.com", PermissionType: types.OWNER}).Return(nil)
 			},

--- a/cmd/datastore/bulk_put.go
+++ b/cmd/datastore/bulk_put.go
@@ -302,7 +302,7 @@ func startBulkPutImport(ctx context.Context, clients *shared.ClientFactory, cmd 
 		}
 
 		query.Items = currentBatch
-		bulkPutResult, err := clients.APIInterface().AppsDatastoreBulkPut(ctx, token, query)
+		bulkPutResult, err := clients.API().AppsDatastoreBulkPut(ctx, token, query)
 		if err != nil {
 			if len(err.(*slackerror.Error).Details) == 0 {
 				return err

--- a/cmd/datastore/bulk_put_test.go
+++ b/cmd/datastore/bulk_put_test.go
@@ -235,7 +235,7 @@ func TestBulkPutCommandImport(t *testing.T) {
 			},
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
 				*cm = *setupDatastoreMocks()
-				cm.APIInterface.On("AppsDatastoreBulkPut", mock.Anything, mock.Anything, mock.Anything).
+				cm.API.On("AppsDatastoreBulkPut", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.AppDatastoreBulkPutResult{}, nil)
 
 				itemsFile, err := cm.Fs.Create("my-file")
@@ -265,7 +265,7 @@ func TestBulkPutCommandImport(t *testing.T) {
 			ExpectedOutputs: []string{"Some items failed to be imported"},
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
 				*cm = *setupDatastoreMocks()
-				cm.APIInterface.On("AppsDatastoreBulkPut", mock.Anything, mock.Anything, mock.Anything).
+				cm.API.On("AppsDatastoreBulkPut", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.AppDatastoreBulkPutResult{}, nil)
 
 				itemsFile, err := cm.Fs.Create("my-file")
@@ -308,7 +308,7 @@ func TestBulkPutCommandImport(t *testing.T) {
 			ExpectedOutputs: []string{"Import will be limited to the first 5000 items in the file"},
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
 				*cm = *setupDatastoreMocks()
-				cm.APIInterface.On("AppsDatastoreBulkPut", mock.Anything, mock.Anything, mock.Anything).
+				cm.API.On("AppsDatastoreBulkPut", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.AppDatastoreBulkPutResult{}, nil)
 
 				itemsFile, err := cm.Fs.Create("my-file")
@@ -338,10 +338,10 @@ func TestBulkPutCommandImport(t *testing.T) {
 				items, err := prepareImportMockData(itemsFile, 2, 0)
 				assert.NoError(t, err)
 
-				cm.APIInterface.On("AppsDatastoreBulkPut", mock.Anything, mock.Anything, mock.Anything).
+				cm.API.On("AppsDatastoreBulkPut", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.AppDatastoreBulkPutResult{FailedItems: items[:1]}, nil).Once()
 
-				cm.APIInterface.On("AppsDatastoreBulkPut", mock.Anything, mock.Anything, mock.Anything).
+				cm.API.On("AppsDatastoreBulkPut", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.AppDatastoreBulkPutResult{}, nil).Once()
 
 				*cf = *shared.NewClientFactory(cm.MockClientFactory())
@@ -350,8 +350,8 @@ func TestBulkPutCommandImport(t *testing.T) {
 				status, _ := importProgressSpinner.Status()
 				assert.Contains(t, status, "Successfully imported (2) items! (0) items failed to be imported. Total processed items is (2)")
 
-				cm.APIInterface.AssertNumberOfCalls(t, "AppsDatastoreBulkPut", 2)
-				cm.APIInterface.AssertCalled(t, "AppsDatastoreBulkPut", mock.Anything, mock.Anything, types.AppDatastoreBulkPut{
+				cm.API.AssertNumberOfCalls(t, "AppsDatastoreBulkPut", 2)
+				cm.API.AssertCalled(t, "AppsDatastoreBulkPut", mock.Anything, mock.Anything, types.AppDatastoreBulkPut{
 					Datastore: "Todos",
 					App:       "A0123456",
 					Items: []map[string]interface{}{
@@ -359,7 +359,7 @@ func TestBulkPutCommandImport(t *testing.T) {
 						{"task_id": "0002", "task": "counting", "status": "ongoing"},
 					},
 				})
-				cm.APIInterface.AssertCalled(t, "AppsDatastoreBulkPut", mock.Anything, mock.Anything, types.AppDatastoreBulkPut{
+				cm.API.AssertCalled(t, "AppsDatastoreBulkPut", mock.Anything, mock.Anything, types.AppDatastoreBulkPut{
 					Datastore: "Todos",
 					App:       "A0123456",
 					Items: []map[string]interface{}{

--- a/cmd/datastore/count.go
+++ b/cmd/datastore/count.go
@@ -135,7 +135,7 @@ func runCountCommandFunc(
 	}
 
 	// Perform the count
-	countResult, err := clients.APIInterface().AppsDatastoreCount(ctx, selection.Auth.Token, count)
+	countResult, err := clients.API().AppsDatastoreCount(ctx, selection.Auth.Token, count)
 	if err != nil {
 		return err
 	}

--- a/cmd/datastore/count_test.go
+++ b/cmd/datastore/count_test.go
@@ -133,14 +133,14 @@ func TestCountCommand(t *testing.T) {
 		"default to the empty expression when no expression is passed": {
 			CmdArgs: []string{"--datastore", "tasks"},
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
-				cm.APIInterface.On("AppsDatastoreCount", mock.Anything, mock.Anything, mock.Anything).
+				cm.API.On("AppsDatastoreCount", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.AppDatastoreCountResult{Datastore: "tasks", Count: 12}, nil)
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
 				cm.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.DatastoreCountSuccess, mock.Anything)
 				cm.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.DatastoreCountTotal, []string{"12"})
 				cm.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.DatastoreCountDatastore, []string{"tasks"})
-				cm.APIInterface.AssertCalled(
+				cm.API.AssertCalled(
 					t,
 					"AppsDatastoreCount",
 					mock.Anything,
@@ -152,14 +152,14 @@ func TestCountCommand(t *testing.T) {
 		"pass an empty expression through arguments": {
 			CmdArgs: []string{`{"datastore":"tasks"}`},
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
-				cm.APIInterface.On("AppsDatastoreCount", mock.Anything, mock.Anything, mock.Anything).
+				cm.API.On("AppsDatastoreCount", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.AppDatastoreCountResult{Datastore: "tasks", Count: 12}, nil)
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
 				cm.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.DatastoreCountSuccess, mock.Anything)
 				cm.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.DatastoreCountTotal, []string{"12"})
 				cm.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.DatastoreCountDatastore, []string{"tasks"})
-				cm.APIInterface.AssertCalled(
+				cm.API.AssertCalled(
 					t,
 					"AppsDatastoreCount",
 					mock.Anything,
@@ -173,14 +173,14 @@ func TestCountCommand(t *testing.T) {
 				`{"datastore":"tasks","expression":"#task_id < :num","expression_attributes":{"#task_id":"task_id"},"expression_values":{":num":"3"}}`,
 			},
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
-				cm.APIInterface.On("AppsDatastoreCount", mock.Anything, mock.Anything, mock.Anything).
+				cm.API.On("AppsDatastoreCount", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.AppDatastoreCountResult{Datastore: "tasks", Count: 12}, nil)
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
 				cm.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.DatastoreCountSuccess, mock.Anything)
 				cm.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.DatastoreCountTotal, []string{"12"})
 				cm.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.DatastoreCountDatastore, []string{"tasks"})
-				cm.APIInterface.AssertCalled(
+				cm.API.AssertCalled(
 					t,
 					"AppsDatastoreCount",
 					mock.Anything,
@@ -204,14 +204,14 @@ func TestCountCommand(t *testing.T) {
 				`{"datastore":"Todos","app":"A001","expression":"#task_id < :num AND #status = :progress","expression_attributes":{"#task_id":"task_id","#status":"status"},"expression_values":{":num":"3",":progress":"wip"}}`,
 			},
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
-				cm.APIInterface.On("AppsDatastoreCount", mock.Anything, mock.Anything, mock.Anything).
+				cm.API.On("AppsDatastoreCount", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.AppDatastoreCountResult{Datastore: "tasks", Count: 12}, nil)
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
 				cm.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.DatastoreCountSuccess, mock.Anything)
 				cm.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.DatastoreCountTotal, []string{"12"})
 				cm.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.DatastoreCountDatastore, []string{"tasks"})
-				cm.APIInterface.AssertCalled(
+				cm.API.AssertCalled(
 					t,
 					"AppsDatastoreCount",
 					mock.Anything,
@@ -252,14 +252,14 @@ func TestCountCommand(t *testing.T) {
 				cm.IO.On("InputPrompt", mock.Anything, "Enter an expression", iostreams.InputPromptConfig{
 					Required: false,
 				}).Return("")
-				cm.APIInterface.On("AppsDatastoreCount", mock.Anything, mock.Anything, mock.Anything).
+				cm.API.On("AppsDatastoreCount", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.AppDatastoreCountResult{Datastore: "numbers", Count: 12}, nil)
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
 				cm.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.DatastoreCountSuccess, mock.Anything)
 				cm.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.DatastoreCountTotal, []string{"12"})
 				cm.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.DatastoreCountDatastore, []string{"numbers"})
-				cm.APIInterface.AssertCalled(
+				cm.API.AssertCalled(
 					t,
 					"AppsDatastoreCount",
 					mock.Anything,
@@ -308,14 +308,14 @@ func TestCountCommand(t *testing.T) {
 				cm.IO.On("InputPrompt", mock.Anything, "Enter a value for ':bool'", iostreams.InputPromptConfig{
 					Required: true,
 				}).Return("true")
-				cm.APIInterface.On("AppsDatastoreCount", mock.Anything, mock.Anything, mock.Anything).
+				cm.API.On("AppsDatastoreCount", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.AppDatastoreCountResult{Datastore: "numbers", Count: 6}, nil)
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
 				cm.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.DatastoreCountSuccess, mock.Anything)
 				cm.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.DatastoreCountTotal, []string{"6"})
 				cm.IO.AssertCalled(t, "PrintTrace", mock.Anything, slacktrace.DatastoreCountDatastore, []string{"numbers"})
-				cm.APIInterface.AssertCalled(
+				cm.API.AssertCalled(
 					t,
 					"AppsDatastoreCount",
 					mock.Anything,

--- a/cmd/datastore/query.go
+++ b/cmd/datastore/query.go
@@ -409,7 +409,7 @@ func startQueryExport(ctx context.Context, clients *shared.ClientFactory, cmd *c
 		}
 
 		query.Limit = maxItemsToRead
-		queryResult, err := clients.APIInterface().AppsDatastoreQuery(ctx, token, query)
+		queryResult, err := clients.API().AppsDatastoreQuery(ctx, token, query)
 		if err != nil {
 			return err
 		}

--- a/cmd/datastore/query_test.go
+++ b/cmd/datastore/query_test.go
@@ -458,7 +458,7 @@ func prepareExportMockData(cm *shared.ClientsMock, numberOfItems int, maxItemsTo
 				nextCursor = fmt.Sprintf("%d", i)
 
 			}
-			cm.APIInterface.On("AppsDatastoreQuery", mock.Anything, mock.Anything, mock.Anything).
+			cm.API.On("AppsDatastoreQuery", mock.Anything, mock.Anything, mock.Anything).
 				Return(types.AppDatastoreQueryResult{
 					Items:      append([]map[string]interface{}{}, data...),
 					NextCursor: nextCursor,

--- a/cmd/doctor/check.go
+++ b/cmd/doctor/check.go
@@ -301,7 +301,7 @@ func checkCLICreds(ctx context.Context, clients *shared.ClientFactory) (Section,
 			// the call. This results in incorrectly deeming tokens invalid if using multiple workspaces
 			// with different API hosts. (cc: @mbrooks)
 			clients.Config.APIHostResolved = clients.AuthInterface().ResolveAPIHost(ctx, clients.Config.APIHostFlag, &authInfo)
-			_, err := clients.APIInterface().ValidateSession(ctx, authInfo.Token)
+			_, err := clients.API().ValidateSession(ctx, authInfo.Token)
 			if err != nil {
 				validitySection.Value = "Invalid"
 			}

--- a/cmd/doctor/doctor_test.go
+++ b/cmd/doctor/doctor_test.go
@@ -55,7 +55,7 @@ func TestDoctorCommand(t *testing.T) {
 		clientsMock := shared.NewClientsMock()
 		clientsMock.AuthInterface.On("Auths", mock.Anything).Return([]types.SlackAuth{expectedCredentials}, nil)
 		clientsMock.AuthInterface.On("ResolveAPIHost", mock.Anything, mock.Anything, mock.Anything).Return("api.slack.com")
-		clientsMock.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
+		clientsMock.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
 		clientsMock.AddDefaultMocks()
 		pcm := &config.ProjectConfigMock{}
 		pcm.On("ReadProjectConfigFile", mock.Anything).Return(config.ProjectConfig{

--- a/cmd/env/add.go
+++ b/cmd/env/add.go
@@ -127,7 +127,7 @@ func runEnvAddCommandFunc(clients *shared.ClientFactory, cmd *cobra.Command, arg
 		variableValue = args[1]
 	}
 
-	err = clients.APIInterface().AddVariable(
+	err = clients.API().AddVariable(
 		ctx,
 		selection.Auth.Token,
 		selection.App.AppID,

--- a/cmd/env/add_test.go
+++ b/cmd/env/add_test.go
@@ -149,7 +149,7 @@ func Test_Env_AddCommand(t *testing.T) {
 				setupEnvAddCommandMocks(ctx, cm, cf)
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
-				cm.APIInterface.AssertCalled(
+				cm.API.AssertCalled(
 					t,
 					"AddVariable",
 					mock.Anything,
@@ -187,7 +187,7 @@ func Test_Env_AddCommand(t *testing.T) {
 				)
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
-				cm.APIInterface.AssertCalled(
+				cm.API.AssertCalled(
 					t,
 					"AddVariable",
 					mock.Anything,
@@ -218,7 +218,7 @@ func Test_Env_AddCommand(t *testing.T) {
 				)
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
-				cm.APIInterface.AssertCalled(
+				cm.API.AssertCalled(
 					t,
 					"AddVariable",
 					mock.Anything,
@@ -258,7 +258,7 @@ func Test_Env_AddCommand(t *testing.T) {
 				)
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
-				cm.APIInterface.AssertCalled(
+				cm.API.AssertCalled(
 					t,
 					"AddVariable",
 					mock.Anything,
@@ -288,5 +288,5 @@ func setupEnvAddCommandMocks(ctx context.Context, cm *shared.ClientsMock, cf *sh
 
 	cm.Config.Flags.String("value", "", "mock value flag")
 
-	cm.APIInterface.On("AddVariable", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	cm.API.On("AddVariable", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 }

--- a/cmd/env/list.go
+++ b/cmd/env/list.go
@@ -88,7 +88,7 @@ func runEnvListCommandFunc(
 		return err
 	}
 
-	variableNames, err := clients.APIInterface().ListVariables(
+	variableNames, err := clients.API().ListVariables(
 		ctx,
 		selection.Auth.Token,
 		selection.App.AppID,

--- a/cmd/env/list_test.go
+++ b/cmd/env/list_test.go
@@ -132,7 +132,7 @@ func Test_Env_ListCommand(t *testing.T) {
 	testutil.TableTestCommand(t, testutil.CommandTests{
 		"list variables using arguments": {
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
-				cm.APIInterface.On(
+				cm.API.On(
 					"ListVariables",
 					mock.Anything,
 					mock.Anything,
@@ -150,7 +150,7 @@ func Test_Env_ListCommand(t *testing.T) {
 				appSelectMock.On("TeamAppSelectPrompt").Return(prompts.SelectedApp{}, nil)
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
-				cm.APIInterface.AssertCalled(
+				cm.API.AssertCalled(
 					t,
 					"ListVariables",
 					mock.Anything,

--- a/cmd/env/remove.go
+++ b/cmd/env/remove.go
@@ -95,7 +95,7 @@ func runEnvRemoveCommandFunc(clients *shared.ClientFactory, cmd *cobra.Command, 
 	if len(args) > 0 {
 		variableName = args[0]
 	} else {
-		variables, err := clients.APIInterface().ListVariables(
+		variables, err := clients.API().ListVariables(
 			ctx,
 			selection.Auth.Token,
 			selection.App.AppID,
@@ -130,7 +130,7 @@ func runEnvRemoveCommandFunc(clients *shared.ClientFactory, cmd *cobra.Command, 
 		}
 	}
 
-	err = clients.APIInterface().RemoveVariable(
+	err = clients.API().RemoveVariable(
 		ctx,
 		selection.Auth.Token,
 		selection.App.AppID,

--- a/cmd/env/remove_test.go
+++ b/cmd/env/remove_test.go
@@ -134,7 +134,7 @@ func Test_Env_RemoveCommand(t *testing.T) {
 		"remove a variable using arguments": {
 			CmdArgs: []string{"ENV_NAME"},
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
-				cm.APIInterface.On(
+				cm.API.On(
 					"ListVariables",
 					mock.Anything,
 					mock.Anything,
@@ -143,7 +143,7 @@ func Test_Env_RemoveCommand(t *testing.T) {
 					[]string{"example"},
 					nil,
 				)
-				cm.APIInterface.On(
+				cm.API.On(
 					"RemoveVariable",
 					mock.Anything,
 					mock.Anything,
@@ -157,7 +157,7 @@ func Test_Env_RemoveCommand(t *testing.T) {
 				appSelectMock.On("TeamAppSelectPrompt").Return(prompts.SelectedApp{}, nil)
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
-				cm.APIInterface.AssertCalled(
+				cm.API.AssertCalled(
 					t,
 					"RemoveVariable",
 					mock.Anything,
@@ -177,7 +177,7 @@ func Test_Env_RemoveCommand(t *testing.T) {
 		"remove a variable using prompt": {
 			CmdArgs: []string{},
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
-				cm.APIInterface.On(
+				cm.API.On(
 					"ListVariables",
 					mock.Anything,
 					mock.Anything,
@@ -186,7 +186,7 @@ func Test_Env_RemoveCommand(t *testing.T) {
 					[]string{"example"},
 					nil,
 				)
-				cm.APIInterface.On(
+				cm.API.On(
 					"RemoveVariable",
 					mock.Anything,
 					mock.Anything,
@@ -216,14 +216,14 @@ func Test_Env_RemoveCommand(t *testing.T) {
 				appSelectMock.On("TeamAppSelectPrompt").Return(prompts.SelectedApp{}, nil)
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
-				cm.APIInterface.AssertCalled(
+				cm.API.AssertCalled(
 					t,
 					"ListVariables",
 					mock.Anything,
 					mock.Anything,
 					mock.Anything,
 				)
-				cm.APIInterface.AssertCalled(
+				cm.API.AssertCalled(
 					t,
 					"RemoveVariable",
 					mock.Anything,
@@ -236,7 +236,7 @@ func Test_Env_RemoveCommand(t *testing.T) {
 		"exit without errors when prompting zero environment variables": {
 			CmdArgs: []string{},
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
-				cm.APIInterface.On(
+				cm.API.On(
 					"ListVariables",
 					mock.Anything,
 					mock.Anything,
@@ -250,7 +250,7 @@ func Test_Env_RemoveCommand(t *testing.T) {
 				appSelectMock.On("TeamAppSelectPrompt").Return(prompts.SelectedApp{}, nil)
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
-				cm.APIInterface.AssertCalled(
+				cm.API.AssertCalled(
 					t,
 					"ListVariables",
 					mock.Anything,

--- a/cmd/externalauth/add.go
+++ b/cmd/externalauth/add.go
@@ -89,7 +89,7 @@ func runAddCommand(clients *shared.ClientFactory, cmd *cobra.Command) error {
 	}
 
 	// Get the oauth2 provider keys
-	providerAuths, err := clients.APIInterface().AppsAuthExternalList(
+	providerAuths, err := clients.API().AppsAuthExternalList(
 		ctx,
 		selection.Auth.Token,
 		selection.App.AppID,
@@ -132,7 +132,7 @@ func runAddCommand(clients *shared.ClientFactory, cmd *cobra.Command) error {
 		return slackerror.New(fmt.Sprintf("Error: No client secret exists. Add one with %s", command))
 	}
 
-	authorizationURL, err := clients.APIInterface().AppsAuthExternalStart(
+	authorizationURL, err := clients.API().AppsAuthExternalStart(
 		ctx,
 		selection.Auth.Token,
 		selection.App.AppID,

--- a/cmd/externalauth/add_secret.go
+++ b/cmd/externalauth/add_secret.go
@@ -92,7 +92,7 @@ func runAddClientSecretCommand(clients *shared.ClientFactory, cmd *cobra.Command
 	}
 
 	// Get the oauth2 provider keys
-	providerAuths, err := clients.APIInterface().AppsAuthExternalList(
+	providerAuths, err := clients.API().AppsAuthExternalList(
 		ctx,
 		selection.Auth.Token,
 		selection.App.AppID,
@@ -121,7 +121,7 @@ func runAddClientSecretCommand(clients *shared.ClientFactory, cmd *cobra.Command
 		clientSecret = response.Value
 	}
 
-	err = clients.APIInterface().AppsAuthExternalClientSecretAdd(
+	err = clients.API().AppsAuthExternalClientSecretAdd(
 		ctx,
 		selection.Auth.Token,
 		selection.App.AppID,

--- a/cmd/externalauth/add_secret_test.go
+++ b/cmd/externalauth/add_secret_test.go
@@ -141,7 +141,7 @@ func TestExternalAuthAddClientSecretCommand(t *testing.T) {
 		"no params": {
 			CmdArgs: []string{},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.APIInterface.On("AppsAuthExternalList",
+				clientsMock.API.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(types.ExternalAuthorizationInfoLists{
 						Authorizations: []types.ExternalAuthorizationInfo{
@@ -153,7 +153,7 @@ func TestExternalAuthAddClientSecretCommand(t *testing.T) {
 							},
 						}}, nil)
 
-				clientsMock.APIInterface.On("AppsAuthExternalClientSecretAdd", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				clientsMock.API.On("AppsAuthExternalClientSecretAdd", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 				clientsMock.IO.On("PasswordPrompt", mock.Anything, "Enter the client secret", iostreams.MatchPromptConfig(iostreams.PasswordPromptConfig{
 					Flag: clientsMock.Config.Flags.Lookup("secret"),
 				})).Return(iostreams.PasswordPromptResponse{
@@ -169,13 +169,13 @@ func TestExternalAuthAddClientSecretCommand(t *testing.T) {
 			},
 			ExpectedOutputs: []string{},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.APIInterface.AssertCalled(t, "AppsAuthExternalClientSecretAdd", mock.Anything, mock.Anything, fakeAppID, "provider_a", "secret_key_1234")
+				clientsMock.API.AssertCalled(t, "AppsAuthExternalClientSecretAdd", mock.Anything, mock.Anything, fakeAppID, "provider_a", "secret_key_1234")
 			},
 		},
 		"with --provider": {
 			CmdArgs: []string{"--provider", "provider_a"},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.APIInterface.On("AppsAuthExternalList",
+				clientsMock.API.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(types.ExternalAuthorizationInfoLists{
 						Authorizations: []types.ExternalAuthorizationInfo{
@@ -188,7 +188,7 @@ func TestExternalAuthAddClientSecretCommand(t *testing.T) {
 						},
 					}, nil)
 
-				clientsMock.APIInterface.On("AppsAuthExternalClientSecretAdd", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				clientsMock.API.On("AppsAuthExternalClientSecretAdd", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 				clientsMock.IO.On("PasswordPrompt", mock.Anything, "Enter the client secret", iostreams.MatchPromptConfig(iostreams.PasswordPromptConfig{
 					Flag: clientsMock.Config.Flags.Lookup("secret"),
 				})).Return(iostreams.PasswordPromptResponse{
@@ -204,13 +204,13 @@ func TestExternalAuthAddClientSecretCommand(t *testing.T) {
 			},
 			ExpectedOutputs: []string{},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.APIInterface.AssertCalled(t, "AppsAuthExternalClientSecretAdd", mock.Anything, mock.Anything, fakeAppID, "provider_a", "secret_key_1234")
+				clientsMock.API.AssertCalled(t, "AppsAuthExternalClientSecretAdd", mock.Anything, mock.Anything, fakeAppID, "provider_a", "secret_key_1234")
 			},
 		},
 		"with --secret": {
 			CmdArgs: []string{"--secret", "secret"},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.APIInterface.On("AppsAuthExternalList",
+				clientsMock.API.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(types.ExternalAuthorizationInfoLists{
 						Authorizations: []types.ExternalAuthorizationInfo{
@@ -221,7 +221,7 @@ func TestExternalAuthAddClientSecretCommand(t *testing.T) {
 								ClientSecretExists: true, ValidTokenExists: false,
 							},
 						}}, nil)
-				clientsMock.APIInterface.On("AppsAuthExternalClientSecretAdd", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				clientsMock.API.On("AppsAuthExternalClientSecretAdd", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 				clientsMock.IO.On("PasswordPrompt", mock.Anything, "Enter the client secret", iostreams.MatchPromptConfig(iostreams.PasswordPromptConfig{
 					Flag: clientsMock.Config.Flags.Lookup("secret"),
 				})).Return(iostreams.PasswordPromptResponse{
@@ -237,13 +237,13 @@ func TestExternalAuthAddClientSecretCommand(t *testing.T) {
 			},
 			ExpectedOutputs: []string{},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.APIInterface.AssertCalled(t, "AppsAuthExternalClientSecretAdd", mock.Anything, mock.Anything, fakeAppID, "provider_a", "secret")
+				clientsMock.API.AssertCalled(t, "AppsAuthExternalClientSecretAdd", mock.Anything, mock.Anything, fakeAppID, "provider_a", "secret")
 			},
 		},
 		"with --provider and --secret": {
 			CmdArgs: []string{"--provider", "provider_a", "--secret", "secret"},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.APIInterface.On("AppsAuthExternalList",
+				clientsMock.API.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything).
 					Return(types.ExternalAuthorizationInfoLists{
 						Authorizations: []types.ExternalAuthorizationInfo{
@@ -254,7 +254,7 @@ func TestExternalAuthAddClientSecretCommand(t *testing.T) {
 								ClientSecretExists: true, ValidTokenExists: false,
 							},
 						}}, nil)
-				clientsMock.APIInterface.On("AppsAuthExternalClientSecretAdd", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				clientsMock.API.On("AppsAuthExternalClientSecretAdd", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 				clientsMock.IO.On("PasswordPrompt", mock.Anything, "Enter the client secret", iostreams.MatchPromptConfig(iostreams.PasswordPromptConfig{
 					Flag: clientsMock.Config.Flags.Lookup("secret"),
 				})).Return(iostreams.PasswordPromptResponse{
@@ -269,17 +269,17 @@ func TestExternalAuthAddClientSecretCommand(t *testing.T) {
 				require.NoError(t, err, "Cant write apps.json")
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.APIInterface.AssertCalled(t, "AppsAuthExternalClientSecretAdd", mock.Anything, mock.Anything, fakeAppID, "provider_a", "secret")
+				clientsMock.API.AssertCalled(t, "AppsAuthExternalClientSecretAdd", mock.Anything, mock.Anything, fakeAppID, "provider_a", "secret")
 			},
 		},
 		"when list api returns error": {
 			CmdArgs: []string{"--provider", "provider_a", "--secret", "secret"},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.APIInterface.On("AppsAuthExternalList",
+				clientsMock.API.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(types.ExternalAuthorizationInfoLists{
 						Authorizations: []types.ExternalAuthorizationInfo{}}, errors.New("test error"))
-				clientsMock.APIInterface.On("AppsAuthExternalClientSecretAdd", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("https://authorizationurl.com", nil)
+				clientsMock.API.On("AppsAuthExternalClientSecretAdd", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("https://authorizationurl.com", nil)
 				clientsMock.IO.On("PasswordPrompt", mock.Anything, "Enter the client secret", iostreams.MatchPromptConfig(iostreams.PasswordPromptConfig{
 					Flag: clientsMock.Config.Flags.Lookup("secret"),
 				})).Return(iostreams.PasswordPromptResponse{
@@ -295,7 +295,7 @@ func TestExternalAuthAddClientSecretCommand(t *testing.T) {
 			},
 			ExpectedErrorStrings: []string{"test error"},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.APIInterface.AssertNotCalled(t, "AppsAuthExternalClientSecretAdd", mock.Anything, mock.Anything, fakeAppID, "provider_a")
+				clientsMock.API.AssertNotCalled(t, "AppsAuthExternalClientSecretAdd", mock.Anything, mock.Anything, fakeAppID, "provider_a")
 			},
 		},
 	}, func(clients *shared.ClientFactory) *cobra.Command {

--- a/cmd/externalauth/add_test.go
+++ b/cmd/externalauth/add_test.go
@@ -141,7 +141,7 @@ func TestExternalAuthAddCommand(t *testing.T) {
 			CmdArgs:         []string{},
 			ExpectedOutputs: []string{},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.APIInterface.On("AppsAuthExternalList",
+				clientsMock.API.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(types.ExternalAuthorizationInfoLists{
 						Authorizations: []types.ExternalAuthorizationInfo{
@@ -152,7 +152,7 @@ func TestExternalAuthAddCommand(t *testing.T) {
 								ClientSecretExists: true, ValidTokenExists: false,
 							},
 						}}, nil)
-				clientsMock.APIInterface.On("AppsAuthExternalStart", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("https://authorizationurl1.com", nil)
+				clientsMock.API.On("AppsAuthExternalStart", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("https://authorizationurl1.com", nil)
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
 				// TODO this can probably be replaced by a helper that sets up an apps.json file in
@@ -161,7 +161,7 @@ func TestExternalAuthAddCommand(t *testing.T) {
 				require.NoError(t, err, "Cant write apps.json")
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.APIInterface.AssertCalled(t, "AppsAuthExternalStart", mock.Anything, mock.Anything, fakeAppID, "provider_a")
+				clientsMock.API.AssertCalled(t, "AppsAuthExternalStart", mock.Anything, mock.Anything, fakeAppID, "provider_a")
 				clientsMock.Browser.AssertCalled(t, "OpenURL", "https://authorizationurl1.com")
 			},
 		},
@@ -169,7 +169,7 @@ func TestExternalAuthAddCommand(t *testing.T) {
 			CmdArgs:              []string{},
 			ExpectedErrorStrings: []string{"No client secret exists"},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.APIInterface.On("AppsAuthExternalList",
+				clientsMock.API.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(types.ExternalAuthorizationInfoLists{
 						Authorizations: []types.ExternalAuthorizationInfo{
@@ -180,7 +180,7 @@ func TestExternalAuthAddCommand(t *testing.T) {
 								ClientSecretExists: false, ValidTokenExists: false,
 							},
 						}}, nil)
-				clientsMock.APIInterface.On("AppsAuthExternalStart", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("https://authorizationurl2.com/example", nil)
+				clientsMock.API.On("AppsAuthExternalStart", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("https://authorizationurl2.com/example", nil)
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
 				// TODO this can probably be replaced by a helper that sets up an apps.json file in
@@ -189,7 +189,7 @@ func TestExternalAuthAddCommand(t *testing.T) {
 				require.NoError(t, err, "Cant write apps.json")
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.APIInterface.AssertNotCalled(t, "AppsAuthExternalStart")
+				clientsMock.API.AssertNotCalled(t, "AppsAuthExternalStart")
 				clientsMock.Browser.AssertNotCalled(t, "OpenURL")
 			},
 		},
@@ -197,7 +197,7 @@ func TestExternalAuthAddCommand(t *testing.T) {
 			CmdArgs:         []string{"--provider", "provider_a"},
 			ExpectedOutputs: []string{},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.APIInterface.On("AppsAuthExternalList",
+				clientsMock.API.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(types.ExternalAuthorizationInfoLists{
 						Authorizations: []types.ExternalAuthorizationInfo{
@@ -208,7 +208,7 @@ func TestExternalAuthAddCommand(t *testing.T) {
 								ClientSecretExists: true, ValidTokenExists: false,
 							},
 						}}, nil)
-				clientsMock.APIInterface.On("AppsAuthExternalStart", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("https://authorizationurl3.com/provider", nil)
+				clientsMock.API.On("AppsAuthExternalStart", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("https://authorizationurl3.com/provider", nil)
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
 				// TODO this can probably be replaced by a helper that sets up an apps.json file in
@@ -217,7 +217,7 @@ func TestExternalAuthAddCommand(t *testing.T) {
 				require.NoError(t, err, "Cant write apps.json")
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.APIInterface.AssertCalled(t, "AppsAuthExternalStart", mock.Anything, mock.Anything, fakeAppID, "provider_a")
+				clientsMock.API.AssertCalled(t, "AppsAuthExternalStart", mock.Anything, mock.Anything, fakeAppID, "provider_a")
 				clientsMock.Browser.AssertCalled(t, "OpenURL", "https://authorizationurl3.com/provider")
 			},
 		},
@@ -225,7 +225,7 @@ func TestExternalAuthAddCommand(t *testing.T) {
 			CmdArgs:              []string{"--provider", "provider_a"},
 			ExpectedErrorStrings: []string{"No client secret exists"},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.APIInterface.On("AppsAuthExternalList",
+				clientsMock.API.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(types.ExternalAuthorizationInfoLists{
 						Authorizations: []types.ExternalAuthorizationInfo{
@@ -237,7 +237,7 @@ func TestExternalAuthAddCommand(t *testing.T) {
 							},
 						}}, nil)
 				providerSelectTeardown = setupMockProviderSelection()
-				clientsMock.APIInterface.On("AppsAuthExternalStart", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("https://authorizationurl4.com/secret", nil)
+				clientsMock.API.On("AppsAuthExternalStart", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("https://authorizationurl4.com/secret", nil)
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
 				// TODO this can probably be replaced by a helper that sets up an apps.json file in
@@ -246,18 +246,18 @@ func TestExternalAuthAddCommand(t *testing.T) {
 				require.NoError(t, err, "Cant write apps.json")
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.APIInterface.AssertNotCalled(t, "AppsAuthExternalStart")
+				clientsMock.API.AssertNotCalled(t, "AppsAuthExternalStart")
 				clientsMock.Browser.AssertNotCalled(t, "OpenURL")
 			},
 		},
 		"when list api returns error": {
 			CmdArgs: []string{"--provider", "provider_a"},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.APIInterface.On("AppsAuthExternalList",
+				clientsMock.API.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(types.ExternalAuthorizationInfoLists{
 						Authorizations: []types.ExternalAuthorizationInfo{}}, errors.New("test error"))
-				clientsMock.APIInterface.On("AppsAuthExternalStart", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("https://authorizationurl5.com/error", nil)
+				clientsMock.API.On("AppsAuthExternalStart", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("https://authorizationurl5.com/error", nil)
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
 				// TODO this can probably be replaced by a helper that sets up an apps.json file in
@@ -267,7 +267,7 @@ func TestExternalAuthAddCommand(t *testing.T) {
 			},
 			ExpectedErrorStrings: []string{"test error"},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.APIInterface.AssertNotCalled(t, "AppsAuthExternalStart", mock.Anything, mock.Anything, fakeAppID, "provider_a")
+				clientsMock.API.AssertNotCalled(t, "AppsAuthExternalStart", mock.Anything, mock.Anything, fakeAppID, "provider_a")
 				clientsMock.Browser.AssertNotCalled(t, "OpenURL")
 			},
 		},

--- a/cmd/externalauth/remove.go
+++ b/cmd/externalauth/remove.go
@@ -121,7 +121,7 @@ func runRemoveCommand(clients *shared.ClientFactory, cmd *cobra.Command) error {
 			return nil
 		}
 
-		err = clients.APIInterface().AppsAuthExternalDelete(
+		err = clients.API().AppsAuthExternalDelete(
 			ctx,
 			selection.Auth.Token,
 			selection.App.AppID,
@@ -142,7 +142,7 @@ func runRemoveCommand(clients *shared.ClientFactory, cmd *cobra.Command) error {
 			return nil
 		}
 
-		err = clients.APIInterface().AppsAuthExternalDelete(
+		err = clients.API().AppsAuthExternalDelete(
 			ctx,
 			selection.Auth.Token,
 			selection.App.AppID,
@@ -154,7 +154,7 @@ func runRemoveCommand(clients *shared.ClientFactory, cmd *cobra.Command) error {
 		}
 	} else {
 		// Get oauth2 providerAuths
-		providerAuths, err := clients.APIInterface().AppsAuthExternalList(
+		providerAuths, err := clients.API().AppsAuthExternalList(
 			ctx,
 			selection.Auth.Token,
 			selection.App.AppID,
@@ -191,7 +191,7 @@ func runRemoveCommand(clients *shared.ClientFactory, cmd *cobra.Command) error {
 			if externalTokenArg == "" {
 				return slackerror.New("Unable to get a provider selection")
 			}
-			err = clients.APIInterface().AppsAuthExternalDelete(
+			err = clients.API().AppsAuthExternalDelete(
 				ctx,
 				selection.Auth.Token,
 				selection.App.AppID,
@@ -202,7 +202,7 @@ func runRemoveCommand(clients *shared.ClientFactory, cmd *cobra.Command) error {
 				return err
 			}
 		} else {
-			err = clients.APIInterface().AppsAuthExternalDelete(
+			err = clients.API().AppsAuthExternalDelete(
 				ctx,
 				selection.Auth.Token,
 				selection.App.AppID,

--- a/cmd/externalauth/remove_test.go
+++ b/cmd/externalauth/remove_test.go
@@ -142,7 +142,7 @@ func TestExternalAuthRemoveCommand(t *testing.T) {
 			CmdArgs:         []string{},
 			ExpectedOutputs: []string{},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.APIInterface.On("AppsAuthExternalList",
+				clientsMock.API.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything).
 					Return(types.ExternalAuthorizationInfoLists{
 						Authorizations: []types.ExternalAuthorizationInfo{
@@ -153,7 +153,7 @@ func TestExternalAuthRemoveCommand(t *testing.T) {
 								ClientSecretExists: false, ValidTokenExists: false,
 							},
 						}}, nil)
-				clientsMock.APIInterface.On("AppsAuthExternalDelete", mock.Anything, mock.Anything, mock.Anything, mock.Anything, "").Return(nil)
+				clientsMock.API.On("AppsAuthExternalDelete", mock.Anything, mock.Anything, mock.Anything, mock.Anything, "").Return(nil)
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
 				// TODO this can probably be replaced by a helper that sets up an apps.json file in
@@ -162,14 +162,14 @@ func TestExternalAuthRemoveCommand(t *testing.T) {
 				require.NoError(t, err, "Cant write apps.json")
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.APIInterface.AssertCalled(t, "AppsAuthExternalDelete", mock.Anything, mock.Anything, fakeAppID, "provider_a", "")
+				clientsMock.API.AssertCalled(t, "AppsAuthExternalDelete", mock.Anything, mock.Anything, fakeAppID, "provider_a", "")
 			},
 		},
 		"with --provider": {
 			CmdArgs:         []string{"--provider", "provider_a"},
 			ExpectedOutputs: []string{},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.APIInterface.On("AppsAuthExternalList",
+				clientsMock.API.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything).
 					Return(types.ExternalAuthorizationInfoLists{
 						Authorizations: []types.ExternalAuthorizationInfo{
@@ -180,21 +180,21 @@ func TestExternalAuthRemoveCommand(t *testing.T) {
 								ClientSecretExists: true, ValidTokenExists: false,
 							},
 						}}, nil)
-				clientsMock.APIInterface.On("AppsAuthExternalDelete", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				clientsMock.API.On("AppsAuthExternalDelete", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 				clientsMock.AddDefaultMocks()
 				clientsMock.IO.On("ConfirmPrompt", mock.Anything, "Are you sure you want to remove all tokens for this app relevant to the specified provider from your current team/org?", mock.Anything).Return(true)
 				err := clients.AppClient().SaveDeployed(ctx, fakeApp)
 				require.NoError(t, err, "Cant write apps.json")
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.APIInterface.AssertCalled(t, "AppsAuthExternalDelete", mock.Anything, mock.Anything, fakeAppID, "provider_a", "")
+				clientsMock.API.AssertCalled(t, "AppsAuthExternalDelete", mock.Anything, mock.Anything, fakeAppID, "provider_a", "")
 			},
 		},
 		"with --all": {
 			CmdArgs:         []string{"--all"},
 			ExpectedOutputs: []string{},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.APIInterface.On("AppsAuthExternalList",
+				clientsMock.API.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything).
 					Return(types.ExternalAuthorizationInfoLists{
 						Authorizations: []types.ExternalAuthorizationInfo{
@@ -205,21 +205,21 @@ func TestExternalAuthRemoveCommand(t *testing.T) {
 								ClientSecretExists: true, ValidTokenExists: false,
 							},
 						}}, nil)
-				clientsMock.APIInterface.On("AppsAuthExternalDelete", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				clientsMock.API.On("AppsAuthExternalDelete", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 				clientsMock.AddDefaultMocks()
 				err := clients.AppClient().SaveDeployed(ctx, fakeApp)
 				require.NoError(t, err, "Cant write apps.json")
 				clientsMock.IO.On("ConfirmPrompt", mock.Anything, "Are you sure you want to remove all tokens for this app from your current team/org?", mock.Anything).Return(true)
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.APIInterface.AssertCalled(t, "AppsAuthExternalDelete", mock.Anything, mock.Anything, fakeAppID, "", "")
+				clientsMock.API.AssertCalled(t, "AppsAuthExternalDelete", mock.Anything, mock.Anything, fakeAppID, "", "")
 			},
 		},
 		"with --all and --provider": {
 			CmdArgs:         []string{"--all", "--provider", "provider_a"},
 			ExpectedOutputs: []string{},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.APIInterface.On("AppsAuthExternalList",
+				clientsMock.API.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything).
 					Return(types.ExternalAuthorizationInfoLists{
 						Authorizations: []types.ExternalAuthorizationInfo{
@@ -230,7 +230,7 @@ func TestExternalAuthRemoveCommand(t *testing.T) {
 								ClientSecretExists: true, ValidTokenExists: false,
 							},
 						}}, nil)
-				clientsMock.APIInterface.On("AppsAuthExternalDelete", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				clientsMock.API.On("AppsAuthExternalDelete", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 				clientsMock.AddDefaultMocks()
 				err := clients.AppClient().SaveDeployed(ctx, fakeApp)
 				require.NoError(t, err, "Cant write apps.json")
@@ -238,24 +238,24 @@ func TestExternalAuthRemoveCommand(t *testing.T) {
 				clientsMock.IO.On("ConfirmPrompt", mock.Anything, "Are you sure you want to remove all tokens for this app relevant to the specified provider from your current team/org?", mock.Anything).Return(true)
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.APIInterface.AssertCalled(t, "AppsAuthExternalDelete", mock.Anything, mock.Anything, fakeAppID, "provider_a", "")
+				clientsMock.API.AssertCalled(t, "AppsAuthExternalDelete", mock.Anything, mock.Anything, fakeAppID, "provider_a", "")
 			},
 		},
 		"with --all but no auth present": {
 			CmdArgs: []string{"--all"},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.APIInterface.On("AppsAuthExternalList",
+				clientsMock.API.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything).
 					Return(types.ExternalAuthorizationInfoLists{
 						Authorizations: []types.ExternalAuthorizationInfo{}}, errors.New("test error"))
-				clientsMock.APIInterface.On("AppsAuthExternalDelete", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				clientsMock.API.On("AppsAuthExternalDelete", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 				clientsMock.AddDefaultMocks()
 				err := clients.AppClient().SaveDeployed(ctx, fakeApp)
 				require.NoError(t, err, "Cant write apps.json")
 				clientsMock.IO.On("ConfirmPrompt", mock.Anything, "Are you sure you want to remove all tokens for this app from your current team/org?", mock.Anything).Return(true)
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.APIInterface.AssertCalled(t, "AppsAuthExternalDelete", mock.Anything, mock.Anything, fakeAppID, "", "")
+				clientsMock.API.AssertCalled(t, "AppsAuthExternalDelete", mock.Anything, mock.Anything, fakeAppID, "", "")
 			},
 		},
 	}, func(clients *shared.ClientFactory) *cobra.Command {

--- a/cmd/externalauth/select_auth.go
+++ b/cmd/externalauth/select_auth.go
@@ -92,7 +92,7 @@ func runSelectAuthCommand(clients *shared.ClientFactory, cmd *cobra.Command) err
 	}
 
 	// Get the oauth2 details for the app
-	externalAuths, err := clients.APIInterface().AppsAuthExternalList(
+	externalAuths, err := clients.API().AppsAuthExternalList(
 		ctx,
 		selection.Auth.Token,
 		selection.App.AppID,
@@ -142,7 +142,7 @@ func runSelectAuthCommand(clients *shared.ClientFactory, cmd *cobra.Command) err
 		return slackerror.New("Account is not used in the selected workflow")
 	}
 
-	err = clients.APIInterface().AppsAuthExternalSelectAuth(
+	err = clients.API().AppsAuthExternalSelectAuth(
 		ctx,
 		selection.Auth.Token,
 		selection.App.AppID,

--- a/cmd/externalauth/select_auth_test.go
+++ b/cmd/externalauth/select_auth_test.go
@@ -244,19 +244,19 @@ func TestExternalAuthSelectAuthCommand(t *testing.T) {
 		"list api returns error": {
 			CmdArgs: []string{},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.APIInterface.On("AppsAuthExternalList",
+				clientsMock.API.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(types.ExternalAuthorizationInfoLists{}, errors.New("test error"))
 			},
 			ExpectedErrorStrings: []string{"test error"},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.APIInterface.AssertNotCalled(t, "AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+				clientsMock.API.AssertNotCalled(t, "AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 			},
 		},
 		"list with no tokens and no params": {
 			CmdArgs: []string{},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.APIInterface.On("AppsAuthExternalList",
+				clientsMock.API.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(sampleListReturnWithoutTokens, nil)
 				clientsMock.IO.On("SelectPrompt", mock.Anything, "Select a workflow", mock.Anything, iostreams.MatchPromptConfig(iostreams.SelectPromptConfig{
@@ -265,13 +265,13 @@ func TestExternalAuthSelectAuthCommand(t *testing.T) {
 			},
 			ExpectedErrorStrings: []string{"No workflows found that require developer authorization"},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.APIInterface.AssertNotCalled(t, "AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, fakeAppID, mock.Anything, mock.Anything)
+				clientsMock.API.AssertNotCalled(t, "AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, fakeAppID, mock.Anything, mock.Anything)
 			},
 		},
 		"list with no tokens and workflow flag": {
 			CmdArgs: []string{"--workflow", "#/workflows/workflow_callback"},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.APIInterface.On("AppsAuthExternalList",
+				clientsMock.API.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(sampleListReturnWithoutTokens, nil)
 				clientsMock.IO.On("SelectPrompt", mock.Anything, "Select a workflow", mock.Anything, iostreams.MatchPromptConfig(iostreams.SelectPromptConfig{
@@ -283,13 +283,13 @@ func TestExternalAuthSelectAuthCommand(t *testing.T) {
 			},
 			ExpectedErrorStrings: []string{"Workflow not found"},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.APIInterface.AssertNotCalled(t, "AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, fakeAppID, mock.Anything, mock.Anything, mock.Anything)
+				clientsMock.API.AssertNotCalled(t, "AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, fakeAppID, mock.Anything, mock.Anything, mock.Anything)
 			},
 		},
 		"list with no workflows and no params": {
 			CmdArgs: []string{},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.APIInterface.On("AppsAuthExternalList",
+				clientsMock.API.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(sampleListReturnWithoutWorkflows, nil)
 				clientsMock.IO.On("SelectPrompt", mock.Anything, "Select a workflow", mock.Anything, iostreams.MatchPromptConfig(iostreams.SelectPromptConfig{
@@ -298,13 +298,13 @@ func TestExternalAuthSelectAuthCommand(t *testing.T) {
 			},
 			ExpectedErrorStrings: []string{"No workflows found that require developer authorization"},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.APIInterface.AssertNotCalled(t, "AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, fakeAppID, mock.Anything, mock.Anything, mock.Anything)
+				clientsMock.API.AssertNotCalled(t, "AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, fakeAppID, mock.Anything, mock.Anything, mock.Anything)
 			},
 		},
 		"list with no workflows and workflow flag": {
 			CmdArgs: []string{"--workflow", "#/workflows/workflow_callback"},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.APIInterface.On("AppsAuthExternalList",
+				clientsMock.API.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(sampleListReturnWithoutWorkflows, nil)
 				clientsMock.IO.On("SelectPrompt", mock.Anything, "Select a workflow", mock.Anything, iostreams.MatchPromptConfig(iostreams.SelectPromptConfig{
@@ -316,13 +316,13 @@ func TestExternalAuthSelectAuthCommand(t *testing.T) {
 			},
 			ExpectedErrorStrings: []string{"Workflow not found"},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.APIInterface.AssertNotCalled(t, "AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, fakeAppID, mock.Anything, mock.Anything, mock.Anything)
+				clientsMock.API.AssertNotCalled(t, "AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, fakeAppID, mock.Anything, mock.Anything, mock.Anything)
 			},
 		},
 		"list with workflows and no param": {
 			CmdArgs: []string{},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.APIInterface.On("AppsAuthExternalList",
+				clientsMock.API.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(sampleListReturnWithWorkflows, nil)
 				clientsMock.IO.On("SelectPrompt", mock.Anything, "Select a workflow", mock.Anything, iostreams.MatchPromptConfig(iostreams.SelectPromptConfig{
@@ -342,13 +342,13 @@ func TestExternalAuthSelectAuthCommand(t *testing.T) {
 			},
 			ExpectedErrorStrings: []string{"No connected accounts found"},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.APIInterface.AssertNotCalled(t, "AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, fakeAppID, mock.Anything, mock.Anything, mock.Anything)
+				clientsMock.API.AssertNotCalled(t, "AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, fakeAppID, mock.Anything, mock.Anything, mock.Anything)
 			},
 		},
 		"list with workflows and invalid workflow param": {
 			CmdArgs: []string{"--workflow", "#/workflows/workflow_callback"},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.APIInterface.On("AppsAuthExternalList",
+				clientsMock.API.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(sampleListReturnWithWorkflows, nil)
 				clientsMock.IO.On("SelectPrompt", mock.Anything, "Select a workflow", mock.Anything, iostreams.MatchPromptConfig(iostreams.SelectPromptConfig{
@@ -374,16 +374,16 @@ func TestExternalAuthSelectAuthCommand(t *testing.T) {
 			},
 			ExpectedErrorStrings: []string{"Workflow not found"},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.APIInterface.AssertNotCalled(t, "AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, fakeAppID, mock.Anything, mock.Anything, mock.Anything)
+				clientsMock.API.AssertNotCalled(t, "AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, fakeAppID, mock.Anything, mock.Anything, mock.Anything)
 			},
 		},
 		"list with workflows and valid workflow param": {
 			CmdArgs: []string{"--workflow", "#/workflows/my_callback_id2"},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.APIInterface.On("AppsAuthExternalList",
+				clientsMock.API.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(sampleListReturnWithWorkflows, nil)
-				clientsMock.APIInterface.On("AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				clientsMock.API.On("AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 				clientsMock.IO.On("SelectPrompt", mock.Anything, "Select a workflow", mock.Anything, iostreams.MatchPromptConfig(iostreams.SelectPromptConfig{
 					Flag: clientsMock.Config.Flags.Lookup("workflow"),
 				})).Return(iostreams.SelectPromptResponse{
@@ -399,13 +399,13 @@ func TestExternalAuthSelectAuthCommand(t *testing.T) {
 			},
 			ExpectedErrorStrings: []string{"No connected accounts found"},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.APIInterface.AssertNotCalled(t, "AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, fakeAppID, mock.Anything, mock.Anything, mock.Anything)
+				clientsMock.API.AssertNotCalled(t, "AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, fakeAppID, mock.Anything, mock.Anything, mock.Anything)
 			},
 		},
 		"list with workflows and valid workflow invalid provider": {
 			CmdArgs: []string{"--workflow", "#/workflows/my_callback_id2", "--provider", "test_provider"},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.APIInterface.On("AppsAuthExternalList",
+				clientsMock.API.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(sampleListReturnWithWorkflows, nil)
 				clientsMock.IO.On("SelectPrompt", mock.Anything, "Select a workflow", mock.Anything, iostreams.MatchPromptConfig(iostreams.SelectPromptConfig{
@@ -423,13 +423,13 @@ func TestExternalAuthSelectAuthCommand(t *testing.T) {
 			},
 			ExpectedErrorStrings: []string{"Provider is not used in the selected workflow"},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.APIInterface.AssertNotCalled(t, "AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, fakeAppID, mock.Anything, mock.Anything, mock.Anything)
+				clientsMock.API.AssertNotCalled(t, "AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, fakeAppID, mock.Anything, mock.Anything, mock.Anything)
 			},
 		},
 		"list with workflows and valid workflow valid provider": {
 			CmdArgs: []string{"--workflow", "#/workflows/my_callback_id2", "--provider", "provider_b"},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.APIInterface.On("AppsAuthExternalList",
+				clientsMock.API.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(sampleListReturnWithWorkflows, nil)
 				clientsMock.IO.On("SelectPrompt", mock.Anything, "Select a workflow", mock.Anything, iostreams.MatchPromptConfig(iostreams.SelectPromptConfig{
@@ -449,16 +449,16 @@ func TestExternalAuthSelectAuthCommand(t *testing.T) {
 			},
 			ExpectedErrorStrings: []string{"No connected accounts found"},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.APIInterface.AssertNotCalled(t, "AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, fakeAppID, mock.Anything, mock.Anything, mock.Anything)
+				clientsMock.API.AssertNotCalled(t, "AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, fakeAppID, mock.Anything, mock.Anything, mock.Anything)
 			},
 		},
 		"list with workflows and valid workflow valid provider with tokens": {
 			CmdArgs: []string{"--workflow", "#/workflows/my_callback_id2", "--provider", "provider_a"},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.APIInterface.On("AppsAuthExternalList",
+				clientsMock.API.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(sampleListReturnWithWorkflows, nil)
-				clientsMock.APIInterface.On("AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				clientsMock.API.On("AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 				clientsMock.IO.On("SelectPrompt", mock.Anything, "Select a workflow", mock.Anything, iostreams.MatchPromptConfig(iostreams.SelectPromptConfig{
 					Flag: clientsMock.Config.Flags.Lookup("workflow"),
 				})).Return(iostreams.SelectPromptResponse{
@@ -481,16 +481,16 @@ func TestExternalAuthSelectAuthCommand(t *testing.T) {
 			},
 			ExpectedOutputs: []string{"Workflow #/workflows/my_callback_id2 will use developer account xyz2@salesforce.com when making calls to provider_a APIs"},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.APIInterface.AssertCalled(t, "AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, fakeAppID, mock.Anything, mock.Anything, mock.Anything)
+				clientsMock.API.AssertCalled(t, "AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, fakeAppID, mock.Anything, mock.Anything, mock.Anything)
 			},
 		},
 		"list with workflows and valid workflow valid provider invalid account": {
 			CmdArgs: []string{"--workflow", "#/workflows/my_callback_id2", "--provider", "provider_a", "--external-account", "test_account"},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.APIInterface.On("AppsAuthExternalList",
+				clientsMock.API.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(sampleListReturnWithWorkflows, nil)
-				clientsMock.APIInterface.On("AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				clientsMock.API.On("AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 				clientsMock.IO.On("SelectPrompt", mock.Anything, "Select a workflow", mock.Anything, iostreams.MatchPromptConfig(iostreams.SelectPromptConfig{
 					Flag: clientsMock.Config.Flags.Lookup("workflow"),
 				})).Return(iostreams.SelectPromptResponse{
@@ -512,16 +512,16 @@ func TestExternalAuthSelectAuthCommand(t *testing.T) {
 			},
 			ExpectedErrorStrings: []string{"Account is not used in the selected workflow"},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.APIInterface.AssertNotCalled(t, "AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, fakeAppID, mock.Anything, mock.Anything, mock.Anything)
+				clientsMock.API.AssertNotCalled(t, "AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, fakeAppID, mock.Anything, mock.Anything, mock.Anything)
 			},
 		},
 		"list with workflows and valid workflow valid provider valid account": {
 			CmdArgs: []string{"--workflow", "#/workflows/my_callback_id2", "--provider", "provider_a", "--external-account", "xyz2@salesforce.com"},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.APIInterface.On("AppsAuthExternalList",
+				clientsMock.API.On("AppsAuthExternalList",
 					mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(sampleListReturnWithWorkflows, nil)
-				clientsMock.APIInterface.On("AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				clientsMock.API.On("AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 				clientsMock.IO.On("SelectPrompt", mock.Anything, "Select a workflow", mock.Anything, iostreams.MatchPromptConfig(iostreams.SelectPromptConfig{
 					Flag: clientsMock.Config.Flags.Lookup("workflow"),
 				})).Return(iostreams.SelectPromptResponse{
@@ -543,7 +543,7 @@ func TestExternalAuthSelectAuthCommand(t *testing.T) {
 			},
 			ExpectedOutputs: []string{"Workflow #/workflows/my_callback_id2 will use developer account xyz2@salesforce.com when making calls to provider_a APIs"},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.APIInterface.AssertCalled(t, "AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, fakeAppID, mock.Anything, mock.Anything, mock.Anything)
+				clientsMock.API.AssertCalled(t, "AppsAuthExternalSelectAuth", mock.Anything, mock.Anything, fakeAppID, mock.Anything, mock.Anything, mock.Anything)
 			},
 		}}, func(clients *shared.ClientFactory) *cobra.Command {
 		cmd := NewSelectAuthCommand(clients)

--- a/cmd/function/access.go
+++ b/cmd/function/access.go
@@ -139,7 +139,7 @@ func handleUpdate(
 			distribution = types.PermissionAppCollaborators
 		}
 
-		_, err := clients.APIInterface().FunctionDistributionSet(ctx, functionFlag, app.AppID, distribution, "")
+		_, err := clients.API().FunctionDistributionSet(ctx, functionFlag, app.AppID, distribution, "")
 		if err != nil {
 			return err
 		}
@@ -154,7 +154,7 @@ func handleUpdate(
 			return err
 		}
 
-		err = clients.APIInterface().FunctionDistributionAddUsers(ctx, functionFlag, app.AppID, distributeFlags.users)
+		err = clients.API().FunctionDistributionAddUsers(ctx, functionFlag, app.AppID, distributeFlags.users)
 		if err != nil {
 			return err
 		}
@@ -170,7 +170,7 @@ func handleUpdate(
 			return slackerror.New(slackerror.ErrMissingFlag).WithRemediation("To revoke a user's access, pass in their user ID with the --users flag: `--users U12345`")
 		}
 
-		err := clients.APIInterface().FunctionDistributionRemoveUsers(ctx, functionFlag, app.AppID, distributeFlags.users)
+		err := clients.API().FunctionDistributionRemoveUsers(ctx, functionFlag, app.AppID, distributeFlags.users)
 		if err != nil {
 			return err
 		}
@@ -205,7 +205,7 @@ func handleUpdate(
 					return err
 				}
 
-				err = clients.APIInterface().FunctionDistributionAddUsers(ctx, functionFlag, app.AppID, users)
+				err = clients.API().FunctionDistributionAddUsers(ctx, functionFlag, app.AppID, users)
 				if err != nil {
 					return err
 				}
@@ -216,7 +216,7 @@ func handleUpdate(
 					Text:  fmt.Sprintf("Function access granted to the provided %s", style.Pluralize("user", "users", len(users))),
 				})))
 			case "remove":
-				err = clients.APIInterface().FunctionDistributionRemoveUsers(ctx, functionFlag, app.AppID, users)
+				err = clients.API().FunctionDistributionRemoveUsers(ctx, functionFlag, app.AppID, users)
 				if err != nil {
 					return err
 				}
@@ -228,7 +228,7 @@ func handleUpdate(
 			return printDistribution(ctx, cmd, clients, app)
 		}
 
-		_, err = clients.APIInterface().FunctionDistributionSet(ctx, functionFlag, app.AppID, dist, "")
+		_, err = clients.API().FunctionDistributionSet(ctx, functionFlag, app.AppID, dist, "")
 		if err != nil {
 			return err
 		}
@@ -298,7 +298,7 @@ func distributePermissionFile(ctx context.Context, clients *shared.ClientFactory
 					permissions.Type,
 				))
 			}
-			_, err := clients.APIInterface().FunctionDistributionSet(ctx, function, app.AppID, permissions.Type, "")
+			_, err := clients.API().FunctionDistributionSet(ctx, function, app.AppID, permissions.Type, "")
 			if err != nil {
 				return err
 			}
@@ -317,11 +317,11 @@ func updateNamedEntitiesDistribution(
 	entities []string,
 ) error {
 	updatedUsers := strings.Join(entities, ",")
-	_, err := clients.APIInterface().FunctionDistributionSet(ctx, function, app.AppID, types.PermissionNamedEntities, updatedUsers)
+	_, err := clients.API().FunctionDistributionSet(ctx, function, app.AppID, types.PermissionNamedEntities, updatedUsers)
 	if err != nil {
 		return err
 	}
-	_, currentUsers, err := clients.APIInterface().FunctionDistributionList(ctx, function, app.AppID)
+	_, currentUsers, err := clients.API().FunctionDistributionList(ctx, function, app.AppID)
 	if err != nil {
 		return err
 	}
@@ -339,7 +339,7 @@ func updateNamedEntitiesDistribution(
 		}
 	}
 	removals := strings.Join(removalSlice, ",")
-	err = clients.APIInterface().FunctionDistributionRemoveUsers(ctx, function, app.AppID, removals)
+	err = clients.API().FunctionDistributionRemoveUsers(ctx, function, app.AppID, removals)
 	if err != nil {
 		return err
 	}
@@ -348,7 +348,7 @@ func updateNamedEntitiesDistribution(
 
 // printDistribution formats and displays access information
 func printDistribution(ctx context.Context, cmd *cobra.Command, clients *shared.ClientFactory, app types.App) error {
-	dist, userAccessList, err := clients.APIInterface().FunctionDistributionList(ctx, functionFlag, app.AppID)
+	dist, userAccessList, err := clients.API().FunctionDistributionList(ctx, functionFlag, app.AppID)
 	if err != nil {
 		return err
 	}
@@ -387,7 +387,7 @@ func printDistribution(ctx context.Context, cmd *cobra.Command, clients *shared.
 
 // printEntityAccess formats and displays the users with access to an app's functions
 func printEntityAccess(ctx context.Context, cmd *cobra.Command, clients *shared.ClientFactory, app types.App) error {
-	distType, users, err := clients.APIInterface().FunctionDistributionList(ctx, functionFlag, app.AppID)
+	distType, users, err := clients.API().FunctionDistributionList(ctx, functionFlag, app.AppID)
 	if err != nil {
 		return err
 	}
@@ -421,7 +421,7 @@ func printEntityAccess(ctx context.Context, cmd *cobra.Command, clients *shared.
 
 // handleDistributionType checks if the function's distribution type is named_entities and if not, updates it
 func handleDistributionType(ctx context.Context, clients *shared.ClientFactory, app types.App) error {
-	distType, _, err := clients.APIInterface().FunctionDistributionList(ctx, functionFlag, app.AppID)
+	distType, _, err := clients.API().FunctionDistributionList(ctx, functionFlag, app.AppID)
 	if err != nil {
 		return err
 	}
@@ -430,7 +430,7 @@ func handleDistributionType(ctx context.Context, clients *shared.ClientFactory, 
 		return nil
 	}
 
-	_, err = clients.APIInterface().FunctionDistributionSet(ctx, functionFlag, app.AppID, types.PermissionNamedEntities, "")
+	_, err = clients.API().FunctionDistributionSet(ctx, functionFlag, app.AppID, types.PermissionNamedEntities, "")
 	if err != nil {
 		return err
 	}
@@ -445,7 +445,7 @@ func AddCollaboratorsToNamedEntities(
 	app types.App,
 	token string,
 ) error {
-	collaborators, err := clients.APIInterface().ListCollaborators(ctx, token, app.AppID)
+	collaborators, err := clients.API().ListCollaborators(ctx, token, app.AppID)
 	if err != nil {
 		return err
 	}
@@ -464,5 +464,5 @@ func AddCollaboratorsToNamedEntities(
 		return err
 	}
 
-	return clients.APIInterface().FunctionDistributionAddUsers(ctx, functionFlag, app.AppID, userIDs)
+	return clients.API().FunctionDistributionAddUsers(ctx, functionFlag, app.AppID, userIDs)
 }

--- a/cmd/function/access_test.go
+++ b/cmd/function/access_test.go
@@ -42,10 +42,10 @@ func TestFunctionDistributionCommand(t *testing.T) {
 			},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				// set distribution
-				clientsMock.APIInterface.On("FunctionDistributionSet", mock.Anything, mock.Anything, mock.Anything, types.PermissionAppCollaborators, mock.Anything).
+				clientsMock.API.On("FunctionDistributionSet", mock.Anything, mock.Anything, mock.Anything, types.PermissionAppCollaborators, mock.Anything).
 					Return([]types.FunctionDistributionUser{}, nil).Once()
 
-				clientsMock.APIInterface.On("FunctionDistributionList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("FunctionDistributionList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.PermissionAppCollaborators, []types.FunctionDistributionUser{}, nil).Once()
 
 				clientsMock.AddDefaultMocks()
@@ -68,16 +68,16 @@ func TestFunctionDistributionCommand(t *testing.T) {
 			},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				// check if distribution type is named_entities
-				clientsMock.APIInterface.On("FunctionDistributionList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("FunctionDistributionList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.PermissionAppCollaborators, []types.FunctionDistributionUser{}, nil).Once()
 				// set distribution type to named_entities
-				clientsMock.APIInterface.On("FunctionDistributionSet", mock.Anything, mock.Anything, mock.Anything, types.PermissionNamedEntities, mock.Anything).
+				clientsMock.API.On("FunctionDistributionSet", mock.Anything, mock.Anything, mock.Anything, types.PermissionNamedEntities, mock.Anything).
 					Return([]types.FunctionDistributionUser{}, nil).Once()
 				// add users
-				clientsMock.APIInterface.On("FunctionDistributionAddUsers", mock.Anything, mock.Anything, mock.Anything, "U00,U01").
+				clientsMock.API.On("FunctionDistributionAddUsers", mock.Anything, mock.Anything, mock.Anything, "U00,U01").
 					Return(nil).Once()
 				// print access
-				clientsMock.APIInterface.On("FunctionDistributionList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("FunctionDistributionList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.PermissionNamedEntities, []types.FunctionDistributionUser{{UserName: "user 0", ID: "U00"}, {UserName: "user 1", ID: "U01"}}, nil).Once()
 
 				clientsMock.AddDefaultMocks()
@@ -99,13 +99,13 @@ func TestFunctionDistributionCommand(t *testing.T) {
 			},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				// check if distribution type is named_entities
-				clientsMock.APIInterface.On("FunctionDistributionList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("FunctionDistributionList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.PermissionNamedEntities, []types.FunctionDistributionUser{{UserName: "user 0", ID: "U00"}, {UserName: "user 1", ID: "U01"}}, nil).Once()
 				// remove users
-				clientsMock.APIInterface.On("FunctionDistributionRemoveUsers", mock.Anything, mock.Anything, mock.Anything, "U00").
+				clientsMock.API.On("FunctionDistributionRemoveUsers", mock.Anything, mock.Anything, mock.Anything, "U00").
 					Return(nil).Once()
 				// print access
-				clientsMock.APIInterface.On("FunctionDistributionList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("FunctionDistributionList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.PermissionNamedEntities, []types.FunctionDistributionUser{{UserName: "user 1", ID: "U01"}}, nil).Once()
 
 				clientsMock.AddDefaultMocks()
@@ -125,7 +125,7 @@ func TestFunctionDistributionCommand(t *testing.T) {
 				"everyone in the workspace",
 			},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.APIInterface.On("FunctionDistributionList", mock.Anything, "F1234", fakeApp.AppID).
+				clientsMock.API.On("FunctionDistributionList", mock.Anything, "F1234", fakeApp.AppID).
 					Return(types.PermissionEveryone, []types.FunctionDistributionUser{}, nil).Once()
 				clientsMock.AddDefaultMocks()
 
@@ -134,9 +134,9 @@ func TestFunctionDistributionCommand(t *testing.T) {
 				require.NoError(t, err, "Cant write apps.json")
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
-				cm.APIInterface.AssertNotCalled(t, "FunctionDistributionAddUsers")
-				cm.APIInterface.AssertNotCalled(t, "FunctionDistributionRemoveUsers")
-				cm.APIInterface.AssertNotCalled(t, "FunctionDistributionSet")
+				cm.API.AssertNotCalled(t, "FunctionDistributionAddUsers")
+				cm.API.AssertNotCalled(t, "FunctionDistributionRemoveUsers")
+				cm.API.AssertNotCalled(t, "FunctionDistributionSet")
 			},
 			Teardown: func() {
 				appSelectTeardown()
@@ -333,12 +333,12 @@ func TestFunctionDistributionCommand_PermissionsFile(t *testing.T) {
 			err := afero.WriteFile(clientsMock.Fs, tt.filename, []byte(tt.data), 0644)
 			require.NoError(t, err)
 			for function, permissions := range tt.functions {
-				clientsMock.APIInterface.On("FunctionDistributionList", mock.Anything, function, mock.Anything).
+				clientsMock.API.On("FunctionDistributionList", mock.Anything, function, mock.Anything).
 					Return(permissions.currentType, permissions.currentEntities, nil)
 			}
-			clientsMock.APIInterface.On("FunctionDistributionRemoveUsers", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			clientsMock.API.On("FunctionDistributionRemoveUsers", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 				Return(nil)
-			clientsMock.APIInterface.On("FunctionDistributionSet", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			clientsMock.API.On("FunctionDistributionSet", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 				Return([]types.FunctionDistributionUser{}, nil)
 
 			clients := shared.NewClientFactory(clientsMock.MockClientFactory())
@@ -359,7 +359,7 @@ func TestFunctionDistributionCommand_PermissionsFile(t *testing.T) {
 					entityIDs = append(entityIDs, entity.ID)
 				}
 				entities := strings.Join(entityIDs, ",")
-				clientsMock.APIInterface.AssertCalled(t, "FunctionDistributionSet", mock.Anything, function, app.AppID, permissions.expectedType, entities)
+				clientsMock.API.AssertCalled(t, "FunctionDistributionSet", mock.Anything, function, app.AppID, permissions.expectedType, entities)
 			}
 		})
 	}
@@ -403,13 +403,13 @@ func TestFunctionDistributeCommand_UpdateNamedEntitiesDistribution(t *testing.T)
 		t.Run(name, func(t *testing.T) {
 			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := shared.NewClientsMock()
-			clientsMock.APIInterface.On("FunctionDistributionSet", mock.Anything, mock.Anything, mock.Anything, types.PermissionNamedEntities, mock.Anything).
+			clientsMock.API.On("FunctionDistributionSet", mock.Anything, mock.Anything, mock.Anything, types.PermissionNamedEntities, mock.Anything).
 				Return([]types.FunctionDistributionUser{}, nil).
 				Run(func(args mock.Arguments) {
-					clientsMock.APIInterface.On("FunctionDistributionList", mock.Anything, mock.Anything, mock.Anything).
+					clientsMock.API.On("FunctionDistributionList", mock.Anything, mock.Anything, mock.Anything).
 						Return(types.PermissionNamedEntities, tt.currentEntities, nil).
 						Run(func(args mock.Arguments) {
-							clientsMock.APIInterface.On("FunctionDistributionRemoveUsers", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+							clientsMock.API.On("FunctionDistributionRemoveUsers", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 								Return(nil)
 						})
 				})
@@ -420,10 +420,10 @@ func TestFunctionDistributeCommand_UpdateNamedEntitiesDistribution(t *testing.T)
 
 			err := updateNamedEntitiesDistribution(ctx, clients, app, function, tt.updatedEntities)
 			assert.NoError(t, err)
-			clientsMock.APIInterface.AssertCalled(t, "FunctionDistributionList", mock.Anything, function, app.AppID)
+			clientsMock.API.AssertCalled(t, "FunctionDistributionList", mock.Anything, function, app.AppID)
 			entities := strings.Join(tt.updatedEntities, ",")
-			clientsMock.APIInterface.AssertCalled(t, "FunctionDistributionSet", mock.Anything, function, app.AppID, types.PermissionNamedEntities, entities)
-			clientsMock.APIInterface.AssertCalled(t, "FunctionDistributionRemoveUsers", mock.Anything, function, app.AppID, tt.removedEntities)
+			clientsMock.API.AssertCalled(t, "FunctionDistributionSet", mock.Anything, function, app.AppID, types.PermissionNamedEntities, entities)
+			clientsMock.API.AssertCalled(t, "FunctionDistributionRemoveUsers", mock.Anything, function, app.AppID, tt.removedEntities)
 		})
 	}
 }

--- a/cmd/function/prompt.go
+++ b/cmd/function/prompt.go
@@ -64,7 +64,7 @@ func chooseDistributionPrompt(
 ) (types.Permission, error) {
 
 	// Get the function's active distribution type
-	currentDist, _, err := clients.APIInterface().FunctionDistributionList(ctx, functionFlag, app.AppID)
+	currentDist, _, err := clients.API().FunctionDistributionList(ctx, functionFlag, app.AppID)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/openformresponse/export.go
+++ b/cmd/openformresponse/export.go
@@ -89,7 +89,7 @@ func runExportCommand(clients *shared.ClientFactory, cmd *cobra.Command) error {
 		}
 	}
 
-	err = clients.APIInterface().StepsResponsesExport(ctx, token, exportFlags.workflow, appID, stepID)
+	err = clients.API().StepsResponsesExport(ctx, token, exportFlags.workflow, appID, stepID)
 	if err != nil {
 		return err
 	}
@@ -105,7 +105,7 @@ func runExportCommand(clients *shared.ClientFactory, cmd *cobra.Command) error {
 }
 
 func pickStepFromPrompt(ctx context.Context, clients *shared.ClientFactory, token string, workflow string, appID string) (string, error) {
-	stepVersions, err := clients.APIInterface().StepsList(ctx, token, workflow, appID)
+	stepVersions, err := clients.API().StepsList(ctx, token, workflow, appID)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/openformresponse/export_test.go
+++ b/cmd/openformresponse/export_test.go
@@ -49,13 +49,13 @@ func TestExportCommand(t *testing.T) {
 			ExpectedOutputs: []string{"Slackbot will DM you with a CSV file once it's ready"},
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
 				appSelectTeardown = setupMockCreateAppSelection(installedProdApp)
-				cm.APIInterface.On("StepsResponsesExport", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				cm.API.On("StepsResponsesExport", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			},
 			Teardown: func() {
 				appSelectTeardown()
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
-				cm.APIInterface.AssertCalled(t, "StepsResponsesExport", mock.Anything, token, "#/workflows/my_workflow", appID, "stepID")
+				cm.API.AssertCalled(t, "StepsResponsesExport", mock.Anything, token, "#/workflows/my_workflow", appID, "stepID")
 			},
 		},
 		"with --step-id, API fails": {
@@ -63,13 +63,13 @@ func TestExportCommand(t *testing.T) {
 			ExpectedErrorStrings: []string{"failed"},
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
 				appSelectTeardown = setupMockCreateAppSelection(installedProdApp)
-				cm.APIInterface.On("StepsResponsesExport", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(errors.New("failed"))
+				cm.API.On("StepsResponsesExport", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(errors.New("failed"))
 			},
 			Teardown: func() {
 				appSelectTeardown()
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
-				cm.APIInterface.AssertCalled(t, "StepsResponsesExport", mock.Anything, token, "#/workflows/my_workflow", appID, "stepID")
+				cm.API.AssertCalled(t, "StepsResponsesExport", mock.Anything, token, "#/workflows/my_workflow", appID, "stepID")
 			},
 		},
 	}, func(clients *shared.ClientFactory) *cobra.Command {

--- a/cmd/platform/deploy.go
+++ b/cmd/platform/deploy.go
@@ -256,7 +256,7 @@ func printDeployHostingCompletion(clients *shared.ClientFactory, cmd *cobra.Comm
 
 	parsedAppInfo := map[string]string{}
 
-	host := clients.APIInterface().Host()
+	host := clients.API().Host()
 	if appID := event.DataToString("appID"); appID != "" && host != "" {
 		parsedAppInfo["Dashboard"] = fmt.Sprintf("%s/apps/%s", host, appID)
 	}

--- a/cmd/platform/deploy_test.go
+++ b/cmd/platform/deploy_test.go
@@ -322,7 +322,7 @@ func TestDeployCommand_PrintHostingCompletion(t *testing.T) {
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {
 			clientsMock := shared.NewClientsMock()
-			clientsMock.APIInterface.On("Host").Return("https://slacker.com")
+			clientsMock.API.On("Host").Return("https://slacker.com")
 			clientsMock.AddDefaultMocks()
 			clients := shared.NewClientFactory(clientsMock.MockClientFactory())
 			cmd := NewDeployCommand(clients)

--- a/cmd/project/init_test.go
+++ b/cmd/project/init_test.go
@@ -150,7 +150,7 @@ func Test_Project_InitCommand(t *testing.T) {
 					Option: "local",
 				}, nil)
 				// Mock status of app for footer
-				cm.APIInterface.On("GetAppStatus",
+				cm.API.On("GetAppStatus",
 					mock.Anything,
 					mockLinkSlackAuth2.Token,
 					[]string{mockLinkAppID1},

--- a/cmd/triggers/access.go
+++ b/cmd/triggers/access.go
@@ -748,7 +748,6 @@ func namedEntitiesAccessMap(entitiesAccessList []string) map[string][]string {
 func AddAppCollaboratorsToNamedEntities(ctx context.Context, clients *shared.ClientFactory, token string, appID string) error {
 	ctx = config.SetContextToken(ctx, token)
 
-	// TODO: this shite needs to use APIInterface but there is no dedicated interface to the collaborator APIs so I guess that's needed now.
 	collaborators, err := clients.API().ListCollaborators(ctx, token, appID)
 	if err != nil {
 		return err

--- a/cmd/triggers/access.go
+++ b/cmd/triggers/access.go
@@ -132,7 +132,7 @@ func runAccessCommand(cmd *cobra.Command, clients *shared.ClientFactory) error {
 	}
 
 	// Get the current access for the trigger
-	currentAccessType, currentAuthorizedEntities, err := clients.APIInterface().TriggerPermissionsList(ctx, token, accessFlags.triggerID)
+	currentAccessType, currentAuthorizedEntities, err := clients.API().TriggerPermissionsList(ctx, token, accessFlags.triggerID)
 	if err != nil {
 		return err
 	}
@@ -164,7 +164,7 @@ func runAccessCommand(cmd *cobra.Command, clients *shared.ClientFactory) error {
 
 	// Set access type
 	if accessType == types.PermissionEveryone || accessType == types.PermissionAppCollaborators {
-		_, err = clients.APIInterface().TriggerPermissionsSet(ctx, token, accessFlags.triggerID, "", accessType, "")
+		_, err = clients.API().TriggerPermissionsSet(ctx, token, accessFlags.triggerID, "", accessType, "")
 		if err != nil {
 			return err
 		}
@@ -350,18 +350,18 @@ func manageNamedEntities(cmd *cobra.Command, clients *shared.ClientFactory, toke
 	case "add_user":
 		if currentAccessType != types.PermissionNamedEntities {
 			if includeAppCollaborators {
-				err := clients.APIInterface().TriggerPermissionsAddEntities(ctx, token, accessFlags.triggerID, accessFlags.users, "users")
+				err := clients.API().TriggerPermissionsAddEntities(ctx, token, accessFlags.triggerID, accessFlags.users, "users")
 				if err != nil {
 					return err
 				}
 			} else {
-				_, err := clients.APIInterface().TriggerPermissionsSet(ctx, token, accessFlags.triggerID, accessFlags.users, types.PermissionNamedEntities, "users")
+				_, err := clients.API().TriggerPermissionsSet(ctx, token, accessFlags.triggerID, accessFlags.users, types.PermissionNamedEntities, "users")
 				if err != nil {
 					return err
 				}
 			}
 		} else {
-			err := clients.APIInterface().TriggerPermissionsAddEntities(ctx, token, accessFlags.triggerID, accessFlags.users, "users")
+			err := clients.API().TriggerPermissionsAddEntities(ctx, token, accessFlags.triggerID, accessFlags.users, "users")
 			if err != nil {
 				return err
 			}
@@ -378,7 +378,7 @@ func manageNamedEntities(cmd *cobra.Command, clients *shared.ClientFactory, toke
 			return slackerror.New("Grant a user access first")
 		}
 
-		err := clients.APIInterface().TriggerPermissionsRemoveEntities(ctx, token, accessFlags.triggerID, accessFlags.users, "users")
+		err := clients.API().TriggerPermissionsRemoveEntities(ctx, token, accessFlags.triggerID, accessFlags.users, "users")
 		if err != nil {
 			return err
 		}
@@ -389,18 +389,18 @@ func manageNamedEntities(cmd *cobra.Command, clients *shared.ClientFactory, toke
 	case "add_channel":
 		if currentAccessType != types.PermissionNamedEntities {
 			if includeAppCollaborators {
-				err := clients.APIInterface().TriggerPermissionsAddEntities(ctx, token, accessFlags.triggerID, accessFlags.channels, "channels")
+				err := clients.API().TriggerPermissionsAddEntities(ctx, token, accessFlags.triggerID, accessFlags.channels, "channels")
 				if err != nil {
 					return err
 				}
 			} else {
-				_, err := clients.APIInterface().TriggerPermissionsSet(ctx, token, accessFlags.triggerID, accessFlags.channels, types.PermissionNamedEntities, "channels")
+				_, err := clients.API().TriggerPermissionsSet(ctx, token, accessFlags.triggerID, accessFlags.channels, types.PermissionNamedEntities, "channels")
 				if err != nil {
 					return err
 				}
 			}
 		} else {
-			err := clients.APIInterface().TriggerPermissionsAddEntities(ctx, token, accessFlags.triggerID, accessFlags.channels, "channels")
+			err := clients.API().TriggerPermissionsAddEntities(ctx, token, accessFlags.triggerID, accessFlags.channels, "channels")
 			if err != nil {
 				return err
 			}
@@ -417,7 +417,7 @@ func manageNamedEntities(cmd *cobra.Command, clients *shared.ClientFactory, toke
 			return slackerror.New("Grant a channel access first")
 		}
 
-		err := clients.APIInterface().TriggerPermissionsRemoveEntities(ctx, token, accessFlags.triggerID, accessFlags.channels, "channels")
+		err := clients.API().TriggerPermissionsRemoveEntities(ctx, token, accessFlags.triggerID, accessFlags.channels, "channels")
 		if err != nil {
 			return err
 		}
@@ -428,18 +428,18 @@ func manageNamedEntities(cmd *cobra.Command, clients *shared.ClientFactory, toke
 	case "add_workspace":
 		if currentAccessType != types.PermissionNamedEntities {
 			if includeAppCollaborators {
-				err := clients.APIInterface().TriggerPermissionsAddEntities(ctx, token, accessFlags.triggerID, accessFlags.workspaces, "workspaces")
+				err := clients.API().TriggerPermissionsAddEntities(ctx, token, accessFlags.triggerID, accessFlags.workspaces, "workspaces")
 				if err != nil {
 					return err
 				}
 			} else {
-				_, err := clients.APIInterface().TriggerPermissionsSet(ctx, token, accessFlags.triggerID, accessFlags.workspaces, types.PermissionNamedEntities, "workspaces")
+				_, err := clients.API().TriggerPermissionsSet(ctx, token, accessFlags.triggerID, accessFlags.workspaces, types.PermissionNamedEntities, "workspaces")
 				if err != nil {
 					return err
 				}
 			}
 		} else {
-			err := clients.APIInterface().TriggerPermissionsAddEntities(ctx, token, accessFlags.triggerID, accessFlags.workspaces, "workspaces")
+			err := clients.API().TriggerPermissionsAddEntities(ctx, token, accessFlags.triggerID, accessFlags.workspaces, "workspaces")
 			if err != nil {
 				return err
 			}
@@ -456,7 +456,7 @@ func manageNamedEntities(cmd *cobra.Command, clients *shared.ClientFactory, toke
 			return slackerror.New("Grant a workspace access first")
 		}
 
-		err := clients.APIInterface().TriggerPermissionsRemoveEntities(ctx, token, accessFlags.triggerID, accessFlags.workspaces, "workspaces")
+		err := clients.API().TriggerPermissionsRemoveEntities(ctx, token, accessFlags.triggerID, accessFlags.workspaces, "workspaces")
 		if err != nil {
 			return err
 		}
@@ -467,18 +467,18 @@ func manageNamedEntities(cmd *cobra.Command, clients *shared.ClientFactory, toke
 	case "add_organization":
 		if currentAccessType != types.PermissionNamedEntities {
 			if includeAppCollaborators {
-				err := clients.APIInterface().TriggerPermissionsAddEntities(ctx, token, accessFlags.triggerID, accessFlags.organizations, "organizations")
+				err := clients.API().TriggerPermissionsAddEntities(ctx, token, accessFlags.triggerID, accessFlags.organizations, "organizations")
 				if err != nil {
 					return err
 				}
 			} else {
-				_, err := clients.APIInterface().TriggerPermissionsSet(ctx, token, accessFlags.triggerID, accessFlags.organizations, types.PermissionNamedEntities, "organizations")
+				_, err := clients.API().TriggerPermissionsSet(ctx, token, accessFlags.triggerID, accessFlags.organizations, types.PermissionNamedEntities, "organizations")
 				if err != nil {
 					return err
 				}
 			}
 		} else {
-			err := clients.APIInterface().TriggerPermissionsAddEntities(ctx, token, accessFlags.triggerID, accessFlags.organizations, "organizations")
+			err := clients.API().TriggerPermissionsAddEntities(ctx, token, accessFlags.triggerID, accessFlags.organizations, "organizations")
 			if err != nil {
 				return err
 			}
@@ -495,7 +495,7 @@ func manageNamedEntities(cmd *cobra.Command, clients *shared.ClientFactory, toke
 			return slackerror.New("Grant an organization access first")
 		}
 
-		err := clients.APIInterface().TriggerPermissionsRemoveEntities(ctx, token, accessFlags.triggerID, accessFlags.organizations, "organizations")
+		err := clients.API().TriggerPermissionsRemoveEntities(ctx, token, accessFlags.triggerID, accessFlags.organizations, "organizations")
 		if err != nil {
 			return err
 		}
@@ -508,12 +508,12 @@ func manageNamedEntities(cmd *cobra.Command, clients *shared.ClientFactory, toke
 			index := 0
 			for namedEntityType, namedEntityVal := range namedEntitiesValMap() {
 				if index == 0 && !includeAppCollaborators {
-					_, triggerSetErr := clients.APIInterface().TriggerPermissionsSet(ctx, token, accessFlags.triggerID, namedEntityVal, types.PermissionNamedEntities, namedEntityType)
+					_, triggerSetErr := clients.API().TriggerPermissionsSet(ctx, token, accessFlags.triggerID, namedEntityVal, types.PermissionNamedEntities, namedEntityType)
 					if triggerSetErr != nil {
 						return triggerSetErr
 					}
 				} else {
-					err := clients.APIInterface().TriggerPermissionsAddEntities(ctx, token, accessFlags.triggerID, namedEntityVal, namedEntityType)
+					err := clients.API().TriggerPermissionsAddEntities(ctx, token, accessFlags.triggerID, namedEntityVal, namedEntityType)
 					if err != nil {
 						return err
 					}
@@ -524,7 +524,7 @@ func manageNamedEntities(cmd *cobra.Command, clients *shared.ClientFactory, toke
 			}
 		} else {
 			for namedEntityType, namedEntityVal := range namedEntitiesValMap() {
-				err := clients.APIInterface().TriggerPermissionsAddEntities(ctx, token, accessFlags.triggerID, namedEntityVal, namedEntityType)
+				err := clients.API().TriggerPermissionsAddEntities(ctx, token, accessFlags.triggerID, namedEntityVal, namedEntityType)
 				if err != nil {
 					return err
 				}
@@ -542,7 +542,7 @@ func manageNamedEntities(cmd *cobra.Command, clients *shared.ClientFactory, toke
 		}
 
 		for namedEntityType, namedEntityVal := range namedEntitiesValMap() {
-			err := clients.APIInterface().TriggerPermissionsRemoveEntities(ctx, token, accessFlags.triggerID, namedEntityVal, namedEntityType)
+			err := clients.API().TriggerPermissionsRemoveEntities(ctx, token, accessFlags.triggerID, namedEntityVal, namedEntityType)
 			if err != nil {
 				return err
 			}
@@ -557,7 +557,7 @@ func manageNamedEntities(cmd *cobra.Command, clients *shared.ClientFactory, toke
 func printAccess(cmd *cobra.Command, clients *shared.ClientFactory, token string, app types.App) error {
 	ctx := cmd.Context()
 
-	accessType, userAccessList, err := clients.APIInterface().TriggerPermissionsList(ctx, token, accessFlags.triggerID)
+	accessType, userAccessList, err := clients.API().TriggerPermissionsList(ctx, token, accessFlags.triggerID)
 	if err != nil {
 		clients.IO.PrintTrace(ctx, slacktrace.TriggersAccessError)
 		return err
@@ -608,7 +608,7 @@ func printAppCollaboratorsHelper(cmd *cobra.Command, clients *shared.ClientFacto
 	}
 
 	for _, entity := range userAccessList {
-		userInfo, err := clients.APIInterface().UsersInfo(ctx, token, entity)
+		userInfo, err := clients.API().UsersInfo(ctx, token, entity)
 		if err != nil {
 			return err
 		}
@@ -641,7 +641,7 @@ func printNamedEntitiesHelper(cmd *cobra.Command, clients *shared.ClientFactory,
 			clients.IO.PrintInfo(ctx, false, "\nTrigger '%s' can be found and run by %s:", accessFlags.triggerID, userLabel)
 		}
 		for _, entity := range namedEntitiesAccessMap["users"] {
-			userInfo, err := clients.APIInterface().UsersInfo(ctx, token, entity)
+			userInfo, err := clients.API().UsersInfo(ctx, token, entity)
 			if err != nil {
 				return err
 			}
@@ -656,7 +656,7 @@ func printNamedEntitiesHelper(cmd *cobra.Command, clients *shared.ClientFactory,
 			clients.IO.PrintInfo(ctx, false, "\nTrigger '%s' can be found and run by all members of %s:", accessFlags.triggerID, channelLabel)
 		}
 		for _, entity := range namedEntitiesAccessMap["channels"] {
-			channelInfo, err := clients.APIInterface().ChannelsInfo(ctx, token, entity)
+			channelInfo, err := clients.API().ChannelsInfo(ctx, token, entity)
 			if err != nil {
 				return err
 			}
@@ -671,7 +671,7 @@ func printNamedEntitiesHelper(cmd *cobra.Command, clients *shared.ClientFactory,
 			clients.IO.PrintInfo(ctx, false, "\nTrigger '%s' can be found and run by all members of %s:", accessFlags.triggerID, teamLabel)
 		}
 		for _, entity := range namedEntitiesAccessMap["teams"] {
-			teamInfo, err := clients.APIInterface().TeamsInfo(ctx, token, entity)
+			teamInfo, err := clients.API().TeamsInfo(ctx, token, entity)
 			if err != nil {
 				return err
 			}
@@ -686,7 +686,7 @@ func printNamedEntitiesHelper(cmd *cobra.Command, clients *shared.ClientFactory,
 			clients.IO.PrintInfo(ctx, false, "\nTrigger '%s' can be found and run by all members of %s:", accessFlags.triggerID, orgLabel)
 		}
 		for _, entity := range namedEntitiesAccessMap["organizations"] {
-			orgInfo, err := clients.APIInterface().TeamsInfo(ctx, token, entity)
+			orgInfo, err := clients.API().TeamsInfo(ctx, token, entity)
 			if err != nil {
 				return err
 			}
@@ -749,7 +749,7 @@ func AddAppCollaboratorsToNamedEntities(ctx context.Context, clients *shared.Cli
 	ctx = config.SetContextToken(ctx, token)
 
 	// TODO: this shite needs to use APIInterface but there is no dedicated interface to the collaborator APIs so I guess that's needed now.
-	collaborators, err := clients.APIInterface().ListCollaborators(ctx, token, appID)
+	collaborators, err := clients.API().ListCollaborators(ctx, token, appID)
 	if err != nil {
 		return err
 	}
@@ -763,7 +763,7 @@ func AddAppCollaboratorsToNamedEntities(ctx context.Context, clients *shared.Cli
 		userIDs = userIDs + "," + collaborators[i].ID
 	}
 
-	_, err = clients.APIInterface().TriggerPermissionsSet(ctx, token, accessFlags.triggerID, userIDs, types.PermissionNamedEntities, "users")
+	_, err = clients.API().TriggerPermissionsSet(ctx, token, accessFlags.triggerID, userIDs, types.PermissionNamedEntities, "users")
 	if err != nil {
 		return err
 	}

--- a/cmd/triggers/access_test.go
+++ b/cmd/triggers/access_test.go
@@ -42,16 +42,16 @@ func TestTriggersAccessCommand(t *testing.T) {
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				appSelectTeardown = setupMockAccessAppSelection(installedProdApp)
 				// get current access type
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.PermissionEveryone, []string{}, nil).Once()
 				// set access type to collaborators
-				clientsMock.APIInterface.On("TriggerPermissionsSet", mock.Anything, mock.Anything, mock.Anything, mock.Anything, types.PermissionAppCollaborators, "").
+				clientsMock.API.On("TriggerPermissionsSet", mock.Anything, mock.Anything, mock.Anything, mock.Anything, types.PermissionAppCollaborators, "").
 					Return([]string{"collaborator_ID"}, nil)
 				// get access type from backend to display
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.PermissionAppCollaborators, []string{"collaborator_ID"}, nil).Once()
 				// display user info for updated access
-				clientsMock.APIInterface.On("UsersInfo", mock.Anything, mock.Anything, "collaborator_ID").
+				clientsMock.API.On("UsersInfo", mock.Anything, mock.Anything, "collaborator_ID").
 					Return(&types.UserInfo{}, nil).Once()
 
 				clientsMock.AddDefaultMocks()
@@ -72,16 +72,16 @@ func TestTriggersAccessCommand(t *testing.T) {
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				appSelectTeardown = setupMockAccessAppSelection(installedProdApp)
 				// get current access type
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.PermissionAppCollaborators, []string{"collaborator_ID"}, nil).Once()
 				// display user info for current access
-				clientsMock.APIInterface.On("UsersInfo", mock.Anything, mock.Anything, "collaborator_ID").
+				clientsMock.API.On("UsersInfo", mock.Anything, mock.Anything, "collaborator_ID").
 					Return(&types.UserInfo{}, nil).Once()
 				// set access type to everyone
-				clientsMock.APIInterface.On("TriggerPermissionsSet", mock.Anything, mock.Anything, fakeTriggerID, mock.Anything, types.PermissionEveryone, "").
+				clientsMock.API.On("TriggerPermissionsSet", mock.Anything, mock.Anything, fakeTriggerID, mock.Anything, types.PermissionEveryone, "").
 					Return([]string{}, nil)
 				// get access type from backend to display
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.PermissionEveryone, []string{}, nil).Once()
 
 				clientsMock.AddDefaultMocks()
@@ -102,16 +102,16 @@ func TestTriggersAccessCommand(t *testing.T) {
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				appSelectTeardown = setupMockAccessAppSelection(installedProdOrgApp)
 				// get current access type
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.PermissionAppCollaborators, []string{"collaborator_ID"}, nil).Once()
 				// display user info for current access
-				clientsMock.APIInterface.On("UsersInfo", mock.Anything, mock.Anything, "collaborator_ID").
+				clientsMock.API.On("UsersInfo", mock.Anything, mock.Anything, "collaborator_ID").
 					Return(&types.UserInfo{}, nil).Once()
 				// set access type to everyone
-				clientsMock.APIInterface.On("TriggerPermissionsSet", mock.Anything, mock.Anything, fakeTriggerID, mock.Anything, types.PermissionEveryone, "").
+				clientsMock.API.On("TriggerPermissionsSet", mock.Anything, mock.Anything, fakeTriggerID, mock.Anything, types.PermissionEveryone, "").
 					Return([]string{}, nil)
 				// get access type from backend to display
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.PermissionEveryone, []string{}, nil).Once()
 
 				clientsMock.AddDefaultMocks()
@@ -129,21 +129,21 @@ func TestTriggersAccessCommand(t *testing.T) {
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				appSelectTeardown = setupMockAccessAppSelection(installedProdApp)
 				// get current access type
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.PermissionAppCollaborators, []string{"collaborator_ID"}, nil).Once()
 				// display user info for current access
-				clientsMock.APIInterface.On("UserInfo", mock.Anything, mock.Anything, "collaborator_ID").
+				clientsMock.API.On("UserInfo", mock.Anything, mock.Anything, "collaborator_ID").
 					Return(&types.UserInfo{}, nil).Once()
 				// set access type to named_entities
-				clientsMock.APIInterface.On("TriggerPermissionsSet", mock.Anything, mock.Anything, fakeTriggerID, "USER1,USER2", types.PermissionNamedEntities, "users").
+				clientsMock.API.On("TriggerPermissionsSet", mock.Anything, mock.Anything, fakeTriggerID, "USER1,USER2", types.PermissionNamedEntities, "users").
 					Return([]string{}, nil)
 				// get access type from backend to display
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.PermissionNamedEntities, []string{"USER1", "USER2"}, nil).Once()
 				// display user info for updated access
-				clientsMock.APIInterface.On("UsersInfo", mock.Anything, mock.Anything, "USER1").
+				clientsMock.API.On("UsersInfo", mock.Anything, mock.Anything, "USER1").
 					Return(&types.UserInfo{RealName: "User One", Name: "USER1", Profile: user1Profile}, nil).Once()
-				clientsMock.APIInterface.On("UsersInfo", mock.Anything, mock.Anything, "USER2").
+				clientsMock.API.On("UsersInfo", mock.Anything, mock.Anything, "USER2").
 					Return(&types.UserInfo{RealName: "User Two", Name: "USER2", Profile: user2Profile}, nil).Once()
 
 				clientsMock.AddDefaultMocks()
@@ -161,21 +161,21 @@ func TestTriggersAccessCommand(t *testing.T) {
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				appSelectTeardown = setupMockAccessAppSelection(installedProdApp)
 				// get current access type
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.PermissionAppCollaborators, []string{"collaborator_ID"}, nil).Once()
 				// display user info for current access
-				clientsMock.APIInterface.On("UserInfo", mock.Anything, mock.Anything, "collaborator_ID").
+				clientsMock.API.On("UserInfo", mock.Anything, mock.Anything, "collaborator_ID").
 					Return(&types.UserInfo{}, nil).Once()
 				// set access type to named_entities
-				clientsMock.APIInterface.On("TriggerPermissionsSet", mock.Anything, mock.Anything, fakeTriggerID, "CHANNEL1,CHANNEL2", types.PermissionNamedEntities, "channels").
+				clientsMock.API.On("TriggerPermissionsSet", mock.Anything, mock.Anything, fakeTriggerID, "CHANNEL1,CHANNEL2", types.PermissionNamedEntities, "channels").
 					Return([]string{}, nil)
 				// get access type from backend to display
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.PermissionNamedEntities, []string{"CHANNEL1", "CHANNEL2"}, nil).Once()
 				// display channel info for updated access
-				clientsMock.APIInterface.On("ChannelsInfo", mock.Anything, mock.Anything, "CHANNEL1").
+				clientsMock.API.On("ChannelsInfo", mock.Anything, mock.Anything, "CHANNEL1").
 					Return(&types.ChannelInfo{ID: "CHANNEL1", Name: "Channel One"}, nil).Once()
-				clientsMock.APIInterface.On("ChannelsInfo", mock.Anything, mock.Anything, "CHANNEL2").
+				clientsMock.API.On("ChannelsInfo", mock.Anything, mock.Anything, "CHANNEL2").
 					Return(&types.ChannelInfo{ID: "CHANNEL2", Name: "Channel Two"}, nil).Once()
 
 				clientsMock.AddDefaultMocks()
@@ -192,28 +192,28 @@ func TestTriggersAccessCommand(t *testing.T) {
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				appSelectTeardown = setupMockAccessAppSelection(installedProdApp)
 				// get current access type
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.PermissionAppCollaborators, []string{"collaborator_ID"}, nil).Once()
 				// display user info for current access
-				clientsMock.APIInterface.On("UserInfo", mock.Anything, mock.Anything, "collaborator_ID").
+				clientsMock.API.On("UserInfo", mock.Anything, mock.Anything, "collaborator_ID").
 					Return(&types.UserInfo{}, nil).Once()
 				// confirm to add app collaborators
 				clientsMock.IO.On("ConfirmPrompt", mock.Anything, "Include app collaborators?", mock.Anything).Return(true, nil)
 				// set access type to named_entities
-				clientsMock.APIInterface.On("TriggerPermissionsSet", mock.Anything, mock.Anything, fakeTriggerID, "collaborator_ID", types.PermissionNamedEntities, "users").
+				clientsMock.API.On("TriggerPermissionsSet", mock.Anything, mock.Anything, fakeTriggerID, "collaborator_ID", types.PermissionNamedEntities, "users").
 					Return([]string{}, nil)
-				clientsMock.APIInterface.On("TriggerPermissionsAddEntities", mock.Anything, mock.Anything, fakeTriggerID, "TEAM1", "workspaces").
+				clientsMock.API.On("TriggerPermissionsAddEntities", mock.Anything, mock.Anything, fakeTriggerID, "TEAM1", "workspaces").
 					Return(nil)
 				// get access type from backend to display
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.PermissionNamedEntities, []string{"collaborator_ID", "TEAM1"}, nil).Once()
-				clientsMock.APIInterface.On("UserInfo", mock.Anything, mock.Anything, "collaborator_ID").
+				clientsMock.API.On("UserInfo", mock.Anything, mock.Anything, "collaborator_ID").
 					Return(&types.UserInfo{}, nil).Once()
 				// display workspace info for updated access
-				clientsMock.APIInterface.On("TeamsInfo", mock.Anything, mock.Anything, "TEAM1").
+				clientsMock.API.On("TeamsInfo", mock.Anything, mock.Anything, "TEAM1").
 					Return(&types.TeamInfo{ID: "TEAM1", Name: "Team One"}, nil).Once()
 				// no-op add-collaborators
-				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+				clientsMock.API.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
 
 				clientsMock.AddDefaultMocks()
 				err := clients.AppClient().SaveDeployed(ctx, fakeApp)
@@ -229,26 +229,26 @@ func TestTriggersAccessCommand(t *testing.T) {
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				appSelectTeardown = setupMockAccessAppSelection(installedProdApp)
 				// get current access type
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.PermissionAppCollaborators, []string{"collaborator_ID"}, nil).Once()
 				// display user info for current access
-				clientsMock.APIInterface.On("UserInfo", mock.Anything, mock.Anything, "collaborator_ID").
+				clientsMock.API.On("UserInfo", mock.Anything, mock.Anything, "collaborator_ID").
 					Return(&types.UserInfo{}, nil).Once()
 				// set access type to named_entities
-				clientsMock.APIInterface.On("TriggerPermissionsSet", mock.Anything, mock.Anything, fakeTriggerID, "collaborator_ID", types.PermissionNamedEntities, "users").
+				clientsMock.API.On("TriggerPermissionsSet", mock.Anything, mock.Anything, fakeTriggerID, "collaborator_ID", types.PermissionNamedEntities, "users").
 					Return([]string{}, nil)
-				clientsMock.APIInterface.On("TriggerPermissionsAddEntities", mock.Anything, mock.Anything, fakeTriggerID, "TEAM1", "workspaces").
+				clientsMock.API.On("TriggerPermissionsAddEntities", mock.Anything, mock.Anything, fakeTriggerID, "TEAM1", "workspaces").
 					Return(nil)
 				// get access type from backend to display
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.PermissionNamedEntities, []string{"collaborator_ID", "TEAM1"}, nil).Once()
-				clientsMock.APIInterface.On("UserInfo", mock.Anything, mock.Anything, "collaborator_ID").
+				clientsMock.API.On("UserInfo", mock.Anything, mock.Anything, "collaborator_ID").
 					Return(&types.UserInfo{}, nil).Once()
 				// display workspace info for updated access
-				clientsMock.APIInterface.On("TeamsInfo", mock.Anything, mock.Anything, "TEAM1").
+				clientsMock.API.On("TeamsInfo", mock.Anything, mock.Anything, "TEAM1").
 					Return(&types.TeamInfo{ID: "TEAM1", Name: "Team One"}, nil).Once()
 				// no-op add-collaborators
-				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+				clientsMock.API.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
 
 				clientsMock.AddDefaultMocks()
 				err := clients.AppClient().SaveDeployed(ctx, fakeApp)
@@ -265,41 +265,41 @@ func TestTriggersAccessCommand(t *testing.T) {
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				appSelectTeardown = setupMockAccessAppSelection(installedProdApp)
 				// get current access type
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.PermissionAppCollaborators, []string{"collaborator_ID"}, nil).Once()
 				// display user info for current access
-				clientsMock.APIInterface.On("UserInfo", mock.Anything, mock.Anything, "collaborator_ID").
+				clientsMock.API.On("UserInfo", mock.Anything, mock.Anything, "collaborator_ID").
 					Return(&types.UserInfo{}, nil).Once()
 				// confirm to add app collaborators
 				clientsMock.IO.On("ConfirmPrompt", mock.Anything, "Include app collaborators?", mock.Anything).Return(true)
 				// set access type to named_entities
-				clientsMock.APIInterface.On("TriggerPermissionsSet", mock.Anything, mock.Anything, fakeTriggerID, "collaborator_ID", types.PermissionNamedEntities, "users").Maybe().
+				clientsMock.API.On("TriggerPermissionsSet", mock.Anything, mock.Anything, fakeTriggerID, "collaborator_ID", types.PermissionNamedEntities, "users").Maybe().
 					Return([]string{}, nil)
-				clientsMock.APIInterface.On("TriggerPermissionsAddEntities", mock.Anything, mock.Anything, fakeTriggerID, "USER1,USER2", types.PermissionNamedEntities, "users").Maybe().
+				clientsMock.API.On("TriggerPermissionsAddEntities", mock.Anything, mock.Anything, fakeTriggerID, "USER1,USER2", types.PermissionNamedEntities, "users").Maybe().
 					Return([]string{}, nil)
-				clientsMock.APIInterface.On("TriggerPermissionsSet", mock.Anything, mock.Anything, fakeTriggerID, "CHANNEL1,CHANNEL2", types.PermissionNamedEntities, "channels").Maybe().
+				clientsMock.API.On("TriggerPermissionsSet", mock.Anything, mock.Anything, fakeTriggerID, "CHANNEL1,CHANNEL2", types.PermissionNamedEntities, "channels").Maybe().
 					Return([]string{}, nil)
-				clientsMock.APIInterface.On("TriggerPermissionsAddEntities", mock.Anything, mock.Anything, fakeTriggerID, "CHANNEL1,CHANNEL2", "channels").Maybe().
+				clientsMock.API.On("TriggerPermissionsAddEntities", mock.Anything, mock.Anything, fakeTriggerID, "CHANNEL1,CHANNEL2", "channels").Maybe().
 					Return(nil)
-				clientsMock.APIInterface.On("TriggerPermissionsAddEntities", mock.Anything, mock.Anything, fakeTriggerID, "USER1,USER2", "users").Maybe().
+				clientsMock.API.On("TriggerPermissionsAddEntities", mock.Anything, mock.Anything, fakeTriggerID, "USER1,USER2", "users").Maybe().
 					Return(nil)
 				// get access type from backend to display
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.PermissionNamedEntities, []string{"USER1", "USER2", "CHANNEL1", "CHANNEL2"}, nil).Once()
 				// display user info for updated access
-				clientsMock.APIInterface.On("UsersInfo", mock.Anything, mock.Anything, "USER1").
+				clientsMock.API.On("UsersInfo", mock.Anything, mock.Anything, "USER1").
 					Return(&types.UserInfo{RealName: "User One", Name: "USER1", Profile: user1Profile}, nil).Once()
-				clientsMock.APIInterface.On("UsersInfo", mock.Anything, mock.Anything, "USER2").
+				clientsMock.API.On("UsersInfo", mock.Anything, mock.Anything, "USER2").
 					Return(&types.UserInfo{RealName: "User Two", Name: "USER2", Profile: user2Profile}, nil).Once()
 
 				// display channel info for updated access
-				clientsMock.APIInterface.On("ChannelsInfo", mock.Anything, mock.Anything, "CHANNEL1").
+				clientsMock.API.On("ChannelsInfo", mock.Anything, mock.Anything, "CHANNEL1").
 					Return(&types.ChannelInfo{ID: "CHANNEL1", Name: "Channel One"}, nil).Once()
-				clientsMock.APIInterface.On("ChannelsInfo", mock.Anything, mock.Anything, "CHANNEL2").
+				clientsMock.API.On("ChannelsInfo", mock.Anything, mock.Anything, "CHANNEL2").
 					Return(&types.ChannelInfo{ID: "CHANNEL2", Name: "Channel Two"}, nil).Once()
 
 				// no-op add-collaborators
-				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+				clientsMock.API.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
 
 				clientsMock.AddDefaultMocks()
 				err := clients.AppClient().SaveDeployed(ctx, fakeApp)
@@ -315,21 +315,21 @@ func TestTriggersAccessCommand(t *testing.T) {
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				appSelectTeardown = setupMockAccessAppSelection(installedProdApp)
 				// get current access type
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.PermissionNamedEntities, []string{"USER1"}, nil).Once()
 				// display user info for current access
-				clientsMock.APIInterface.On("UserInfo", mock.Anything, mock.Anything, "USER1").
+				clientsMock.API.On("UserInfo", mock.Anything, mock.Anything, "USER1").
 					Return(&types.UserInfo{}, nil).Once()
 				// add users to named_entities ACL
-				clientsMock.APIInterface.On("TriggerPermissionsAddEntities", mock.Anything, mock.Anything, fakeTriggerID, "USER2", "users").
+				clientsMock.API.On("TriggerPermissionsAddEntities", mock.Anything, mock.Anything, fakeTriggerID, "USER2", "users").
 					Return(nil)
 				// get access type from backend to display
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.PermissionNamedEntities, []string{"USER1", "USER2"}, nil).Once()
 				// display user info for updated access
-				clientsMock.APIInterface.On("UsersInfo", mock.Anything, mock.Anything, "USER1").
+				clientsMock.API.On("UsersInfo", mock.Anything, mock.Anything, "USER1").
 					Return(&types.UserInfo{RealName: "User One", Name: "USER1", Profile: user1Profile}, nil).Once()
-				clientsMock.APIInterface.On("UsersInfo", mock.Anything, mock.Anything, "USER2").
+				clientsMock.API.On("UsersInfo", mock.Anything, mock.Anything, "USER2").
 					Return(&types.UserInfo{RealName: "User Two", Name: "USER2", Profile: user2Profile}, nil).Once()
 
 				clientsMock.AddDefaultMocks()
@@ -347,21 +347,21 @@ func TestTriggersAccessCommand(t *testing.T) {
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				appSelectTeardown = setupMockAccessAppSelection(installedProdApp)
 				// get current access type
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.PermissionNamedEntities, []string{"CHANNEL1"}, nil).Once()
 				// display user info for current access
-				// clientsMock.APIInterface.On("UserInfo", mock.Anything, mock.Anything, "USER1").
+				// clientsMock.API.On("UserInfo", mock.Anything, mock.Anything, "USER1").
 				// 	Return(&types.UserInfo{}, nil).Once()
 				// add users to named_entities ACL
-				clientsMock.APIInterface.On("TriggerPermissionsAddEntities", mock.Anything, mock.Anything, fakeTriggerID, "CHANNEL2", "channels").
+				clientsMock.API.On("TriggerPermissionsAddEntities", mock.Anything, mock.Anything, fakeTriggerID, "CHANNEL2", "channels").
 					Return(nil)
 				// get access type from backend to display
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.PermissionNamedEntities, []string{"CHANNEL1", "CHANNEL2"}, nil).Once()
 				// display channel info for updated access
-				clientsMock.APIInterface.On("ChannelsInfo", mock.Anything, mock.Anything, "CHANNEL1").
+				clientsMock.API.On("ChannelsInfo", mock.Anything, mock.Anything, "CHANNEL1").
 					Return(&types.ChannelInfo{ID: "CHANNEL1", Name: "Channel One"}, nil).Once()
-				clientsMock.APIInterface.On("ChannelsInfo", mock.Anything, mock.Anything, "CHANNEL2").
+				clientsMock.API.On("ChannelsInfo", mock.Anything, mock.Anything, "CHANNEL2").
 					Return(&types.ChannelInfo{ID: "CHANNEL2", Name: "Channel Two"}, nil).Once()
 
 				clientsMock.AddDefaultMocks()
@@ -379,31 +379,31 @@ func TestTriggersAccessCommand(t *testing.T) {
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				appSelectTeardown = setupMockAccessAppSelection(installedProdApp)
 				// get current access type
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.PermissionNamedEntities, []string{"CHANNEL1"}, nil).Once()
-				clientsMock.APIInterface.On("TriggerPermissionsAddEntities", mock.Anything, mock.Anything, fakeTriggerID, "CHANNEL2", "channels").
+				clientsMock.API.On("TriggerPermissionsAddEntities", mock.Anything, mock.Anything, fakeTriggerID, "CHANNEL2", "channels").
 					Return(nil)
-				clientsMock.APIInterface.On("TriggerPermissionsAddEntities", mock.Anything, mock.Anything, fakeTriggerID, "USER1,USER2", "users").
+				clientsMock.API.On("TriggerPermissionsAddEntities", mock.Anything, mock.Anything, fakeTriggerID, "USER1,USER2", "users").
 					Return(nil)
-				clientsMock.APIInterface.On("TriggerPermissionsAddEntities", mock.Anything, mock.Anything, fakeTriggerID, "TEAM1", "workspaces").
+				clientsMock.API.On("TriggerPermissionsAddEntities", mock.Anything, mock.Anything, fakeTriggerID, "TEAM1", "workspaces").
 					Return(nil)
 				// get access type from backend to display
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.PermissionNamedEntities, []string{"USER1", "USER2", "CHANNEL1", "CHANNEL2", "TEAM1"}, nil).Once()
 				// display user info for updated access
-				clientsMock.APIInterface.On("UsersInfo", mock.Anything, mock.Anything, "USER1").
+				clientsMock.API.On("UsersInfo", mock.Anything, mock.Anything, "USER1").
 					Return(&types.UserInfo{RealName: "User One", Name: "USER1", Profile: user1Profile}, nil).Once()
-				clientsMock.APIInterface.On("UsersInfo", mock.Anything, mock.Anything, "USER2").
+				clientsMock.API.On("UsersInfo", mock.Anything, mock.Anything, "USER2").
 					Return(&types.UserInfo{RealName: "User Two", Name: "USER2", Profile: user2Profile}, nil).Once()
 
 				// display channel info for updated access
-				clientsMock.APIInterface.On("ChannelsInfo", mock.Anything, mock.Anything, "CHANNEL1").
+				clientsMock.API.On("ChannelsInfo", mock.Anything, mock.Anything, "CHANNEL1").
 					Return(&types.ChannelInfo{ID: "CHANNEL1", Name: "Channel One"}, nil).Once()
-				clientsMock.APIInterface.On("ChannelsInfo", mock.Anything, mock.Anything, "CHANNEL2").
+				clientsMock.API.On("ChannelsInfo", mock.Anything, mock.Anything, "CHANNEL2").
 					Return(&types.ChannelInfo{ID: "CHANNEL2", Name: "Channel Two"}, nil).Once()
 
 				// display workspace info for updated access
-				clientsMock.APIInterface.On("TeamsInfo", mock.Anything, mock.Anything, "TEAM1").
+				clientsMock.API.On("TeamsInfo", mock.Anything, mock.Anything, "TEAM1").
 					Return(&types.TeamInfo{ID: "TEAM1", Name: "Team One"}, nil).Once()
 
 				clientsMock.AddDefaultMocks()
@@ -421,19 +421,19 @@ func TestTriggersAccessCommand(t *testing.T) {
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				appSelectTeardown = setupMockAccessAppSelection(installedProdApp)
 				// get current access type
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.PermissionNamedEntities, []string{"USER1", "USER2"}, nil).Once()
 				// display user info for current access
-				clientsMock.APIInterface.On("UserInfo", mock.Anything, mock.Anything, "USER1").
+				clientsMock.API.On("UserInfo", mock.Anything, mock.Anything, "USER1").
 					Return(&types.UserInfo{}, nil).Once()
 				// remove users from named_entities ACL
-				clientsMock.APIInterface.On("TriggerPermissionsRemoveEntities", mock.Anything, mock.Anything, fakeTriggerID, "USER2", "users").
+				clientsMock.API.On("TriggerPermissionsRemoveEntities", mock.Anything, mock.Anything, fakeTriggerID, "USER2", "users").
 					Return(nil)
 				// get access type from backend to display
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.PermissionNamedEntities, []string{"USER1"}, nil).Once()
 				// display user info for updated access
-				clientsMock.APIInterface.On("UsersInfo", mock.Anything, mock.Anything, "USER1").
+				clientsMock.API.On("UsersInfo", mock.Anything, mock.Anything, "USER1").
 					Return(&types.UserInfo{RealName: "User One", Name: "USER1", Profile: user1Profile}, nil).Once()
 
 				clientsMock.AddDefaultMocks()
@@ -450,17 +450,17 @@ func TestTriggersAccessCommand(t *testing.T) {
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				appSelectTeardown = setupMockAccessAppSelection(installedProdApp)
 				// get current access type
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.PermissionNamedEntities, []string{"CHANNEL1", "CHANNEL2"}, nil).Once()
 				// remove channel from named_entities ACL
-				clientsMock.APIInterface.On("TriggerPermissionsRemoveEntities", mock.Anything, mock.Anything, fakeTriggerID, "CHANNEL2", "channels").
+				clientsMock.API.On("TriggerPermissionsRemoveEntities", mock.Anything, mock.Anything, fakeTriggerID, "CHANNEL2", "channels").
 					Return(nil)
 				// get access type from backend to display
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.PermissionNamedEntities, []string{"CHANNEL1"}, nil).Once()
 
 				// display channel info for updated access
-				clientsMock.APIInterface.On("ChannelsInfo", mock.Anything, mock.Anything, "CHANNEL1").
+				clientsMock.API.On("ChannelsInfo", mock.Anything, mock.Anything, "CHANNEL1").
 					Return(&types.ChannelInfo{ID: "CHANNEL1", Name: "Channel One"}, nil).Once()
 
 				clientsMock.AddDefaultMocks()
@@ -478,17 +478,17 @@ func TestTriggersAccessCommand(t *testing.T) {
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				appSelectTeardown = setupMockAccessAppSelection(installedProdApp)
 				// get current access type
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.PermissionNamedEntities, []string{"TEAM1", "TEAM2"}, nil).Once()
 				// remove workspace from named_entities ACL
-				clientsMock.APIInterface.On("TriggerPermissionsRemoveEntities", mock.Anything, mock.Anything, fakeTriggerID, "TEAM2", "workspaces").
+				clientsMock.API.On("TriggerPermissionsRemoveEntities", mock.Anything, mock.Anything, fakeTriggerID, "TEAM2", "workspaces").
 					Return(nil)
 				// get access type from backend to display
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.PermissionNamedEntities, []string{"TEAM1"}, nil).Once()
 
 				// display team info for updated access
-				clientsMock.APIInterface.On("TeamsInfo", mock.Anything, mock.Anything, "TEAM1").
+				clientsMock.API.On("TeamsInfo", mock.Anything, mock.Anything, "TEAM1").
 					Return(&types.TeamInfo{ID: "TEAM1", Name: "Team One"}, nil).Once()
 
 				clientsMock.AddDefaultMocks()
@@ -506,22 +506,22 @@ func TestTriggersAccessCommand(t *testing.T) {
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				appSelectTeardown = setupMockAccessAppSelection(installedProdApp)
 				// get current access type
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.PermissionNamedEntities, []string{"USER1", "USER2", "CHANNEL1", "CHANNEL2"}, nil).Once()
 				// remove user from named_entities ACL
-				clientsMock.APIInterface.On("TriggerPermissionsRemoveEntities", mock.Anything, mock.Anything, fakeTriggerID, "USER2", "users").
+				clientsMock.API.On("TriggerPermissionsRemoveEntities", mock.Anything, mock.Anything, fakeTriggerID, "USER2", "users").
 					Return(nil)
 				// remove channel from named_entities ACL
-				clientsMock.APIInterface.On("TriggerPermissionsRemoveEntities", mock.Anything, mock.Anything, fakeTriggerID, "CHANNEL2", "channels").
+				clientsMock.API.On("TriggerPermissionsRemoveEntities", mock.Anything, mock.Anything, fakeTriggerID, "CHANNEL2", "channels").
 					Return(nil)
 				// get access type from backend to display
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.PermissionNamedEntities, []string{"USER1", "CHANNEL1"}, nil).Once()
-				clientsMock.APIInterface.On("UsersInfo", mock.Anything, mock.Anything, "USER1").
+				clientsMock.API.On("UsersInfo", mock.Anything, mock.Anything, "USER1").
 					Return(&types.UserInfo{RealName: "User One", Name: "USER1", Profile: user1Profile}, nil).Once()
 				clientsMock.AddDefaultMocks()
 				// display channel info for updated access
-				clientsMock.APIInterface.On("ChannelsInfo", mock.Anything, mock.Anything, "CHANNEL1").
+				clientsMock.API.On("ChannelsInfo", mock.Anything, mock.Anything, "CHANNEL1").
 					Return(&types.ChannelInfo{ID: "CHANNEL1", Name: "Channel One"}, nil).Once()
 				err := clients.AppClient().SaveDeployed(ctx, fakeApp)
 				require.NoError(t, err, "Cant write apps.json")
@@ -537,16 +537,16 @@ func TestTriggersAccessCommand(t *testing.T) {
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				appSelectTeardown = setupMockAccessAppSelection(installedProdApp)
 				// trigger ID prompt lists available triggers, including current access
-				clientsMock.APIInterface.On("WorkflowsTriggersList", mock.Anything, mock.Anything, mock.Anything).Return(
+				clientsMock.API.On("WorkflowsTriggersList", mock.Anything, mock.Anything, mock.Anything).Return(
 					[]types.DeployedTrigger{{Name: "Trigger 1", ID: fakeTriggerID, Type: "Shortcut", Workflow: types.TriggerWorkflow{AppID: fakeAppID}}}, "", nil)
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.PermissionEveryone, []string{}, nil).Once()
 				// set and display access
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.PermissionEveryone, []string{}, nil).Once()
-				clientsMock.APIInterface.On("TriggerPermissionsSet", mock.Anything, mock.Anything, mock.Anything, mock.Anything, types.PermissionEveryone, "").
+				clientsMock.API.On("TriggerPermissionsSet", mock.Anything, mock.Anything, mock.Anything, mock.Anything, types.PermissionEveryone, "").
 					Return([]string{}, nil)
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.PermissionEveryone, []string{}, nil).Once()
 
 				clientsMock.IO.On("SelectPrompt", mock.Anything, "Choose a trigger:", mock.Anything, iostreams.MatchPromptConfig(iostreams.SelectPromptConfig{

--- a/cmd/triggers/create.go
+++ b/cmd/triggers/create.go
@@ -135,7 +135,7 @@ func runCreateCommand(clients *shared.ClientFactory, cmd *cobra.Command) error {
 	// def file for dev and prod.
 	triggerArg.WorkflowAppID = app.AppID
 
-	createdTrigger, err := clients.APIInterface().WorkflowsTriggersCreate(ctx, token, triggerArg)
+	createdTrigger, err := clients.API().WorkflowsTriggersCreate(ctx, token, triggerArg)
 	if extendedErr, ok := err.(*api.TriggerCreateOrUpdateError); ok {
 		// If the user used --workflow and the creation failed because we were missing the interactivity
 		// context, lets prompt and optionally add it
@@ -149,7 +149,7 @@ func runCreateCommand(clients *shared.ClientFactory, cmd *cobra.Command) error {
 				return err
 			}
 			if retryTriggerCreate {
-				createdTrigger, err = clients.APIInterface().WorkflowsTriggersCreate(ctx, token, triggerArg)
+				createdTrigger, err = clients.API().WorkflowsTriggersCreate(ctx, token, triggerArg)
 			}
 		}
 	}
@@ -215,7 +215,7 @@ func promptShouldInstallAndRetry(ctx context.Context, clients *shared.ClientFact
 			return types.DeployedTrigger{}, false, nil
 		}
 
-		trigger, err := clients.APIInterface().WorkflowsTriggersCreate(ctx, token, triggerArg)
+		trigger, err := clients.API().WorkflowsTriggersCreate(ctx, token, triggerArg)
 		if err != nil {
 			return types.DeployedTrigger{}, false, err
 		}

--- a/cmd/triggers/create_test.go
+++ b/cmd/triggers/create_test.go
@@ -62,9 +62,9 @@ func TestTriggersCreateCommand(t *testing.T) {
 				appSelectTeardown = setupMockCreateAppSelection(installedProdApp)
 				// TODO: always a) mock out calls and b) call AddDefaultMocks before making any clients.* calls
 				fakeTrigger := createFakeTrigger(fakeTriggerID, fakeTriggerName, fakeAppID, "shortcut")
-				clientsMock.APIInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).Return(fakeTrigger, nil)
-				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).Return(fakeTrigger, nil)
+				clientsMock.API.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+				clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.PermissionEveryone, []string{}, nil).Once()
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
@@ -85,7 +85,7 @@ func TestTriggersCreateCommand(t *testing.T) {
 					Workflow:      "#/workflows/my_workflow",
 					WorkflowAppID: fakeAppID,
 				}
-				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, expectedTriggerRequest)
+				clientsMock.API.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, expectedTriggerRequest)
 			},
 		},
 		"pass all shortcut parameters": {
@@ -95,9 +95,9 @@ func TestTriggersCreateCommand(t *testing.T) {
 				appSelectTeardown = setupMockCreateAppSelection(installedProdApp)
 				// TODO: always a) mock out calls and b) call AddDefaultMocks before making any clients.* calls
 				fakeTrigger := createFakeTrigger(fakeTriggerID, "unit tests", fakeAppID, "shortcut")
-				clientsMock.APIInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).Return(fakeTrigger, nil)
-				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).Return(fakeTrigger, nil)
+				clientsMock.API.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+				clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.PermissionEveryone, []string{}, nil).Once()
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
@@ -116,7 +116,7 @@ func TestTriggersCreateCommand(t *testing.T) {
 					Workflow:      "#/workflows/my_workflow",
 					WorkflowAppID: fakeAppID,
 				}
-				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, expectedTriggerRequest)
+				clientsMock.API.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, expectedTriggerRequest)
 			},
 		},
 		"pass --interactivity, default name": {
@@ -126,9 +126,9 @@ func TestTriggersCreateCommand(t *testing.T) {
 				appSelectTeardown = setupMockCreateAppSelection(installedProdApp)
 				// TODO: always a) mock out calls and b) call AddDefaultMocks before making any clients.* calls
 				fakeTrigger := createFakeTrigger(fakeTriggerID, "unit tests", fakeAppID, "shortcut")
-				clientsMock.APIInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).Return(fakeTrigger, nil)
-				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).Return(fakeTrigger, nil)
+				clientsMock.API.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+				clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.PermissionEveryone, []string{}, nil).Once()
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
@@ -152,7 +152,7 @@ func TestTriggersCreateCommand(t *testing.T) {
 						},
 					},
 				}
-				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, expectedTriggerRequest)
+				clientsMock.API.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, expectedTriggerRequest)
 			},
 		},
 		"pass --interactivity, custom name": {
@@ -162,9 +162,9 @@ func TestTriggersCreateCommand(t *testing.T) {
 				appSelectTeardown = setupMockCreateAppSelection(installedProdApp)
 				// TODO: always a) mock out calls and b) call AddDefaultMocks before making any clients.* calls
 				fakeTrigger := createFakeTrigger(fakeTriggerID, "unit tests", fakeAppID, "shortcut")
-				clientsMock.APIInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).Return(fakeTrigger, nil)
-				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).Return(fakeTrigger, nil)
+				clientsMock.API.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+				clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.PermissionEveryone, []string{}, nil).Once()
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
@@ -188,7 +188,7 @@ func TestTriggersCreateCommand(t *testing.T) {
 						},
 					},
 				}
-				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, expectedTriggerRequest)
+				clientsMock.API.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, expectedTriggerRequest)
 			},
 		},
 		"api call fails": {
@@ -197,7 +197,7 @@ func TestTriggersCreateCommand(t *testing.T) {
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				appSelectTeardown = setupMockCreateAppSelection(installedProdApp)
 				// TODO: always a) mock out calls and b) call AddDefaultMocks before making any clients.* calls
-				clientsMock.APIInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).Return(types.DeployedTrigger{}, errors.New("invalid_auth"))
+				clientsMock.API.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).Return(types.DeployedTrigger{}, errors.New("invalid_auth"))
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
 				err := clients.AppClient().SaveDeployed(ctx, fakeApp)
@@ -214,10 +214,10 @@ func TestTriggersCreateCommand(t *testing.T) {
 				appSelectTeardown = setupMockCreateAppSelection(installedProdApp)
 				// TODO: always a) mock out calls and b) call AddDefaultMocks before making any clients.* calls
 				fakeTrigger := createFakeTrigger(fakeTriggerID, "name", fakeAppID, "scheduled")
-				clientsMock.APIInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).Return(fakeTrigger, nil)
+				clientsMock.API.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).Return(fakeTrigger, nil)
 				// no collaborators on app
-				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+				clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.PermissionEveryone, []string{}, nil).Once()
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
@@ -246,7 +246,7 @@ func TestTriggersCreateCommand(t *testing.T) {
 					WorkflowAppID: fakeAppID,
 					Schedule:      types.ToRawJSON(`{"start_time":"2020-03-15","frequency":{"type":"daily"}}`),
 				}
-				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, expectedTriggerRequest)
+				clientsMock.API.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, expectedTriggerRequest)
 			},
 		},
 		"--trigger-def, file missing": {
@@ -269,9 +269,9 @@ func TestTriggersCreateCommand(t *testing.T) {
 			ExpectedOutputs: []string{},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				appSelectTeardown = setupMockCreateAppSelection(installedProdApp)
-				clientsMock.APIInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).Return(types.DeployedTrigger{}, nil)
-				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{{}}, nil)
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).Return(types.DeployedTrigger{}, nil)
+				clientsMock.API.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{{}}, nil)
+				clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.PermissionEveryone, []string{}, nil).Once()
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
@@ -288,7 +288,7 @@ func TestTriggersCreateCommand(t *testing.T) {
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
 				clientsMock.HookExecutor.AssertCalled(t, "Execute", mock.Anything, mock.Anything)
-				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything)
+				clientsMock.API.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything)
 			},
 		},
 		"--trigger-def, not json, `get-trigger` hook missing": {
@@ -309,7 +309,7 @@ func TestTriggersCreateCommand(t *testing.T) {
 				appSelectTeardown()
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.APIInterface.AssertNotCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything)
+				clientsMock.API.AssertNotCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything)
 			},
 		},
 	}, func(clients *shared.ClientFactory) *cobra.Command {
@@ -364,12 +364,12 @@ func TestTriggersCreateCommand_MissingParameters(t *testing.T) {
 						Type: "slack#/types/interactivity",
 					},
 				}
-				clientsMock.APIInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, triggerRequestMissingInputs).Return(types.DeployedTrigger{}, extendedErr)
+				clientsMock.API.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, triggerRequestMissingInputs).Return(types.DeployedTrigger{}, extendedErr)
 
 				fakeTrigger := createFakeTrigger(fakeTriggerID, "unit tests", fakeAppID, "shortcut")
-				clientsMock.APIInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, triggerRequestWithInteractivityInputs).Return(fakeTrigger, nil)
-				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, triggerRequestWithInteractivityInputs).Return(fakeTrigger, nil)
+				clientsMock.API.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+				clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.PermissionEveryone, []string{}, nil).Once()
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
@@ -377,8 +377,8 @@ func TestTriggersCreateCommand_MissingParameters(t *testing.T) {
 				require.NoError(t, err, "Cant write apps.json")
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, triggerRequestMissingInputs)
-				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, triggerRequestWithInteractivityInputs)
+				clientsMock.API.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, triggerRequestMissingInputs)
+				clientsMock.API.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, triggerRequestWithInteractivityInputs)
 			},
 			Teardown: func() {
 				appSelectTeardown()
@@ -399,17 +399,17 @@ func TestTriggersCreateCommand_MissingParameters(t *testing.T) {
 						Type: "slack#/types/interactivity",
 					},
 				}
-				clientsMock.APIInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, triggerRequestMissingInputs).Return(types.DeployedTrigger{}, extendedErr).Once()
+				clientsMock.API.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, triggerRequestMissingInputs).Return(types.DeployedTrigger{}, extendedErr).Once()
 
-				clientsMock.APIInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, triggerRequestWithInteractivityInputs).Return(types.DeployedTrigger{}, errors.New("internal_error")).Once()
+				clientsMock.API.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, triggerRequestWithInteractivityInputs).Return(types.DeployedTrigger{}, errors.New("internal_error")).Once()
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
 				err := clients.AppClient().SaveDeployed(ctx, fakeApp)
 				require.NoError(t, err, "Cant write apps.json")
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, triggerRequestMissingInputs)
-				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, triggerRequestWithInteractivityInputs)
+				clientsMock.API.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, triggerRequestMissingInputs)
+				clientsMock.API.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, triggerRequestWithInteractivityInputs)
 			},
 			Teardown: func() {
 				appSelectTeardown()
@@ -430,14 +430,14 @@ func TestTriggersCreateCommand_MissingParameters(t *testing.T) {
 						Type: "number",
 					},
 				}
-				clientsMock.APIInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).Return(types.DeployedTrigger{}, extendedErr)
+				clientsMock.API.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).Return(types.DeployedTrigger{}, extendedErr)
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
 				err := clients.AppClient().SaveDeployed(ctx, fakeApp)
 				require.NoError(t, err, "Cant write apps.json")
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything)
+				clientsMock.API.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything)
 			},
 			Teardown: func() {
 				appSelectTeardown()
@@ -491,7 +491,7 @@ func TestTriggersCreateCommand_AppSelection(t *testing.T) {
 				}
 				appCommandMock.On("RunAddCommand", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(ctx, types.InstallSuccess, newDevApp.App, nil)
-				clientsMock.APIInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.DeployedTrigger{}, nil)
 				// Define default mocks
 				clientsMock.AddDefaultMocks()
@@ -502,7 +502,7 @@ func TestTriggersCreateCommand_AppSelection(t *testing.T) {
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
 				appCommandMock.AssertCalled(t, "RunAddCommand", mock.Anything, mock.Anything, &newDevApp, mock.Anything)
-				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything)
+				clientsMock.API.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything)
 			},
 		},
 		"select a non-installed prod app": {
@@ -519,7 +519,7 @@ func TestTriggersCreateCommand_AppSelection(t *testing.T) {
 				}
 				appCommandMock.On("RunAddCommand", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(ctx, types.InstallSuccess, newDevApp.App, nil)
-				clientsMock.APIInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.DeployedTrigger{}, nil)
 				// Define default mocks
 				clientsMock.AddDefaultMocks()
@@ -530,7 +530,7 @@ func TestTriggersCreateCommand_AppSelection(t *testing.T) {
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
 				appCommandMock.AssertCalled(t, "RunAddCommand", mock.Anything, mock.Anything, &newProdApp, mock.Anything)
-				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything)
+				clientsMock.API.AssertCalled(t, "WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything)
 			},
 		},
 	}, func(clients *shared.ClientFactory) *cobra.Command {
@@ -554,7 +554,7 @@ func TestTriggersCreateCommand_promptShouldInstallAndRetry(t *testing.T) {
 			name: "Accept prompt to reinstall and create the trigger successfully",
 			prepareMocks: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, appCmdMock *app.AppMock) {
 				appCmdMock.On("RunAddCommand", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(ctx, types.InstallSuccess, types.App{}, nil)
-				clientsMock.APIInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.DeployedTrigger{Name: "trigger name", ID: "Ft123", Type: "shortcut"}, nil)
 				clientsMock.IO.On("ConfirmPrompt", mock.Anything, "Re-install app to apply local file changes and try again?", mock.Anything).Return(true, nil)
 			},
@@ -578,7 +578,7 @@ func TestTriggersCreateCommand_promptShouldInstallAndRetry(t *testing.T) {
 			name: "Accept prompt to reinstall but fail to create the trigger",
 			prepareMocks: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, appCmdMock *app.AppMock) {
 				appCmdMock.On("RunAddCommand", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(ctx, types.InstallSuccess, types.App{}, nil)
-				clientsMock.APIInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.DeployedTrigger{}, errors.New("something_else_went_wrong"))
 				clientsMock.Os.On("UserHomeDir").Return("", nil) // Called by clients.IO.PrintError
 				clientsMock.IO.On("ConfirmPrompt", mock.Anything, "Re-install app to apply local file changes and try again?", mock.Anything).Return(true, nil)

--- a/cmd/triggers/delete.go
+++ b/cmd/triggers/delete.go
@@ -90,7 +90,7 @@ func runDeleteCommand(clients *shared.ClientFactory, cmd *cobra.Command) error {
 		}
 	}
 
-	err = clients.APIInterface().WorkflowsTriggersDelete(ctx, token, deleteFlags.triggerID)
+	err = clients.API().WorkflowsTriggersDelete(ctx, token, deleteFlags.triggerID)
 	if err != nil {
 		return err
 	}

--- a/cmd/triggers/delete_test.go
+++ b/cmd/triggers/delete_test.go
@@ -41,10 +41,10 @@ func TestTriggersDeleteCommand(t *testing.T) {
 				appSelectTeardown = setupMockDeleteAppSelection(installedProdApp)
 				clientsMock.AddDefaultMocks()
 				// promptForTriggerID lists available triggers
-				clientsMock.APIInterface.On("WorkflowsTriggersList", mock.Anything, mock.Anything, mock.Anything).Return(
+				clientsMock.API.On("WorkflowsTriggersList", mock.Anything, mock.Anything, mock.Anything).Return(
 					[]types.DeployedTrigger{{Name: "Trigger 1", ID: fakeTriggerID, Type: "Shortcut", Workflow: types.TriggerWorkflow{AppID: fakeAppID}}}, "", nil)
 				clientsMock.IO.On("SelectPrompt", mock.Anything, "Choose a trigger:", mock.Anything, mock.Anything).Return(iostreams.SelectPromptResponse{}, nil)
-				clientsMock.APIInterface.On("WorkflowsTriggersDelete", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				clientsMock.API.On("WorkflowsTriggersDelete", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 			},
 			Teardown: func() {
 				appSelectTeardown()
@@ -66,7 +66,7 @@ func TestTriggersDeleteCommand(t *testing.T) {
 			ExpectedOutputs: []string{"Trigger '" + fakeTriggerID + "' deleted"},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				appSelectTeardown = setupMockDeleteAppSelection(installedProdApp)
-				clientsMock.APIInterface.On("WorkflowsTriggersDelete", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+				clientsMock.API.On("WorkflowsTriggersDelete", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
 				// TODO this can probably be replaced by a helper that sets up an apps.json file in
@@ -78,7 +78,7 @@ func TestTriggersDeleteCommand(t *testing.T) {
 				appSelectTeardown()
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersDelete", mock.Anything, mock.Anything, fakeTriggerID)
+				clientsMock.API.AssertCalled(t, "WorkflowsTriggersDelete", mock.Anything, mock.Anything, fakeTriggerID)
 			},
 		},
 		"pass --trigger-id, failure": {
@@ -86,7 +86,7 @@ func TestTriggersDeleteCommand(t *testing.T) {
 			ExpectedErrorStrings: []string{"invalid_auth"},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				appSelectTeardown = setupMockDeleteAppSelection(installedProdApp)
-				clientsMock.APIInterface.On("WorkflowsTriggersDelete", mock.Anything, mock.Anything, mock.Anything).Return(errors.New("invalid_auth"))
+				clientsMock.API.On("WorkflowsTriggersDelete", mock.Anything, mock.Anything, mock.Anything).Return(errors.New("invalid_auth"))
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
 				err := clients.AppClient().SaveDeployed(ctx, fakeApp)
@@ -96,7 +96,7 @@ func TestTriggersDeleteCommand(t *testing.T) {
 				appSelectTeardown()
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersDelete", mock.Anything, mock.Anything, fakeTriggerID)
+				clientsMock.API.AssertCalled(t, "WorkflowsTriggersDelete", mock.Anything, mock.Anything, fakeTriggerID)
 			},
 		},
 	}, func(clients *shared.ClientFactory) *cobra.Command {

--- a/cmd/triggers/generate.go
+++ b/cmd/triggers/generate.go
@@ -54,7 +54,7 @@ func TriggerGenerate(ctx context.Context, clients *shared.ClientFactory, app typ
 		AppID: app.AppID,
 		Limit: 4, // Limit to improve performance for apps with many triggers
 	}
-	existingTriggers, _, err := clients.APIInterface().WorkflowsTriggersList(ctx, token, args)
+	existingTriggers, _, err := clients.API().WorkflowsTriggersList(ctx, token, args)
 	if err != nil {
 		return nil, err
 	}
@@ -115,7 +115,7 @@ func TriggerGenerate(ctx context.Context, clients *shared.ClientFactory, app typ
 	// def file for dev and prod.
 	triggerArg.WorkflowAppID = app.AppID
 
-	createdTrigger, err := clients.APIInterface().WorkflowsTriggersCreate(ctx, token, triggerArg)
+	createdTrigger, err := clients.API().WorkflowsTriggersCreate(ctx, token, triggerArg)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/triggers/generate_test.go
+++ b/cmd/triggers/generate_test.go
@@ -64,8 +64,8 @@ func Test_TriggerGenerate_accept_prompt(t *testing.T) {
 			Option: "trigger/file.ts",
 			Index:  0,
 		}, nil)
-		clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-		clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+		clientsMock.API.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+		clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 			Return(types.PermissionEveryone, []string{}, nil).Once()
 
 		clients := shared.NewClientFactory(clientsMock.MockClientFactory(), func(clients *shared.ClientFactory) {
@@ -129,8 +129,8 @@ func Test_TriggerGenerate_skip_prompt(t *testing.T) {
 
 	t.Run(tt.name, func(t *testing.T) {
 		ctx, clientsMock := prepareMocks(t, tt.triggersListResponse, tt.globResponse, tt.triggersCreateResponse, nil /*trigger create error*/)
-		clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-		clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+		clientsMock.API.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+		clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 			Return(types.PermissionEveryone, []string{}, nil).Once()
 		clients := shared.NewClientFactory(clientsMock.MockClientFactory(), func(clients *shared.ClientFactory) {
 			clients.SDKConfig = hooks.NewSDKConfigMock()
@@ -167,8 +167,8 @@ func Test_TriggerGenerate_handle_error(t *testing.T) {
 			Option: "triggers/trigger.ts",
 			Index:  0,
 		}, nil)
-		clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-		clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+		clientsMock.API.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+		clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 			Return(types.PermissionEveryone, []string{}, nil).Once()
 		clients := shared.NewClientFactory(clientsMock.MockClientFactory(), func(clients *shared.ClientFactory) {
 			clients.SDKConfig = hooks.NewSDKConfigMock()
@@ -235,8 +235,8 @@ func Test_TriggerGenerate_Config_TriggerPaths_Default(t *testing.T) {
 			Option: "triggers/trigger.ts",
 			Index:  0,
 		}, nil)
-		clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-		clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+		clientsMock.API.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+		clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 			Return(types.PermissionEveryone, []string{}, nil).Once()
 		clients := shared.NewClientFactory(clientsMock.MockClientFactory(), func(clients *shared.ClientFactory) {
 			clients.SDKConfig = hooks.NewSDKConfigMock()
@@ -275,8 +275,8 @@ func Test_TriggerGenerate_Config_TriggerPaths_Custom(t *testing.T) {
 			Option: "triggers/trigger.ts",
 			Index:  0,
 		}, nil)
-		clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-		clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+		clientsMock.API.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+		clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 			Return(types.PermissionEveryone, []string{}, nil).Once()
 		clients := shared.NewClientFactory(clientsMock.MockClientFactory(), func(clients *shared.ClientFactory) {
 			clients.SDKConfig = hooks.NewSDKConfigMock()
@@ -458,9 +458,9 @@ func prepareMocks(t *testing.T, triggersListResponse []types.DeployedTrigger, gl
 	ctx = config.SetContextToken(ctx, "token")
 
 	clientsMock := shared.NewClientsMock()
-	clientsMock.APIInterface.On("WorkflowsTriggersList", mock.Anything, mock.Anything, mock.Anything).Return(triggersListResponse, "", nil)
+	clientsMock.API.On("WorkflowsTriggersList", mock.Anything, mock.Anything, mock.Anything).Return(triggersListResponse, "", nil)
 	clientsMock.Os.On("Glob", mock.Anything).Return(globResponse, nil)
-	clientsMock.APIInterface.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).Return(triggersCreateResponse, triggersCreateResponseError)
+	clientsMock.API.On("WorkflowsTriggersCreate", mock.Anything, mock.Anything, mock.Anything).Return(triggersCreateResponse, triggersCreateResponseError)
 	clientsMock.HookExecutor.On("Execute", mock.Anything, mock.Anything).Return(`{}`, nil)
 
 	clientsMock.AddDefaultMocks()

--- a/cmd/triggers/info.go
+++ b/cmd/triggers/info.go
@@ -89,7 +89,7 @@ func runInfoCommand(cmd *cobra.Command, clients *shared.ClientFactory) error {
 		}
 	}
 
-	requestedTrigger, err := clients.APIInterface().WorkflowsTriggersInfo(ctx, token, infoFlags.triggerID)
+	requestedTrigger, err := clients.API().WorkflowsTriggersInfo(ctx, token, infoFlags.triggerID)
 	if err != nil {
 		return err
 	}

--- a/cmd/triggers/info_test.go
+++ b/cmd/triggers/info_test.go
@@ -40,18 +40,18 @@ func TestTriggersInfoCommand(t *testing.T) {
 				appSelectTeardown = setupMockInfoAppSelection(installedProdApp)
 				mockRequestTrigger := createFakeTrigger(fakeTriggerID, "test trigger", "test app", "shortcut")
 				// promptForTriggerID lists available triggers
-				cm.APIInterface.On("WorkflowsTriggersList", mock.Anything, mock.Anything, mock.Anything).Return(
+				cm.API.On("WorkflowsTriggersList", mock.Anything, mock.Anything, mock.Anything).Return(
 					[]types.DeployedTrigger{{Name: "test trigger", ID: fakeTriggerID, Type: "Shortcut", Workflow: types.TriggerWorkflow{AppID: fakeAppID}}}, "", nil)
 				cm.IO.On("SelectPrompt", mock.Anything, "Choose a trigger:", mock.Anything, mock.Anything).Return(iostreams.SelectPromptResponse{Index: 0, Prompt: true}, nil)
-				cm.APIInterface.On("WorkflowsTriggersInfo", mock.Anything, mock.Anything, mock.Anything).Return(mockRequestTrigger, nil)
-				cm.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-				cm.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).Return(types.PermissionEveryone, []string{}, nil).Once()
+				cm.API.On("WorkflowsTriggersInfo", mock.Anything, mock.Anything, mock.Anything).Return(mockRequestTrigger, nil)
+				cm.API.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+				cm.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).Return(types.PermissionEveryone, []string{}, nil).Once()
 			},
 			ExpectedOutputs: []string{
 				"Trigger Info",
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersInfo", mock.Anything, mock.Anything, fakeTriggerID)
+				clientsMock.API.AssertCalled(t, "WorkflowsTriggersInfo", mock.Anything, mock.Anything, fakeTriggerID)
 			},
 			Teardown: func() {
 				appSelectTeardown()
@@ -78,9 +78,9 @@ func TestTriggersInfoCommand(t *testing.T) {
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				appSelectTeardown = setupMockInfoAppSelection(installedProdApp)
 				mockRequestTrigger := createFakeTrigger(fakeTriggerID, "test trigger", "test app", "shortcut")
-				clientsMock.APIInterface.On("WorkflowsTriggersInfo", mock.Anything, mock.Anything, mock.Anything).Return(mockRequestTrigger, nil)
-				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("WorkflowsTriggersInfo", mock.Anything, mock.Anything, mock.Anything).Return(mockRequestTrigger, nil)
+				clientsMock.API.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+				clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.PermissionEveryone, []string{}, nil).Once()
 				clientsMock.AddDefaultMocks()
 				err := clients.AppClient().SaveDeployed(ctx, fakeApp)
@@ -90,7 +90,7 @@ func TestTriggersInfoCommand(t *testing.T) {
 				appSelectTeardown()
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersInfo", mock.Anything, mock.Anything, fakeTriggerID)
+				clientsMock.API.AssertCalled(t, "WorkflowsTriggersInfo", mock.Anything, mock.Anything, fakeTriggerID)
 			},
 		},
 		"pass --trigger-id for an org app, success": {
@@ -103,9 +103,9 @@ func TestTriggersInfoCommand(t *testing.T) {
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				appSelectTeardown = setupMockInfoAppSelection(installedProdOrgApp)
 				mockRequestTrigger := createFakeTrigger(fakeTriggerID, "test trigger", "test app", "shortcut")
-				clientsMock.APIInterface.On("WorkflowsTriggersInfo", mock.Anything, mock.Anything, mock.Anything).Return(mockRequestTrigger, nil)
-				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("WorkflowsTriggersInfo", mock.Anything, mock.Anything, mock.Anything).Return(mockRequestTrigger, nil)
+				clientsMock.API.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+				clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.PermissionEveryone, []string{}, nil).Once()
 				clientsMock.AddDefaultMocks()
 				err := clients.AppClient().SaveDeployed(ctx, fakeApp)
@@ -115,7 +115,7 @@ func TestTriggersInfoCommand(t *testing.T) {
 				appSelectTeardown()
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersInfo", mock.Anything, mock.Anything, fakeTriggerID)
+				clientsMock.API.AssertCalled(t, "WorkflowsTriggersInfo", mock.Anything, mock.Anything, fakeTriggerID)
 			},
 		},
 		"pass --trigger-id, failure": {
@@ -123,7 +123,7 @@ func TestTriggersInfoCommand(t *testing.T) {
 			ExpectedErrorStrings: []string{"invalid_auth"},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				appSelectTeardown = setupMockInfoAppSelection(installedProdApp)
-				clientsMock.APIInterface.On("WorkflowsTriggersInfo", mock.Anything, mock.Anything, mock.Anything).Return(types.DeployedTrigger{}, errors.New("invalid_auth"))
+				clientsMock.API.On("WorkflowsTriggersInfo", mock.Anything, mock.Anything, mock.Anything).Return(types.DeployedTrigger{}, errors.New("invalid_auth"))
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
 				err := clients.AppClient().SaveDeployed(ctx, fakeApp)
@@ -133,7 +133,7 @@ func TestTriggersInfoCommand(t *testing.T) {
 				appSelectTeardown()
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersInfo", mock.Anything, mock.Anything, fakeTriggerID)
+				clientsMock.API.AssertCalled(t, "WorkflowsTriggersInfo", mock.Anything, mock.Anything, fakeTriggerID)
 			},
 		},
 		"event trigger displays hints and warnings": {
@@ -141,9 +141,9 @@ func TestTriggersInfoCommand(t *testing.T) {
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				appSelectTeardown = setupMockInfoAppSelection(installedProdApp)
 				mockRequestTrigger := createFakeTrigger(fakeTriggerID, "test trigger", "test app", "event")
-				clientsMock.APIInterface.On("WorkflowsTriggersInfo", mock.Anything, mock.Anything, mock.Anything).Return(mockRequestTrigger, nil)
-				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("WorkflowsTriggersInfo", mock.Anything, mock.Anything, mock.Anything).Return(mockRequestTrigger, nil)
+				clientsMock.API.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+				clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.PermissionEveryone, []string{}, nil).Once()
 				clientsMock.AddDefaultMocks()
 				err := clients.AppClient().SaveDeployed(ctx, fakeApp)
@@ -159,7 +159,7 @@ func TestTriggersInfoCommand(t *testing.T) {
 				"Warning:\n",
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersInfo", mock.Anything, mock.Anything, fakeTriggerID)
+				clientsMock.API.AssertCalled(t, "WorkflowsTriggersInfo", mock.Anything, mock.Anything, fakeTriggerID)
 			},
 		},
 	}, func(clients *shared.ClientFactory) *cobra.Command {

--- a/cmd/triggers/list.go
+++ b/cmd/triggers/list.go
@@ -98,7 +98,7 @@ func runListCommand(cmd *cobra.Command, clients *shared.ClientFactory) error {
 		Limit: listFlags.triggerLimit,
 		Type:  listFlags.triggerType,
 	}
-	deployedTriggers, cursor, err := clients.APIInterface().WorkflowsTriggersList(ctx, token, args)
+	deployedTriggers, cursor, err := clients.API().WorkflowsTriggersList(ctx, token, args)
 	if err != nil {
 		return err
 	}
@@ -172,7 +172,7 @@ func showMoreTriggers(ctx context.Context, cmd *cobra.Command, clients *shared.C
 
 	for proceed && args.Cursor != "" {
 		proceed = false
-		deployedTriggers, nextCursor, err := clients.APIInterface().WorkflowsTriggersList(ctx, token, args)
+		deployedTriggers, nextCursor, err := clients.API().WorkflowsTriggersList(ctx, token, args)
 		if err != nil {
 			return err
 		}

--- a/cmd/triggers/list_test.go
+++ b/cmd/triggers/list_test.go
@@ -45,7 +45,7 @@ func TestTriggersListCommand(t *testing.T) {
 					Cursor: "",
 					Type:   listFlags.triggerType,
 				}
-				clientsMock.APIInterface.On("WorkflowsTriggersList", mock.Anything, mock.Anything, triggerListRequestArgs).Return([]types.DeployedTrigger{}, "", nil)
+				clientsMock.API.On("WorkflowsTriggersList", mock.Anything, mock.Anything, triggerListRequestArgs).Return([]types.DeployedTrigger{}, "", nil)
 
 				clientsMock.AddDefaultMocks()
 			},
@@ -57,7 +57,7 @@ func TestTriggersListCommand(t *testing.T) {
 				"There are no triggers installed for the app",
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersList", mock.Anything, mock.Anything, triggerListRequestArgs)
+				clientsMock.API.AssertCalled(t, "WorkflowsTriggersList", mock.Anything, mock.Anything, triggerListRequestArgs)
 			},
 		},
 
@@ -73,15 +73,15 @@ func TestTriggersListCommand(t *testing.T) {
 					Cursor: "",
 					Type:   listFlags.triggerType,
 				}
-				clientsMock.APIInterface.On("WorkflowsTriggersList", mock.Anything, mock.Anything, triggerListRequestArgs).Return(
+				clientsMock.API.On("WorkflowsTriggersList", mock.Anything, mock.Anything, triggerListRequestArgs).Return(
 					[]types.DeployedTrigger{
 						createFakeTrigger(fakeTriggerID, fakeTriggerName, fakeAppID, "shortcut"),
 					},
 					"",
 					nil,
 				)
-				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).Return(types.PermissionEveryone, []string{}, nil)
+				clientsMock.API.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+				clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).Return(types.PermissionEveryone, []string{}, nil)
 
 				clientsMock.AddDefaultMocks()
 			},
@@ -94,7 +94,7 @@ func TestTriggersListCommand(t *testing.T) {
 				"everyone in the workspace",
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersList", mock.Anything, mock.Anything, triggerListRequestArgs)
+				clientsMock.API.AssertCalled(t, "WorkflowsTriggersList", mock.Anything, mock.Anything, triggerListRequestArgs)
 			},
 		},
 
@@ -110,15 +110,15 @@ func TestTriggersListCommand(t *testing.T) {
 					Cursor: "",
 					Type:   listFlags.triggerType,
 				}
-				clientsMock.APIInterface.On("WorkflowsTriggersList", mock.Anything, mock.Anything, triggerListRequestArgs).Return(
+				clientsMock.API.On("WorkflowsTriggersList", mock.Anything, mock.Anything, triggerListRequestArgs).Return(
 					[]types.DeployedTrigger{
 						createFakeTrigger(fakeTriggerID, fakeTriggerName, fakeAppID, "shortcut"),
 					},
 					"",
 					nil,
 				)
-				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).Return(types.PermissionEveryone, []string{}, nil)
+				clientsMock.API.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+				clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).Return(types.PermissionEveryone, []string{}, nil)
 
 				clientsMock.AddDefaultMocks()
 			},
@@ -131,7 +131,7 @@ func TestTriggersListCommand(t *testing.T) {
 				"everyone in all workspaces in this org granted to this app",
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersList", mock.Anything, mock.Anything, triggerListRequestArgs)
+				clientsMock.API.AssertCalled(t, "WorkflowsTriggersList", mock.Anything, mock.Anything, triggerListRequestArgs)
 			},
 		},
 
@@ -147,7 +147,7 @@ func TestTriggersListCommand(t *testing.T) {
 					Cursor: "",
 					Type:   listFlags.triggerType,
 				}
-				clientsMock.APIInterface.On("WorkflowsTriggersList", mock.Anything, mock.Anything, triggerListRequestArgs).Return(
+				clientsMock.API.On("WorkflowsTriggersList", mock.Anything, mock.Anything, triggerListRequestArgs).Return(
 					[]types.DeployedTrigger{
 						createFakeTrigger(fakeTriggerID, fakeTriggerName, fakeAppID, "shortcut"),
 						createFakeTrigger(fakeTriggerID, fakeTriggerName, fakeAppID, "scheduled"),
@@ -155,8 +155,8 @@ func TestTriggersListCommand(t *testing.T) {
 					"",
 					nil,
 				)
-				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).Return(types.PermissionEveryone, []string{}, nil)
+				clientsMock.API.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+				clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).Return(types.PermissionEveryone, []string{}, nil)
 
 				clientsMock.AddDefaultMocks()
 			},
@@ -169,7 +169,7 @@ func TestTriggersListCommand(t *testing.T) {
 				fmt.Sprintf("Trigger ID: %s (%s)", fakeTriggerID, "scheduled"),
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersList", mock.Anything, mock.Anything, triggerListRequestArgs)
+				clientsMock.API.AssertCalled(t, "WorkflowsTriggersList", mock.Anything, mock.Anything, triggerListRequestArgs)
 			},
 		},
 	}, func(clients *shared.ClientFactory) *cobra.Command {

--- a/cmd/triggers/triggers.go
+++ b/cmd/triggers/triggers.go
@@ -110,7 +110,7 @@ func sprintTrigger(ctx context.Context, t types.DeployedTrigger, clients *shared
 	token := config.GetContextToken(ctx)
 
 	// Get app owners & collaborators
-	collaborators, err := clients.APIInterface().ListCollaborators(ctx, token, app.AppID)
+	collaborators, err := clients.API().ListCollaborators(ctx, token, app.AppID)
 	if err != nil {
 		return []string{}, err
 	}
@@ -119,7 +119,7 @@ func sprintTrigger(ctx context.Context, t types.DeployedTrigger, clients *shared
 			style.Indent(style.Secondary("Collaborators:")),
 		))
 		for _, collaborator := range collaborators {
-			userInfo, err := clients.APIInterface().UsersInfo(ctx, token, collaborator.ID)
+			userInfo, err := clients.API().UsersInfo(ctx, token, collaborator.ID)
 			if err != nil {
 				return []string{}, err
 			}
@@ -130,7 +130,7 @@ func sprintTrigger(ctx context.Context, t types.DeployedTrigger, clients *shared
 		}
 	}
 	// Get trigger's ACL type
-	accessType, entitiesAccessList, err := clients.APIInterface().TriggerPermissionsList(ctx, token, t.ID)
+	accessType, entitiesAccessList, err := clients.API().TriggerPermissionsList(ctx, token, t.ID)
 	if err != nil {
 		return []string{}, err
 	}
@@ -153,7 +153,7 @@ func sprintTrigger(ctx context.Context, t types.DeployedTrigger, clients *shared
 					style.Indent(style.Secondary("Can be found and used by:")),
 				))
 				for _, entity := range entitiesAccessList {
-					userInfo, err := clients.APIInterface().UsersInfo(ctx, token, entity)
+					userInfo, err := clients.API().UsersInfo(ctx, token, entity)
 					if err != nil {
 						return []string{}, err
 					}
@@ -170,7 +170,7 @@ func sprintTrigger(ctx context.Context, t types.DeployedTrigger, clients *shared
 				if len(namedEntitiesAccessMap["users"]) > 0 {
 
 					for _, entity := range namedEntitiesAccessMap["users"] {
-						userInfo, err := clients.APIInterface().UsersInfo(ctx, token, entity)
+						userInfo, err := clients.API().UsersInfo(ctx, token, entity)
 						if err != nil {
 							return []string{}, err
 						}
@@ -182,7 +182,7 @@ func sprintTrigger(ctx context.Context, t types.DeployedTrigger, clients *shared
 				}
 				if len(namedEntitiesAccessMap["channels"]) > 0 {
 					for _, entity := range namedEntitiesAccessMap["channels"] {
-						channelInfo, err := clients.APIInterface().ChannelsInfo(ctx, token, entity)
+						channelInfo, err := clients.API().ChannelsInfo(ctx, token, entity)
 						if err != nil {
 							return []string{}, err
 						}
@@ -194,7 +194,7 @@ func sprintTrigger(ctx context.Context, t types.DeployedTrigger, clients *shared
 				}
 				if len(namedEntitiesAccessMap["teams"]) > 0 {
 					for _, entity := range namedEntitiesAccessMap["teams"] {
-						teamInfo, err := clients.APIInterface().TeamsInfo(ctx, token, entity)
+						teamInfo, err := clients.API().TeamsInfo(ctx, token, entity)
 						if err != nil {
 							return []string{}, err
 						}
@@ -206,7 +206,7 @@ func sprintTrigger(ctx context.Context, t types.DeployedTrigger, clients *shared
 				}
 				if len(namedEntitiesAccessMap["organizations"]) > 0 {
 					for _, entity := range namedEntitiesAccessMap["organizations"] {
-						orgInfo, err := clients.APIInterface().TeamsInfo(ctx, token, entity)
+						orgInfo, err := clients.API().TeamsInfo(ctx, token, entity)
 						if err != nil {
 							return []string{}, err
 						}
@@ -353,7 +353,7 @@ func promptForTriggerID(ctx context.Context, cmd *cobra.Command, clients *shared
 		Limit: 0,     // 0 means no pagation
 		Type:  "all", // all means showing all types of triggers
 	}
-	triggers, _, err := clients.APIInterface().WorkflowsTriggersList(ctx, token, args)
+	triggers, _, err := clients.API().WorkflowsTriggersList(ctx, token, args)
 	if err != nil {
 		return "", err
 	}
@@ -373,7 +373,7 @@ func promptForTriggerID(ctx context.Context, cmd *cobra.Command, clients *shared
 	triggerLabels := []string{}
 	for _, tr := range triggers {
 		if labelOption == labelsIncludeAccessType {
-			accessType, _, err := clients.APIInterface().TriggerPermissionsList(ctx, token, tr.ID)
+			accessType, _, err := clients.API().TriggerPermissionsList(ctx, token, tr.ID)
 			if err != nil {
 				return "", err
 			}

--- a/cmd/triggers/triggers_test.go
+++ b/cmd/triggers/triggers_test.go
@@ -44,13 +44,13 @@ func TestTriggersCommand(t *testing.T) {
 	cmd := NewCommand(clients)
 	testutil.MockCmdIO(clients.IO, cmd)
 
-	clientsMock.APIInterface.On("WorkflowsTriggersList", mock.Anything, mock.Anything, mock.Anything).Return([]types.DeployedTrigger{}, "", nil)
+	clientsMock.API.On("WorkflowsTriggersList", mock.Anything, mock.Anything, mock.Anything).Return([]types.DeployedTrigger{}, "", nil)
 
 	err := cmd.ExecuteContext(ctx)
 	if err != nil {
 		assert.Fail(t, "cmd.Execute had unexpected error")
 	}
 
-	clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersList", mock.Anything, mock.Anything, mock.Anything)
+	clientsMock.API.AssertCalled(t, "WorkflowsTriggersList", mock.Anything, mock.Anything, mock.Anything)
 
 }

--- a/cmd/triggers/update.go
+++ b/cmd/triggers/update.go
@@ -134,7 +134,7 @@ func runUpdateCommand(clients *shared.ClientFactory, cmd *cobra.Command) error {
 		TriggerRequest: triggerArg,
 	}
 
-	updatedTrigger, err := clients.APIInterface().WorkflowsTriggersUpdate(ctx, token, updateRequest)
+	updatedTrigger, err := clients.API().WorkflowsTriggersUpdate(ctx, token, updateRequest)
 	if extendedErr, ok := err.(*api.TriggerCreateOrUpdateError); ok {
 		// If the user used --workflow and the creation failed because we were missing the interactivity
 		// context, lets prompt and optionally add it
@@ -149,7 +149,7 @@ func runUpdateCommand(clients *shared.ClientFactory, cmd *cobra.Command) error {
 			if shouldUpdate {
 				// TODO: based on the unit tests, I _think_ this should be the behaviour.. but needs a review.
 				// Assumption is: if trigger update fails due to missing interactivity, we prompt user to tweak their definition to include interactivity, recreate, and if successful, proceed.
-				updatedTrigger, innerErr = clients.APIInterface().WorkflowsTriggersUpdate(ctx, token, updateRequest)
+				updatedTrigger, innerErr = clients.API().WorkflowsTriggersUpdate(ctx, token, updateRequest)
 				if innerErr != nil {
 					return innerErr
 				} else {

--- a/cmd/triggers/update_test.go
+++ b/cmd/triggers/update_test.go
@@ -43,7 +43,7 @@ func TestTriggersUpdateCommand(t *testing.T) {
 				appSelectTeardown = setupMockUpdateAppSelection(installedProdApp)
 				clientsMock.AddDefaultMocks()
 				// Prompt for Trigger ID
-				clientsMock.APIInterface.On("WorkflowsTriggersList", mock.Anything, mock.Anything, mock.Anything).Return(
+				clientsMock.API.On("WorkflowsTriggersList", mock.Anything, mock.Anything, mock.Anything).Return(
 					[]types.DeployedTrigger{{Name: fakeTriggerName, ID: fakeTriggerID, Type: "Shortcut", Workflow: types.TriggerWorkflow{AppID: fakeAppID}}}, "", nil)
 				clientsMock.IO.On("SelectPrompt", mock.Anything, "Choose a trigger:", mock.Anything, mock.Anything).Return(iostreams.SelectPromptResponse{Index: 0, Prompt: true}, nil)
 				// Prompt for trigger definition file
@@ -51,10 +51,10 @@ func TestTriggersUpdateCommand(t *testing.T) {
 				clientsMock.IO.On("SelectPrompt", mock.Anything, "Choose a trigger definition file:", mock.Anything, mock.Anything).Return(iostreams.SelectPromptResponse{Index: 0, Prompt: true}, nil)
 				// Execute update
 				fakeTrigger := createFakeTrigger(fakeTriggerID, fakeTriggerName, fakeAppID, "shortcut")
-				clientsMock.APIInterface.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, mock.Anything).Return(fakeTrigger, nil)
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).Return(types.PermissionEveryone, []string{}, nil).Once()
-				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).Return(types.PermissionEveryone, []string{}, nil).Once()
+				clientsMock.API.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, mock.Anything).Return(fakeTrigger, nil)
+				clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).Return(types.PermissionEveryone, []string{}, nil).Once()
+				clientsMock.API.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+				clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).Return(types.PermissionEveryone, []string{}, nil).Once()
 			},
 			Teardown: func() {
 				appSelectTeardown()
@@ -69,7 +69,7 @@ func TestTriggersUpdateCommand(t *testing.T) {
 						WorkflowAppID: fakeAppID,
 					},
 				}
-				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersUpdate", mock.Anything, mock.Anything, expectedTriggerRequest)
+				clientsMock.API.AssertCalled(t, "WorkflowsTriggersUpdate", mock.Anything, mock.Anything, expectedTriggerRequest)
 			},
 		},
 		"hosted app not installed": {
@@ -111,9 +111,9 @@ func TestTriggersUpdateCommand(t *testing.T) {
 				appSelectTeardown = setupMockUpdateAppSelection(installedProdApp)
 				// TODO: always a) mock out calls and b) call AddDefaultMocks before making any clients.* calls
 				fakeTrigger := createFakeTrigger(fakeTriggerID, fakeTriggerName, fakeAppID, "shortcut")
-				clientsMock.APIInterface.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, mock.Anything).Return(fakeTrigger, nil)
-				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, mock.Anything).Return(fakeTrigger, nil)
+				clientsMock.API.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+				clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.PermissionEveryone, []string{}, nil).Once()
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
@@ -137,7 +137,7 @@ func TestTriggersUpdateCommand(t *testing.T) {
 						WorkflowAppID: fakeAppID,
 					},
 				}
-				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersUpdate", mock.Anything, mock.Anything, expectedTriggerRequest)
+				clientsMock.API.AssertCalled(t, "WorkflowsTriggersUpdate", mock.Anything, mock.Anything, expectedTriggerRequest)
 			},
 		},
 		"only pass --workflow and --trigger-id, with interactivity": {
@@ -147,9 +147,9 @@ func TestTriggersUpdateCommand(t *testing.T) {
 				appSelectTeardown = setupMockUpdateAppSelection(installedProdApp)
 				// TODO: always a) mock out calls and b) call AddDefaultMocks before making any clients.* calls
 				fakeTrigger := createFakeTrigger(fakeTriggerID, fakeTriggerName, fakeAppID, "shortcut")
-				clientsMock.APIInterface.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, mock.Anything).Return(fakeTrigger, nil)
-				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, mock.Anything).Return(fakeTrigger, nil)
+				clientsMock.API.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+				clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.PermissionEveryone, []string{}, nil).Once()
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
@@ -178,7 +178,7 @@ func TestTriggersUpdateCommand(t *testing.T) {
 						},
 					},
 				}
-				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersUpdate", mock.Anything, mock.Anything, expectedTriggerRequest)
+				clientsMock.API.AssertCalled(t, "WorkflowsTriggersUpdate", mock.Anything, mock.Anything, expectedTriggerRequest)
 			},
 		},
 		"only pass --workflow and --trigger-id, with interactivity and custom name": {
@@ -188,9 +188,9 @@ func TestTriggersUpdateCommand(t *testing.T) {
 				appSelectTeardown = setupMockUpdateAppSelection(installedProdApp)
 				// TODO: always a) mock out calls and b) call AddDefaultMocks before making any clients.* calls
 				fakeTrigger := createFakeTrigger(fakeTriggerID, fakeTriggerName, fakeAppID, "shortcut")
-				clientsMock.APIInterface.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, mock.Anything).Return(fakeTrigger, nil)
-				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, mock.Anything).Return(fakeTrigger, nil)
+				clientsMock.API.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+				clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.PermissionEveryone, []string{}, nil).Once()
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
@@ -219,7 +219,7 @@ func TestTriggersUpdateCommand(t *testing.T) {
 						},
 					},
 				}
-				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersUpdate", mock.Anything, mock.Anything, expectedTriggerRequest)
+				clientsMock.API.AssertCalled(t, "WorkflowsTriggersUpdate", mock.Anything, mock.Anything, expectedTriggerRequest)
 			},
 		},
 		"pass all shortcut parameters": {
@@ -229,9 +229,9 @@ func TestTriggersUpdateCommand(t *testing.T) {
 				appSelectTeardown = setupMockUpdateAppSelection(installedProdApp)
 				// TODO: always a) mock out calls and b) call AddDefaultMocks before making any clients.* calls
 				fakeTrigger := createFakeTrigger(fakeTriggerID, "unit tests", fakeAppID, "shortcut")
-				clientsMock.APIInterface.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, mock.Anything).Return(fakeTrigger, nil)
-				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, mock.Anything).Return(fakeTrigger, nil)
+				clientsMock.API.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+				clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.PermissionEveryone, []string{}, nil).Once()
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
@@ -253,7 +253,7 @@ func TestTriggersUpdateCommand(t *testing.T) {
 						WorkflowAppID: fakeAppID,
 					},
 				}
-				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersUpdate", mock.Anything, mock.Anything, expectedTriggerRequest)
+				clientsMock.API.AssertCalled(t, "WorkflowsTriggersUpdate", mock.Anything, mock.Anything, expectedTriggerRequest)
 			},
 		},
 		"api call fails": {
@@ -261,7 +261,7 @@ func TestTriggersUpdateCommand(t *testing.T) {
 			ExpectedErrorStrings: []string{"invalid_auth"},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				appSelectTeardown = setupMockUpdateAppSelection(installedProdApp)
-				clientsMock.APIInterface.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, mock.Anything).Return(types.DeployedTrigger{}, errors.New("invalid_auth"))
+				clientsMock.API.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, mock.Anything).Return(types.DeployedTrigger{}, errors.New("invalid_auth"))
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
 				err := clients.AppClient().SaveDeployed(ctx, fakeApp)
@@ -278,9 +278,9 @@ func TestTriggersUpdateCommand(t *testing.T) {
 				appSelectTeardown = setupMockUpdateAppSelection(installedProdApp)
 				// TODO: always a) mock out calls and b) call AddDefaultMocks before making any clients.* calls
 				fakeTrigger := createFakeTrigger(fakeTriggerID, "name", fakeAppID, "scheduled")
-				clientsMock.APIInterface.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, mock.Anything).Return(fakeTrigger, nil)
-				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, mock.Anything).Return(fakeTrigger, nil)
+				clientsMock.API.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+				clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.PermissionEveryone, []string{}, nil).Once()
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
@@ -312,7 +312,7 @@ func TestTriggersUpdateCommand(t *testing.T) {
 						Schedule:      types.ToRawJSON(`{"start_time":"2020-03-15","frequency":{"type":"daily"}}`),
 					},
 				}
-				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersUpdate", mock.Anything, mock.Anything, expectedTriggerRequest)
+				clientsMock.API.AssertCalled(t, "WorkflowsTriggersUpdate", mock.Anything, mock.Anything, expectedTriggerRequest)
 			},
 		},
 		"--trigger-def, file missing": {
@@ -334,9 +334,9 @@ func TestTriggersUpdateCommand(t *testing.T) {
 			ExpectedErrorStrings: []string{"unexpected end of JSON"},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
 				appSelectTeardown = setupMockUpdateAppSelection(installedProdApp)
-				clientsMock.APIInterface.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, mock.Anything).Return(types.DeployedTrigger{}, nil)
-				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, mock.Anything).Return(types.DeployedTrigger{}, nil)
+				clientsMock.API.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+				clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.PermissionEveryone, []string{}, nil).Once()
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
@@ -415,12 +415,12 @@ func TestTriggersUpdateCommand_MissingParameters(t *testing.T) {
 						Type: "slack#/types/interactivity",
 					},
 				}
-				clientsMock.APIInterface.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, triggerRequestMissingInputs).Return(types.DeployedTrigger{}, extendedErr)
+				clientsMock.API.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, triggerRequestMissingInputs).Return(types.DeployedTrigger{}, extendedErr)
 
 				fakeTrigger := createFakeTrigger(fakeTriggerID, "unit tests", fakeAppID, "shortcut")
-				clientsMock.APIInterface.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, triggerRequestWithInteractivityInputs).Return(fakeTrigger, nil)
-				clientsMock.APIInterface.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
-				clientsMock.APIInterface.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
+				clientsMock.API.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, triggerRequestWithInteractivityInputs).Return(fakeTrigger, nil)
+				clientsMock.API.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).Return([]types.SlackUser{}, nil)
+				clientsMock.API.On("TriggerPermissionsList", mock.Anything, mock.Anything, mock.Anything).
 					Return(types.PermissionEveryone, []string{}, nil).Once()
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
@@ -432,8 +432,8 @@ func TestTriggersUpdateCommand_MissingParameters(t *testing.T) {
 				promptForInteractivityTeardown()
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersUpdate", mock.Anything, mock.Anything, triggerRequestMissingInputs)
-				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersUpdate", mock.Anything, mock.Anything, triggerRequestWithInteractivityInputs)
+				clientsMock.API.AssertCalled(t, "WorkflowsTriggersUpdate", mock.Anything, mock.Anything, triggerRequestMissingInputs)
+				clientsMock.API.AssertCalled(t, "WorkflowsTriggersUpdate", mock.Anything, mock.Anything, triggerRequestWithInteractivityInputs)
 			},
 		},
 		"initial api call fails, missing interactivity, fails on retry": {
@@ -450,9 +450,9 @@ func TestTriggersUpdateCommand_MissingParameters(t *testing.T) {
 						Type: "slack#/types/interactivity",
 					},
 				}
-				clientsMock.APIInterface.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, triggerRequestMissingInputs).Return(types.DeployedTrigger{}, extendedErr)
+				clientsMock.API.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, triggerRequestMissingInputs).Return(types.DeployedTrigger{}, extendedErr)
 
-				clientsMock.APIInterface.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, triggerRequestWithInteractivityInputs).Return(types.DeployedTrigger{}, errors.New("internal_error"))
+				clientsMock.API.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, triggerRequestWithInteractivityInputs).Return(types.DeployedTrigger{}, errors.New("internal_error"))
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
 				err := clients.AppClient().SaveDeployed(ctx, fakeApp)
@@ -463,8 +463,8 @@ func TestTriggersUpdateCommand_MissingParameters(t *testing.T) {
 				promptForInteractivityTeardown()
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersUpdate", mock.Anything, mock.Anything, triggerRequestMissingInputs)
-				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersUpdate", mock.Anything, mock.Anything, triggerRequestWithInteractivityInputs)
+				clientsMock.API.AssertCalled(t, "WorkflowsTriggersUpdate", mock.Anything, mock.Anything, triggerRequestMissingInputs)
+				clientsMock.API.AssertCalled(t, "WorkflowsTriggersUpdate", mock.Anything, mock.Anything, triggerRequestWithInteractivityInputs)
 			},
 		},
 		"initial api call fails, missing a different type": {
@@ -481,7 +481,7 @@ func TestTriggersUpdateCommand_MissingParameters(t *testing.T) {
 						Type: "number",
 					},
 				}
-				clientsMock.APIInterface.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, mock.Anything).Return(types.DeployedTrigger{}, extendedErr)
+				clientsMock.API.On("WorkflowsTriggersUpdate", mock.Anything, mock.Anything, mock.Anything).Return(types.DeployedTrigger{}, extendedErr)
 				// TODO: testing chicken and egg: we need the default mocks in place before we can use any of the `clients` methods
 				clientsMock.AddDefaultMocks()
 				err := clients.AppClient().SaveDeployed(ctx, fakeApp)
@@ -492,7 +492,7 @@ func TestTriggersUpdateCommand_MissingParameters(t *testing.T) {
 				promptForInteractivityTeardown()
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock) {
-				clientsMock.APIInterface.AssertCalled(t, "WorkflowsTriggersUpdate", mock.Anything, mock.Anything, mock.Anything)
+				clientsMock.API.AssertCalled(t, "WorkflowsTriggersUpdate", mock.Anything, mock.Anything, mock.Anything)
 			},
 		},
 	}, func(clients *shared.ClientFactory) *cobra.Command {

--- a/internal/pkg/apps/delete.go
+++ b/internal/pkg/apps/delete.go
@@ -56,7 +56,7 @@ func Delete(ctx context.Context, clients *shared.ClientFactory, log *logger.Logg
 	log.Info("on_apps_delete_app_init")
 
 	// Delete app remotely via Slack API
-	err = clients.APIInterface().DeleteApp(ctx, config.GetContextToken(ctx), app.AppID)
+	err = clients.API().DeleteApp(ctx, config.GetContextToken(ctx), app.AppID)
 	if err != nil {
 		return app, err
 	}
@@ -91,7 +91,7 @@ func getAuthSession(ctx context.Context, clients *shared.ClientFactory, auth typ
 	clients.Config.APIHostResolved = clients.AuthInterface().ResolveAPIHost(ctx, clients.Config.APIHostFlag, &auth)
 	clients.Config.LogstashHostResolved = clients.AuthInterface().ResolveLogstashHost(ctx, clients.Config.APIHostResolved, clients.Config.Version)
 
-	authSession, err := clients.APIInterface().ValidateSession(ctx, token)
+	authSession, err := clients.API().ValidateSession(ctx, token)
 	if err != nil {
 		return ctx, api.AuthSession{}, slackerror.Wrap(err, slackerror.ErrInvalidAuth)
 	}

--- a/internal/pkg/apps/delete_test.go
+++ b/internal/pkg/apps/delete_test.go
@@ -83,11 +83,11 @@ func TestAppsDelete(t *testing.T) {
 			clientsMock := shared.NewClientsMock()
 			clientsMock.AuthInterface.On("ResolveAPIHost", mock.Anything, mock.Anything, mock.Anything).Return("api host")
 			clientsMock.AuthInterface.On("ResolveLogstashHost", mock.Anything, mock.Anything, mock.Anything).Return("logstash host")
-			clientsMock.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{
+			clientsMock.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{
 				TeamName: &tt.auth.TeamDomain,
 				TeamID:   &tt.auth.TeamID,
 			}, nil)
-			clientsMock.APIInterface.On("DeleteApp", mock.Anything, mock.Anything, tt.app.AppID).Return(nil)
+			clientsMock.API.On("DeleteApp", mock.Anything, mock.Anything, tt.app.AppID).Return(nil)
 			clientsMock.AddDefaultMocks()
 
 			clients := shared.NewClientFactory(clientsMock.MockClientFactory())
@@ -110,7 +110,7 @@ func TestAppsDelete(t *testing.T) {
 			app, err := Delete(ctx, clients, logger.New(nil), tt.app.TeamDomain, tt.app, tt.auth)
 			require.NoError(t, err)
 			assert.Equal(t, tt.app, app)
-			clientsMock.APIInterface.AssertCalled(
+			clientsMock.API.AssertCalled(
 				t,
 				"DeleteApp",
 				mock.Anything,

--- a/internal/pkg/apps/install.go
+++ b/internal/pkg/apps/install.go
@@ -59,7 +59,7 @@ func Install(ctx context.Context, clients *shared.ClientFactory, log *logger.Log
 	}
 
 	// Get the token for the authenticated workspace
-	apiInterface := clients.APIInterface()
+	apiInterface := clients.API()
 	token := auth.Token
 	authSession, err := apiInterface.ValidateSession(ctx, token)
 	if err != nil {
@@ -144,7 +144,7 @@ func Install(ctx context.Context, clients *shared.ClientFactory, log *logger.Log
 		if err != nil {
 			return types.App{}, "", err
 		}
-		upstream, err := clients.APIInterface().ExportAppManifest(ctx, auth.Token, app.AppID)
+		upstream, err := clients.API().ExportAppManifest(ctx, auth.Token, app.AppID)
 		if err != nil {
 			return types.App{}, "", err
 		}
@@ -259,10 +259,10 @@ func printNonSuccessInstallState(ctx context.Context, clients *shared.ClientFact
 func validateManifestForInstall(ctx context.Context, clients *shared.ClientFactory, app types.App, appManifest types.AppManifest) error {
 	var token = config.GetContextToken(ctx)
 
-	validationResult, err := clients.APIInterface().ValidateAppManifest(ctx, token, appManifest, app.AppID)
+	validationResult, err := clients.API().ValidateAppManifest(ctx, token, appManifest, app.AppID)
 
 	if retryValidate := manifest.HandleConnectorNotInstalled(ctx, clients, token, err); retryValidate {
-		validationResult, err = clients.APIInterface().ValidateAppManifest(ctx, token, appManifest, app.AppID)
+		validationResult, err = clients.API().ValidateAppManifest(ctx, token, appManifest, app.AppID)
 	}
 
 	if err := manifest.HandleConnectorApprovalRequired(ctx, clients, token, err); err != nil {
@@ -344,7 +344,7 @@ func InstallLocalApp(ctx context.Context, clients *shared.ClientFactory, orgGran
 		return app, api.DeveloperAppInstallResult{}, "", nil
 	}
 
-	apiInterface := clients.APIInterface()
+	apiInterface := clients.API()
 	token := auth.Token
 	authSession, err := apiInterface.ValidateSession(ctx, token)
 	if err != nil {
@@ -438,7 +438,7 @@ func InstallLocalApp(ctx context.Context, clients *shared.ClientFactory, orgGran
 		if err != nil {
 			return types.App{}, api.DeveloperAppInstallResult{}, "", err
 		}
-		upstream, err := clients.APIInterface().ExportAppManifest(ctx, auth.Token, app.AppID)
+		upstream, err := clients.API().ExportAppManifest(ctx, auth.Token, app.AppID)
 		if err != nil {
 			return types.App{}, api.DeveloperAppInstallResult{}, "", err
 		}
@@ -562,7 +562,7 @@ func configureHostedManifest(
 	if manifest.Settings.Interactivity == nil {
 		manifest.Settings.Interactivity = &types.ManifestInteractivity{}
 	}
-	host := clients.APIInterface().Host()
+	host := clients.API().Host()
 	manifest.Settings.Interactivity.IsEnabled = true
 	manifest.Settings.Interactivity.MessageMenuOptionsURL = host
 	manifest.Settings.Interactivity.RequestURL = host
@@ -626,7 +626,7 @@ func updateIcon(ctx context.Context, clients *shared.ClientFactory, iconPath, ap
 
 	// var iconResp apiclient.IconResult
 	var err error
-	_, err = clients.APIInterface().Icon(ctx, clients.Fs, token, appID, iconPath)
+	_, err = clients.API().Icon(ctx, clients.Fs, token, appID, iconPath)
 	if err != nil {
 		// TODO: separate the icon upload into a different function because if an error is returned
 		// the new app_id might be ignored and next time we'll create another app.
@@ -712,7 +712,7 @@ func shouldUpdateManifest(ctx context.Context, clients *shared.ClientFactory, ap
 	if err != nil {
 		return false, err
 	}
-	upstream, err := clients.APIInterface().ExportAppManifest(ctx, auth.Token, app.AppID)
+	upstream, err := clients.API().ExportAppManifest(ctx, auth.Token, app.AppID)
 	if err != nil {
 		return false, err
 	}

--- a/internal/pkg/apps/install_test.go
+++ b/internal/pkg/apps/install_test.go
@@ -459,7 +459,7 @@ func TestInstall(t *testing.T) {
 			clientsMock := shared.NewClientsMock()
 			clientsMock.IO.On("IsTTY").Return(tt.mockIsTTY)
 			clientsMock.AddDefaultMocks()
-			clientsMock.APIInterface.On(
+			clientsMock.API.On(
 				"CreateApp",
 				mock.Anything,
 				mock.Anything,
@@ -469,7 +469,7 @@ func TestInstall(t *testing.T) {
 				tt.mockAPICreate,
 				tt.mockAPICreateError,
 			)
-			clientsMock.APIInterface.On(
+			clientsMock.API.On(
 				"DeveloperAppInstall",
 				mock.Anything,
 				mock.Anything,
@@ -484,7 +484,7 @@ func TestInstall(t *testing.T) {
 				tt.mockAPIInstallState,
 				tt.mockAPIInstallError,
 			)
-			clientsMock.APIInterface.On(
+			clientsMock.API.On(
 				"ExportAppManifest",
 				mock.Anything,
 				mock.Anything,
@@ -493,7 +493,7 @@ func TestInstall(t *testing.T) {
 				api.ExportAppResult{},
 				nil,
 			)
-			clientsMock.APIInterface.On(
+			clientsMock.API.On(
 				"ValidateAppManifest",
 				mock.Anything,
 				mock.Anything,
@@ -503,7 +503,7 @@ func TestInstall(t *testing.T) {
 				api.ValidateAppManifestResult{},
 				nil,
 			)
-			clientsMock.APIInterface.On(
+			clientsMock.API.On(
 				"UpdateApp",
 				mock.Anything,
 				mock.Anything,
@@ -515,7 +515,7 @@ func TestInstall(t *testing.T) {
 				tt.mockAPIUpdate,
 				tt.mockAPIUpdateError,
 			)
-			clientsMock.APIInterface.On(
+			clientsMock.API.On(
 				"ValidateSession",
 				mock.Anything,
 				mock.Anything,
@@ -593,7 +593,7 @@ func TestInstall(t *testing.T) {
 			assert.Equal(t, tt.expectedInstallState, state)
 			assert.Equal(t, tt.expectedApp, app)
 			if tt.expectedUpdate {
-				clientsMock.APIInterface.AssertCalled(
+				clientsMock.API.AssertCalled(
 					t,
 					"UpdateApp",
 					mock.Anything,
@@ -603,9 +603,9 @@ func TestInstall(t *testing.T) {
 					mock.Anything,
 					mock.Anything,
 				)
-				clientsMock.APIInterface.AssertNotCalled(t, "CreateApp")
+				clientsMock.API.AssertNotCalled(t, "CreateApp")
 			} else if tt.expectedCreate {
-				clientsMock.APIInterface.AssertCalled(
+				clientsMock.API.AssertCalled(
 					t,
 					"CreateApp",
 					mock.Anything,
@@ -613,9 +613,9 @@ func TestInstall(t *testing.T) {
 					mock.Anything,
 					mock.Anything,
 				)
-				clientsMock.APIInterface.AssertNotCalled(t, "UpdateApp")
+				clientsMock.API.AssertNotCalled(t, "UpdateApp")
 			}
-			for _, call := range clientsMock.APIInterface.Calls {
+			for _, call := range clientsMock.API.Calls {
 				args := call.Arguments
 				switch call.Method {
 				case "CreateApp":
@@ -902,7 +902,7 @@ func TestInstallLocalApp(t *testing.T) {
 			clientsMock := shared.NewClientsMock()
 			clientsMock.IO.On("IsTTY").Return(tt.mockIsTTY)
 			clientsMock.AddDefaultMocks()
-			clientsMock.APIInterface.On(
+			clientsMock.API.On(
 				"CreateApp",
 				mock.Anything,
 				mock.Anything,
@@ -912,7 +912,7 @@ func TestInstallLocalApp(t *testing.T) {
 				tt.mockAPICreate,
 				tt.mockAPICreateError,
 			)
-			clientsMock.APIInterface.On(
+			clientsMock.API.On(
 				"DeveloperAppInstall",
 				mock.Anything,
 				mock.Anything,
@@ -927,7 +927,7 @@ func TestInstallLocalApp(t *testing.T) {
 				tt.mockAPIInstallState,
 				tt.mockAPIInstallError,
 			)
-			clientsMock.APIInterface.On(
+			clientsMock.API.On(
 				"ExportAppManifest",
 				mock.Anything,
 				mock.Anything,
@@ -936,7 +936,7 @@ func TestInstallLocalApp(t *testing.T) {
 				api.ExportAppResult{Manifest: tt.mockManifest},
 				nil,
 			)
-			clientsMock.APIInterface.On(
+			clientsMock.API.On(
 				"ValidateAppManifest",
 				mock.Anything,
 				mock.Anything,
@@ -946,7 +946,7 @@ func TestInstallLocalApp(t *testing.T) {
 				api.ValidateAppManifestResult{},
 				nil,
 			)
-			clientsMock.APIInterface.On(
+			clientsMock.API.On(
 				"UpdateApp",
 				mock.Anything,
 				mock.Anything,
@@ -958,7 +958,7 @@ func TestInstallLocalApp(t *testing.T) {
 				tt.mockAPIUpdate,
 				tt.mockAPIUpdateError,
 			)
-			clientsMock.APIInterface.On(
+			clientsMock.API.On(
 				"ValidateSession",
 				mock.Anything,
 				mock.Anything,
@@ -1027,7 +1027,7 @@ func TestInstallLocalApp(t *testing.T) {
 			assert.Equal(t, tt.expectedInstallState, state)
 			assert.Equal(t, tt.expectedApp, app)
 			if tt.expectedUpdate {
-				clientsMock.APIInterface.AssertCalled(
+				clientsMock.API.AssertCalled(
 					t,
 					"UpdateApp",
 					mock.Anything,
@@ -1037,9 +1037,9 @@ func TestInstallLocalApp(t *testing.T) {
 					mock.Anything,
 					mock.Anything,
 				)
-				clientsMock.APIInterface.AssertNotCalled(t, "CreateApp")
+				clientsMock.API.AssertNotCalled(t, "CreateApp")
 			} else if tt.expectedCreate {
-				clientsMock.APIInterface.AssertCalled(
+				clientsMock.API.AssertCalled(
 					t,
 					"CreateApp",
 					mock.Anything,
@@ -1047,9 +1047,9 @@ func TestInstallLocalApp(t *testing.T) {
 					mock.Anything,
 					mock.Anything,
 				)
-				clientsMock.APIInterface.AssertNotCalled(t, "UpdateApp")
+				clientsMock.API.AssertNotCalled(t, "UpdateApp")
 			}
-			for _, call := range clientsMock.APIInterface.Calls {
+			for _, call := range clientsMock.API.Calls {
 				args := call.Arguments
 				switch call.Method {
 				case "CreateApp":
@@ -1147,7 +1147,7 @@ func TestValidateManifestForInstall(t *testing.T) {
 			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := shared.NewClientsMock()
 			tt.setup(clientsMock)
-			clientsMock.APIInterface.On("ValidateAppManifest", mock.Anything, mock.Anything, mock.Anything, tt.app.AppID).
+			clientsMock.API.On("ValidateAppManifest", mock.Anything, mock.Anything, mock.Anything, tt.app.AppID).
 				Return(tt.result, tt.err)
 			clients := shared.NewClientFactory(clientsMock.MockClientFactory())
 

--- a/internal/pkg/apps/list.go
+++ b/internal/pkg/apps/list.go
@@ -122,7 +122,7 @@ func FetchAppInstallStates(ctx context.Context, clients *shared.ClientFactory, a
 			continue
 		}
 
-		apiClient := clients.APIInterface()
+		apiClient := clients.API()
 		if auth.APIHost != nil {
 			// Most internal/api methods do not explicitly require the host to be set.
 			// Rather, they rely implicitly on host being set on the apiClient when the instance

--- a/internal/pkg/apps/list_test.go
+++ b/internal/pkg/apps/list_test.go
@@ -98,7 +98,7 @@ func TestAppsList_FetchInstallStates_NoAuthsShouldReturnUnknownState(t *testing.
 
 	apps, err := FetchAppInstallStates(ctx, clients, []types.App{team1DeployedApp, team2LocalApp})
 	require.NoError(t, err)
-	clientsMock.APIInterface.AssertNotCalled(t, "GetAppStatus")
+	clientsMock.API.AssertNotCalled(t, "GetAppStatus")
 
 	require.Contains(t, apps, team1DeployedApp)
 	require.Contains(t, apps, team2LocalApp)
@@ -121,7 +121,7 @@ func TestAppsList_FetchInstallStates_HasEnterpriseApp_HasEnterpriseAuth(t *testi
 	clients := shared.NewClientFactory(clientsMock.MockClientFactory())
 
 	// Return installed true
-	clientsMock.APIInterface.On("GetAppStatus", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+	clientsMock.API.On("GetAppStatus", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 		api.GetAppStatusResult{
 			Apps: []api.AppStatusResultAppInfo{{AppID: team1AppID, Installed: true}},
 		}, nil)
@@ -143,11 +143,11 @@ func TestAppsList_FetchInstallStates_TokenFlag(t *testing.T) {
 	clientsMock.AuthInterface.On("AuthWithToken", mock.Anything, team2Token).
 		Return(authTeam2, nil)
 
-	clientsMock.APIInterface.On("GetAppStatus", mock.Anything, team1Token, []string{team1DeployedApp.AppID}, team1TeamID).Return(
+	clientsMock.API.On("GetAppStatus", mock.Anything, team1Token, []string{team1DeployedApp.AppID}, team1TeamID).Return(
 		api.GetAppStatusResult{
 			Apps: []api.AppStatusResultAppInfo{{AppID: team1DeployedApp.AppID, Installed: true}},
 		}, nil)
-	clientsMock.APIInterface.On("GetAppStatus", mock.Anything, team2Token, []string{team2LocalApp.AppID}, team2TeamID).Return(
+	clientsMock.API.On("GetAppStatus", mock.Anything, team2Token, []string{team2LocalApp.AppID}, team2TeamID).Return(
 		api.GetAppStatusResult{
 			Apps: []api.AppStatusResultAppInfo{{AppID: team2LocalApp.AppID, Installed: false}},
 		}, nil)
@@ -160,7 +160,7 @@ func TestAppsList_FetchInstallStates_TokenFlag(t *testing.T) {
 	apps, err := FetchAppInstallStates(ctx, clients, []types.App{team1DeployedApp, team2LocalApp})
 	require.NoError(t, err)
 	require.Len(t, apps, 2)
-	clientsMock.APIInterface.AssertNumberOfCalls(t, "GetAppStatus", 2)
+	clientsMock.API.AssertNumberOfCalls(t, "GetAppStatus", 2)
 
 	for _, app := range apps {
 		switch app.AppID {

--- a/internal/pkg/apps/uninstall.go
+++ b/internal/pkg/apps/uninstall.go
@@ -56,7 +56,7 @@ func Uninstall(ctx context.Context, clients *shared.ClientFactory, log *logger.L
 
 	// Uninstall the app
 	log.Info("on_apps_uninstall_app_init")
-	err = clients.APIInterface().UninstallApp(ctx, token, app.AppID, app.TeamID)
+	err = clients.API().UninstallApp(ctx, token, app.AppID, app.TeamID)
 	if err != nil {
 		return app, err
 	}

--- a/internal/pkg/auth/login.go
+++ b/internal/pkg/auth/login.go
@@ -37,7 +37,7 @@ const InvalidNoPromptFlags = "Invalid arguments, both --ticket and --challenge f
 
 // LoginWithClients ...
 func LoginWithClients(ctx context.Context, clients *shared.ClientFactory, userToken string, noRotation bool) (auth types.SlackAuth, credentialsPath string, err error) {
-	return Login(ctx, clients.APIInterface(), clients.AuthInterface(), clients.IO, userToken, noRotation)
+	return Login(ctx, clients.API(), clients.AuthInterface(), clients.IO, userToken, noRotation)
 }
 
 // Login takes the user through the Slack CLI login process
@@ -250,11 +250,11 @@ func LoginNoPrompt(ctx context.Context, clients *shared.ClientFactory, ticketArg
 
 	// existing ticket request, try to exchange
 	if ticketArg != "" && challengeCodeArg != "" {
-		authExchangeRes, err := clients.APIInterface().ExchangeAuthTicket(ctx, ticketArg, challengeCodeArg, version.Get())
+		authExchangeRes, err := clients.API().ExchangeAuthTicket(ctx, ticketArg, challengeCodeArg, version.Get())
 		if err != nil || !authExchangeRes.IsReady {
 			return types.SlackAuth{}, "", err
 		}
-		savedAuth, credentialsPath, err := saveNewAuth(ctx, clients.APIInterface(), clients.AuthInterface(), authExchangeRes, noRotation)
+		savedAuth, credentialsPath, err := saveNewAuth(ctx, clients.API(), clients.AuthInterface(), authExchangeRes, noRotation)
 		if err != nil {
 			return types.SlackAuth{}, "", err
 		}
@@ -263,7 +263,7 @@ func LoginNoPrompt(ctx context.Context, clients *shared.ClientFactory, ticketArg
 
 	// brand new login
 	if ticketArg == "" && challengeCodeArg == "" {
-		_, err := requestAuthTicket(ctx, clients.APIInterface(), clients.IO, noRotation)
+		_, err := requestAuthTicket(ctx, clients.API(), clients.IO, noRotation)
 		if err != nil {
 			return types.SlackAuth{}, "", err
 		}

--- a/internal/pkg/datastore/bulk_delete.go
+++ b/internal/pkg/datastore/bulk_delete.go
@@ -31,7 +31,7 @@ func BulkDelete(ctx context.Context, clients *shared.ClientFactory, log *logger.
 	// Get auth token
 	var token = config.GetContextToken(ctx)
 
-	deleteResult, err := clients.APIInterface().AppsDatastoreBulkDelete(ctx, token, request)
+	deleteResult, err := clients.API().AppsDatastoreBulkDelete(ctx, token, request)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/datastore/bulk_delete_test.go
+++ b/internal/pkg/datastore/bulk_delete_test.go
@@ -62,7 +62,7 @@ func TestDatastoreBulkDeleteArguments(t *testing.T) {
 			log := logger.Logger{
 				Data: map[string]interface{}{},
 			}
-			clientsMock.APIInterface.On("AppsDatastoreBulkDelete", mock.Anything, mock.Anything, tt.Query).
+			clientsMock.API.On("AppsDatastoreBulkDelete", mock.Anything, mock.Anything, tt.Query).
 				Return(tt.Results, nil)
 			client := shared.NewClientFactory(clientsMock.MockClientFactory())
 

--- a/internal/pkg/datastore/bulk_get.go
+++ b/internal/pkg/datastore/bulk_get.go
@@ -31,7 +31,7 @@ func BulkGet(ctx context.Context, clients *shared.ClientFactory, log *logger.Log
 	// Get auth token
 	var token = config.GetContextToken(ctx)
 
-	getResult, err := clients.APIInterface().AppsDatastoreBulkGet(ctx, token, request)
+	getResult, err := clients.API().AppsDatastoreBulkGet(ctx, token, request)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/datastore/bulk_get_test.go
+++ b/internal/pkg/datastore/bulk_get_test.go
@@ -63,7 +63,7 @@ func TestDatastoreBulkGetArguments(t *testing.T) {
 			log := logger.Logger{
 				Data: map[string]interface{}{},
 			}
-			clientsMock.APIInterface.On("AppsDatastoreBulkGet", mock.Anything, mock.Anything, tt.Query).
+			clientsMock.API.On("AppsDatastoreBulkGet", mock.Anything, mock.Anything, tt.Query).
 				Return(tt.Results, nil)
 			client := shared.NewClientFactory(clientsMock.MockClientFactory())
 

--- a/internal/pkg/datastore/bulk_put.go
+++ b/internal/pkg/datastore/bulk_put.go
@@ -31,7 +31,7 @@ func BulkPut(ctx context.Context, clients *shared.ClientFactory, log *logger.Log
 	// Get auth token
 	var token = config.GetContextToken(ctx)
 
-	bulkPutResult, err := clients.APIInterface().AppsDatastoreBulkPut(ctx, token, request)
+	bulkPutResult, err := clients.API().AppsDatastoreBulkPut(ctx, token, request)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/datastore/bulk_put_test.go
+++ b/internal/pkg/datastore/bulk_put_test.go
@@ -70,7 +70,7 @@ func TestDatastoreBulkPutArguments(t *testing.T) {
 			log := logger.Logger{
 				Data: map[string]interface{}{},
 			}
-			clientsMock.APIInterface.On("AppsDatastoreBulkPut", mock.Anything, mock.Anything, tt.Query).
+			clientsMock.API.On("AppsDatastoreBulkPut", mock.Anything, mock.Anything, tt.Query).
 				Return(tt.Results, nil)
 			client := shared.NewClientFactory(clientsMock.MockClientFactory())
 

--- a/internal/pkg/datastore/delete.go
+++ b/internal/pkg/datastore/delete.go
@@ -31,7 +31,7 @@ func Delete(ctx context.Context, clients *shared.ClientFactory, log *logger.Logg
 	// Get auth token
 	var token = config.GetContextToken(ctx)
 
-	deleteResult, err := clients.APIInterface().AppsDatastoreDelete(ctx, token, request)
+	deleteResult, err := clients.API().AppsDatastoreDelete(ctx, token, request)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/datastore/delete_test.go
+++ b/internal/pkg/datastore/delete_test.go
@@ -51,7 +51,7 @@ func TestDatastoreDeleteArguments(t *testing.T) {
 			log := logger.Logger{
 				Data: map[string]interface{}{},
 			}
-			clientsMock.APIInterface.On("AppsDatastoreDelete", mock.Anything, mock.Anything, tt.Query).
+			clientsMock.API.On("AppsDatastoreDelete", mock.Anything, mock.Anything, tt.Query).
 				Return(tt.Results, nil)
 			client := shared.NewClientFactory(clientsMock.MockClientFactory())
 

--- a/internal/pkg/datastore/get.go
+++ b/internal/pkg/datastore/get.go
@@ -31,7 +31,7 @@ func Get(ctx context.Context, clients *shared.ClientFactory, log *logger.Logger,
 	// Get auth token
 	var token = config.GetContextToken(ctx)
 
-	getResult, err := clients.APIInterface().AppsDatastoreGet(ctx, token, request)
+	getResult, err := clients.API().AppsDatastoreGet(ctx, token, request)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/datastore/get_test.go
+++ b/internal/pkg/datastore/get_test.go
@@ -51,7 +51,7 @@ func TestDatastoreGetArguments(t *testing.T) {
 			log := logger.Logger{
 				Data: map[string]interface{}{},
 			}
-			clientsMock.APIInterface.On("AppsDatastoreGet", mock.Anything, mock.Anything, tt.Query).
+			clientsMock.API.On("AppsDatastoreGet", mock.Anything, mock.Anything, tt.Query).
 				Return(tt.Results, nil)
 			client := shared.NewClientFactory(clientsMock.MockClientFactory())
 

--- a/internal/pkg/datastore/put.go
+++ b/internal/pkg/datastore/put.go
@@ -31,7 +31,7 @@ func Put(ctx context.Context, clients *shared.ClientFactory, log *logger.Logger,
 	// Get auth token
 	var token = config.GetContextToken(ctx)
 
-	putResult, err := clients.APIInterface().AppsDatastorePut(ctx, token, request)
+	putResult, err := clients.API().AppsDatastorePut(ctx, token, request)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/datastore/put_test.go
+++ b/internal/pkg/datastore/put_test.go
@@ -51,7 +51,7 @@ func TestDatastorePutArguments(t *testing.T) {
 			log := logger.Logger{
 				Data: map[string]interface{}{},
 			}
-			clientsMock.APIInterface.On("AppsDatastorePut", mock.Anything, mock.Anything, tt.Query).
+			clientsMock.API.On("AppsDatastorePut", mock.Anything, mock.Anything, tt.Query).
 				Return(tt.Results, nil)
 			client := shared.NewClientFactory(clientsMock.MockClientFactory())
 

--- a/internal/pkg/datastore/query.go
+++ b/internal/pkg/datastore/query.go
@@ -31,7 +31,7 @@ func Query(ctx context.Context, clients *shared.ClientFactory, log *logger.Logge
 	// Get auth token
 	var token = config.GetContextToken(ctx)
 
-	queryResult, err := clients.APIInterface().AppsDatastoreQuery(ctx, token, request)
+	queryResult, err := clients.API().AppsDatastoreQuery(ctx, token, request)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/datastore/query_test.go
+++ b/internal/pkg/datastore/query_test.go
@@ -109,7 +109,7 @@ func TestDatastoreQueryArguments(t *testing.T) {
 			log := logger.Logger{
 				Data: map[string]interface{}{},
 			}
-			clientsMock.APIInterface.On("AppsDatastoreQuery", mock.Anything, mock.Anything, tt.Query).
+			clientsMock.API.On("AppsDatastoreQuery", mock.Anything, mock.Anything, tt.Query).
 				Return(tt.Results, nil)
 			client := shared.NewClientFactory(clientsMock.MockClientFactory())
 

--- a/internal/pkg/datastore/update.go
+++ b/internal/pkg/datastore/update.go
@@ -31,7 +31,7 @@ func Update(ctx context.Context, clients *shared.ClientFactory, log *logger.Logg
 	// Get auth token
 	var token = config.GetContextToken(ctx)
 
-	updateResult, err := clients.APIInterface().AppsDatastoreUpdate(ctx, token, request)
+	updateResult, err := clients.API().AppsDatastoreUpdate(ctx, token, request)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/pkg/datastore/update_test.go
+++ b/internal/pkg/datastore/update_test.go
@@ -51,7 +51,7 @@ func TestDatastoreUpdateArguments(t *testing.T) {
 			log := logger.Logger{
 				Data: map[string]interface{}{},
 			}
-			clientsMock.APIInterface.On("AppsDatastoreUpdate", mock.Anything, mock.Anything, tt.Query).
+			clientsMock.API.On("AppsDatastoreUpdate", mock.Anything, mock.Anything, tt.Query).
 				Return(tt.Results, nil)
 			client := shared.NewClientFactory(clientsMock.MockClientFactory())
 

--- a/internal/pkg/manifest/validate.go
+++ b/internal/pkg/manifest/validate.go
@@ -40,7 +40,7 @@ func ManifestValidate(ctx context.Context, clients *shared.ClientFactory, log *l
 		return nil, nil, slackerror.New(slackerror.ErrAuthToken)
 	}
 
-	_, err := clients.APIInterface().ValidateSession(ctx, token)
+	_, err := clients.API().ValidateSession(ctx, token)
 	if err != nil {
 		return nil, nil, slackerror.New(slackerror.ErrAuthToken).WithRootCause(err)
 	}
@@ -51,10 +51,10 @@ func ManifestValidate(ctx context.Context, clients *shared.ClientFactory, log *l
 	}
 
 	// validate the manifest
-	validationResult, err := clients.APIInterface().ValidateAppManifest(ctx, token, slackManifest.AppManifest, app.AppID)
+	validationResult, err := clients.API().ValidateAppManifest(ctx, token, slackManifest.AppManifest, app.AppID)
 
 	if retryValidate := HandleConnectorNotInstalled(ctx, clients, token, err); retryValidate {
-		validationResult, err = clients.APIInterface().ValidateAppManifest(ctx, token, slackManifest.AppManifest, app.AppID)
+		validationResult, err = clients.API().ValidateAppManifest(ctx, token, slackManifest.AppManifest, app.AppID)
 	}
 
 	if err := HandleConnectorApprovalRequired(ctx, clients, token, err); err != nil {
@@ -82,7 +82,7 @@ func HandleConnectorNotInstalled(ctx context.Context, clients *shared.ClientFact
 		if detail.Code == slackerror.ErrConnectorNotInstalled {
 			attemptInstall = true
 			clients.IO.PrintDebug(ctx, "Attempting to install connector app: %s", detail.RelatedComponent)
-			_, err := clients.APIInterface().CertifiedAppInstall(ctx, token, detail.RelatedComponent)
+			_, err := clients.API().CertifiedAppInstall(ctx, token, detail.RelatedComponent)
 			if err != nil {
 				clients.IO.PrintDebug(ctx, "Error installing connector app: %s", detail.RelatedComponent)
 			}
@@ -155,7 +155,7 @@ func attemptConnectorAppsApprovalRequests(ctx context.Context, clients *shared.C
 
 	for _, errorDetail := range approvalRequiredErrorDetails {
 		// Passing in an empty string for team_id here, meaning connectors will be requested at the org level
-		_, err := clients.APIInterface().RequestAppApproval(ctx, token, errorDetail.RelatedComponent, "", reason, "", []string{})
+		_, err := clients.API().RequestAppApproval(ctx, token, errorDetail.RelatedComponent, "", reason, "", []string{})
 		if err != nil {
 			clients.IO.PrintDebug(ctx, "Error requesting approval for %s", errorDetail.RelatedComponent)
 			return err

--- a/internal/pkg/manifest/validate_test.go
+++ b/internal/pkg/manifest/validate_test.go
@@ -51,7 +51,7 @@ func Test_ManifestValidate_Success(t *testing.T) {
 		ctx, clients, clientsMock, log, appMock, authMock := setupCommonMocks(t)
 
 		// Mock manifest validation api result with no error
-		clientsMock.APIInterface.On("ValidateAppManifest", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.ValidateAppManifestResult{}, nil)
+		clientsMock.API.On("ValidateAppManifest", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.ValidateAppManifestResult{}, nil)
 
 		// Test
 		logEvent, _, err := ManifestValidate(ctx, clients, log, appMock, authMock.Token)
@@ -67,7 +67,7 @@ func Test_ManifestValidate_Warnings(t *testing.T) {
 		ctx, clients, clientsMock, log, appMock, authMock := setupCommonMocks(t)
 
 		// Mock manifest validation api result with no error
-		clientsMock.APIInterface.On("ValidateAppManifest", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.ValidateAppManifestResult{
+		clientsMock.API.On("ValidateAppManifest", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.ValidateAppManifestResult{
 			Warnings: slackerror.Warnings{
 				slackerror.Warning{
 					Code: "dummy warning",
@@ -91,7 +91,7 @@ func Test_ManifestValidate_Error(t *testing.T) {
 		ctx, clients, clientsMock, log, appMock, authMock := setupCommonMocks(t)
 
 		// Mock manifest validation api result with an error
-		clientsMock.APIInterface.On("ValidateAppManifest", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+		clientsMock.API.On("ValidateAppManifest", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 			api.ValidateAppManifestResult{},
 			slackerror.New("a dummy error").WithDetails(slackerror.ErrorDetails{
 				slackerror.ErrorDetail{
@@ -112,7 +112,7 @@ func Test_ManifestValidate_Error_ErrConnectorNotInstalled(t *testing.T) {
 		ctx, clients, clientsMock, log, appMock, authMock := setupCommonMocks(t)
 
 		// Mock manifest validation api result with an error and error details
-		clientsMock.APIInterface.On("ValidateAppManifest", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.ValidateAppManifestResult{
+		clientsMock.API.On("ValidateAppManifest", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.ValidateAppManifestResult{
 			Warnings: nil,
 		}, slackerror.New("a dummy error").WithDetails(slackerror.ErrorDetails{
 			slackerror.ErrorDetail{
@@ -130,7 +130,7 @@ func Test_ManifestValidate_Error_ErrConnectorNotInstalled(t *testing.T) {
 		}))
 
 		// Mock CertifiedAppInstall method success
-		clientsMock.APIInterface.On("CertifiedAppInstall", mock.Anything, authMock.Token, mock.Anything).Return(api.CertifiedInstallResult{}, nil)
+		clientsMock.API.On("CertifiedAppInstall", mock.Anything, authMock.Token, mock.Anything).Return(api.CertifiedInstallResult{}, nil)
 
 		// Test
 		_, _, err := ManifestValidate(ctx, clients, log, appMock, authMock.Token)
@@ -140,10 +140,10 @@ func Test_ManifestValidate_Error_ErrConnectorNotInstalled(t *testing.T) {
 		// even after successful CertifiedAppInstall call.
 		assert.Error(t, err)
 
-		clientsMock.APIInterface.AssertCalled(t, "CertifiedAppInstall", mock.Anything, authMock.Token, "A12345")
-		clientsMock.APIInterface.AssertCalled(t, "CertifiedAppInstall", mock.Anything, authMock.Token, "A56789")
-		clientsMock.APIInterface.AssertNumberOfCalls(t, "CertifiedAppInstall", 2)
-		clientsMock.APIInterface.AssertNumberOfCalls(t, "ValidateAppManifest", 2)
+		clientsMock.API.AssertCalled(t, "CertifiedAppInstall", mock.Anything, authMock.Token, "A12345")
+		clientsMock.API.AssertCalled(t, "CertifiedAppInstall", mock.Anything, authMock.Token, "A56789")
+		clientsMock.API.AssertNumberOfCalls(t, "CertifiedAppInstall", 2)
+		clientsMock.API.AssertNumberOfCalls(t, "ValidateAppManifest", 2)
 	})
 }
 
@@ -175,15 +175,15 @@ func Test_HandleConnectorApprovalRequired(t *testing.T) {
 
 		clientsMock.IO.On("ConfirmPrompt", mock.Anything, mock.Anything, mock.Anything).Return(true, nil)
 		clientsMock.IO.On("InputPrompt", mock.Anything, mock.Anything, mock.Anything).Return(testReason, nil)
-		clientsMock.APIInterface.On("RequestAppApproval", mock.Anything, authMock.Token, mock.Anything, mock.Anything, testReason, mock.Anything, mock.Anything).Return(api.AppsApprovalsRequestsCreateResult{}, nil)
+		clientsMock.API.On("RequestAppApproval", mock.Anything, authMock.Token, mock.Anything, mock.Anything, testReason, mock.Anything, mock.Anything).Return(api.AppsApprovalsRequestsCreateResult{}, nil)
 
 		// Test
 		err := HandleConnectorApprovalRequired(ctx, clients, authMock.Token, testErr)
 
 		assert.NoError(t, err)
-		clientsMock.APIInterface.AssertCalled(t, "RequestAppApproval", mock.Anything, authMock.Token, "A12345", mock.Anything, testReason, mock.Anything, mock.Anything)
-		clientsMock.APIInterface.AssertCalled(t, "RequestAppApproval", mock.Anything, authMock.Token, "A56789", mock.Anything, testReason, mock.Anything, mock.Anything)
-		clientsMock.APIInterface.AssertNumberOfCalls(t, "RequestAppApproval", 2)
+		clientsMock.API.AssertCalled(t, "RequestAppApproval", mock.Anything, authMock.Token, "A12345", mock.Anything, testReason, mock.Anything, mock.Anything)
+		clientsMock.API.AssertCalled(t, "RequestAppApproval", mock.Anything, authMock.Token, "A56789", mock.Anything, testReason, mock.Anything, mock.Anything)
+		clientsMock.API.AssertNumberOfCalls(t, "RequestAppApproval", 2)
 		assert.Equal(t, len(testErr.Details), 1)
 	})
 
@@ -204,7 +204,7 @@ func Test_HandleConnectorApprovalRequired(t *testing.T) {
 		err := HandleConnectorApprovalRequired(ctx, clients, authMock.Token, testErr)
 
 		assert.NoError(t, err)
-		clientsMock.APIInterface.AssertNumberOfCalls(t, "RequestAppApproval", 0)
+		clientsMock.API.AssertNumberOfCalls(t, "RequestAppApproval", 0)
 		assert.Equal(t, len(testErr.Details), 0)
 	})
 
@@ -221,13 +221,13 @@ func Test_HandleConnectorApprovalRequired(t *testing.T) {
 
 		clientsMock.IO.On("ConfirmPrompt", mock.Anything, mock.Anything, mock.Anything).Return(true, nil)
 		clientsMock.IO.On("InputPrompt", mock.Anything, mock.Anything, mock.Anything).Return(testReason, nil)
-		clientsMock.APIInterface.On("RequestAppApproval", mock.Anything, authMock.Token, mock.Anything, mock.Anything, testReason, mock.Anything, mock.Anything).Return(api.AppsApprovalsRequestsCreateResult{}, slackerror.New("dummy error"))
+		clientsMock.API.On("RequestAppApproval", mock.Anything, authMock.Token, mock.Anything, mock.Anything, testReason, mock.Anything, mock.Anything).Return(api.AppsApprovalsRequestsCreateResult{}, slackerror.New("dummy error"))
 
 		// Test
 		err := HandleConnectorApprovalRequired(ctx, clients, authMock.Token, testErr)
 
 		assert.Error(t, err)
-		clientsMock.APIInterface.AssertNumberOfCalls(t, "RequestAppApproval", 1)
+		clientsMock.API.AssertNumberOfCalls(t, "RequestAppApproval", 1)
 	})
 }
 
@@ -244,7 +244,7 @@ func setupCommonMocks(t *testing.T) (ctx context.Context, clients *shared.Client
 	})
 
 	// Mock valid auth session
-	clientsMock.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
+	clientsMock.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
 
 	// Mock the manifest
 	manifestMock := &app.ManifestMockObject{}

--- a/internal/pkg/platform/activity.go
+++ b/internal/pkg/platform/activity.go
@@ -64,7 +64,7 @@ func Activity(
 		return nil
 	}
 
-	authSession, err := clients.APIInterface().ValidateSession(ctx, token)
+	authSession, err := clients.API().ValidateSession(ctx, token)
 	if err != nil {
 		return err
 	}
@@ -136,7 +136,7 @@ func printLatestActivity(ctx context.Context, clients *shared.ClientFactory, tok
 	span, ctx = opentracing.StartSpanFromContext(ctx, "getLatestActivity")
 	defer span.Finish()
 
-	var result, err = clients.APIInterface().Activity(ctx, xoxpToken, args)
+	var result, err = clients.API().Activity(ctx, xoxpToken, args)
 	if err != nil {
 		return 0, 0, err
 	}

--- a/internal/pkg/platform/activity_test.go
+++ b/internal/pkg/platform/activity_test.go
@@ -110,14 +110,14 @@ func TestPlatformActivity_StreamingLogs(t *testing.T) {
 		},
 		"should return error if session validation fails": {
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) context.Context {
-				cm.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, slackerror.New("boomsies"))
+				cm.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, slackerror.New("boomsies"))
 				return ctx
 			},
 			ExpectedError: slackerror.New("boomsies"),
 		},
 		"should return error if activity request fails": {
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) context.Context {
-				cm.APIInterface.On("Activity", mock.Anything, mock.Anything, mock.Anything).Return(api.ActivityResult{}, slackerror.New("explosions"))
+				cm.API.On("Activity", mock.Anything, mock.Anything, mock.Anything).Return(api.ActivityResult{}, slackerror.New("explosions"))
 				return ctx
 			},
 			ExpectedError: slackerror.New("explosions"),
@@ -127,11 +127,11 @@ func TestPlatformActivity_StreamingLogs(t *testing.T) {
 				TailArg: false,
 			},
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) context.Context {
-				cm.APIInterface.On("Activity", mock.Anything, mock.Anything, mock.Anything).Return(api.ActivityResult{}, nil)
+				cm.API.On("Activity", mock.Anything, mock.Anything, mock.Anything).Return(api.ActivityResult{}, nil)
 				return ctx
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
-				cm.APIInterface.AssertNumberOfCalls(t, "Activity", 1)
+				cm.API.AssertNumberOfCalls(t, "Activity", 1)
 			},
 		},
 		"should return nil if TailArg is set and context is canceled": {
@@ -140,7 +140,7 @@ func TestPlatformActivity_StreamingLogs(t *testing.T) {
 				PollingIntervalMS: 20, // poll activity every 20 ms
 			},
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) context.Context {
-				cm.APIInterface.On("Activity", mock.Anything, mock.Anything, mock.Anything).Return(api.ActivityResult{}, nil)
+				cm.API.On("Activity", mock.Anything, mock.Anything, mock.Anything).Return(api.ActivityResult{}, nil)
 				ctx, cancel := context.WithCancel(ctx)
 				go func() {
 					time.Sleep(time.Millisecond * 10) // cancel activity in 10 ms
@@ -150,7 +150,7 @@ func TestPlatformActivity_StreamingLogs(t *testing.T) {
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
 				// with the above polling/canceling setup, expectation is activity called only once.
-				cm.APIInterface.AssertNumberOfCalls(t, "Activity", 1)
+				cm.API.AssertNumberOfCalls(t, "Activity", 1)
 			},
 		},
 	} {
@@ -166,7 +166,7 @@ func TestPlatformActivity_StreamingLogs(t *testing.T) {
 				ctxMock = tt.Setup(t, ctxMock, clientsMock)
 			}
 			// Setup generic test suite mocks
-			clientsMock.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
+			clientsMock.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
 			// Setup default mock actions
 			clientsMock.AddDefaultMocks()
 

--- a/internal/pkg/platform/deploy.go
+++ b/internal/pkg/platform/deploy.go
@@ -52,7 +52,7 @@ func Deploy(ctx context.Context, clients *shared.ClientFactory, showTriggers boo
 	}
 
 	// Validate auth session
-	authSession, err := clients.APIInterface().ValidateSession(ctx, token)
+	authSession, err := clients.API().ValidateSession(ctx, token)
 	if err != nil {
 		return nil, slackerror.Wrap(err, slackerror.ErrSlackAuth)
 	}
@@ -152,19 +152,19 @@ func deployApp(ctx context.Context, clients *shared.ClientFactory, log *logger.L
 
 	//upload zip to s3
 	var startDeploy = time.Now()
-	s3Params, err := clients.APIInterface().GetPresignedS3PostParams(ctx, token, app.AppID)
+	s3Params, err := clients.API().GetPresignedS3PostParams(ctx, token, app.AppID)
 	if err != nil {
 		return app, slackerror.Wrapf(err, "failed generating s3 upload params %s", app.AppID)
 	}
 
-	fileName, err := clients.APIInterface().UploadPackageToS3(ctx, clients.Fs, app.AppID, s3Params, result.Filename)
+	fileName, err := clients.API().UploadPackageToS3(ctx, clients.Fs, app.AppID, s3Params, result.Filename)
 	if err != nil {
 		return app, slackerror.Wrapf(err, "failed uploading the zip file to s3 %s", app.AppID)
 	}
 
 	// upload
 	runtime := strings.ToLower(clients.Runtime.Name())
-	err = clients.APIInterface().UploadApp(ctx, token, runtime, app.AppID, fileName)
+	err = clients.API().UploadApp(ctx, token, runtime, app.AppID, fileName)
 	if err != nil {
 		return app, fmt.Errorf("error uploading app: %s", err)
 	}
@@ -179,7 +179,7 @@ func deployApp(ctx context.Context, clients *shared.ClientFactory, log *logger.L
 	var apiHost = clients.Config.APIHostResolved
 	if clients.AuthInterface().IsAPIHostSlackDev(apiHost) {
 		apiHostURL := fmt.Sprintf("%s/api/", apiHost)
-		_ = clients.APIInterface().AddVariable(ctx, token, app.AppID, "SLACK_API_URL", apiHostURL)
+		_ = clients.API().AddVariable(ctx, token, app.AppID, "SLACK_API_URL", apiHostURL)
 	}
 
 	return app, nil

--- a/internal/pkg/platform/localserver.go
+++ b/internal/pkg/platform/localserver.go
@@ -91,7 +91,7 @@ func (r *LocalServer) Start(ctx context.Context) error {
 		err := func() error {
 			// Get a socket connection address
 			r.clients.IO.PrintDebug(ctx, "Retrieving and establishing connection to WebSocket URL...")
-			result, err := r.clients.APIInterface().ConnectionsOpen(ctx, r.token)
+			result, err := r.clients.API().ConnectionsOpen(ctx, r.token)
 			if err != nil {
 				return slackerror.Wrap(err, slackerror.ErrSocketConnection).WithMessage("Error fetching socket connection URL")
 			}

--- a/internal/pkg/platform/localserver_test.go
+++ b/internal/pkg/platform/localserver_test.go
@@ -47,7 +47,7 @@ func Test_LocalServer_Start(t *testing.T) {
 	}{
 		"should return an error if there was a problem asking for a WebSocket connection URL": {
 			Setup: func(t *testing.T, cm *shared.ClientsMock, clients *shared.ClientFactory, conn *WebSocketConnMock) {
-				cm.APIInterface.On("ConnectionsOpen", mock.Anything, mock.Anything).Return(api.AppsConnectionsOpenResult{}, slackerror.New("no can do, pipes are clogged"))
+				cm.API.On("ConnectionsOpen", mock.Anything, mock.Anything).Return(api.AppsConnectionsOpenResult{}, slackerror.New("no can do, pipes are clogged"))
 			},
 			Test: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, server LocalServer, conn *WebSocketConnMock) {
 				require.ErrorContains(t, server.Start(ctx), "pipes are clogged")
@@ -130,7 +130,7 @@ func Test_LocalServer_Start(t *testing.T) {
 			if tt.Setup != nil {
 				tt.Setup(t, clientsMock, clients, conn)
 			}
-			clientsMock.APIInterface.On("ConnectionsOpen", mock.Anything, mock.Anything).Return(api.AppsConnectionsOpenResult{URL: wsFakeURL}, nil)
+			clientsMock.API.On("ConnectionsOpen", mock.Anything, mock.Anything).Return(api.AppsConnectionsOpenResult{URL: wsFakeURL}, nil)
 			// Setup default mock actions
 			conn.AddDefaultMocks()
 			clientsMock.AddDefaultMocks()

--- a/internal/pkg/platform/run.go
+++ b/internal/pkg/platform/run.go
@@ -51,7 +51,7 @@ func Run(ctx context.Context, clients *shared.ClientFactory, log *logger.Logger,
 	ctx = config.SetContextToken(ctx, runArgs.Auth.Token)
 
 	// Validate auth session
-	authSession, err := clients.APIInterface().ValidateSession(ctx, runArgs.Auth.Token)
+	authSession, err := clients.API().ValidateSession(ctx, runArgs.Auth.Token)
 	if err != nil {
 		err = slackerror.Wrap(err, "No auth session found")
 		return nil, "", slackerror.Wrap(err, slackerror.ErrLocalAppRun)

--- a/internal/prompts/app_select.go
+++ b/internal/prompts/app_select.go
@@ -545,7 +545,7 @@ func getTokenApp(ctx context.Context, clients *shared.ClientFactory, token strin
 		return SelectedApp{}, err
 	}
 	var appStatus api.AppStatusResultAppInfo
-	if appStatusResult, err := clients.APIInterface().GetAppStatus(ctx, token, []string{appID}, auth.TeamID); err != nil {
+	if appStatusResult, err := clients.API().GetAppStatus(ctx, token, []string{appID}, auth.TeamID); err != nil {
 		return SelectedApp{}, err
 	} else if len(appStatusResult.Apps) != 1 || appStatusResult.Apps[0].AppID != appID {
 		return SelectedApp{}, slackerror.New(slackerror.ErrAppNotFound)
@@ -627,7 +627,7 @@ func getInstallationStatuses(ctx context.Context, clients *shared.ClientFactory,
 	startTimer := time.Now()
 
 	// Ensure that the client's host in this case is set to any apiHost provided
-	apiClient := clients.APIInterface()
+	apiClient := clients.API()
 	if apiHost != "" {
 		apiClient.SetHost(apiHost)
 	}
@@ -1687,7 +1687,7 @@ func TeamAppSelectPrompt(ctx context.Context, clients *shared.ClientFactory, env
 
 // OrgSelectWorkspacePrompt prompts the user to select a single workspace to grant app access to, or grant all workspaces within the org.
 func OrgSelectWorkspacePrompt(ctx context.Context, clients *shared.ClientFactory, orgDomain, token string, topOptionAllWorkspaces bool) (string, error) {
-	teams, paginationCursor, err := clients.APIInterface().AuthTeamsList(ctx, token, api.DefaultAuthTeamsListPageSize)
+	teams, paginationCursor, err := clients.API().AuthTeamsList(ctx, token, api.DefaultAuthTeamsListPageSize)
 	if err != nil {
 		return "", err
 	}
@@ -1824,7 +1824,7 @@ func appExists(app types.App) bool {
 // validateAuth checks if the auth for the selected app is valid and if not,
 // prompts the user to re-authenticate
 func validateAuth(ctx context.Context, clients *shared.ClientFactory, auth *types.SlackAuth) error {
-	apiClient := clients.APIInterface()
+	apiClient := clients.API()
 	if auth == nil {
 		auth = &types.SlackAuth{}
 	}

--- a/internal/prompts/app_select_test.go
+++ b/internal/prompts/app_select_test.go
@@ -239,7 +239,7 @@ func TestGetTeamApps(t *testing.T) {
 				tt.mockAuthWithTeamIDResponse,
 				tt.mockAuthWithTeamIDError,
 			)
-			clientsMock.APIInterface.On(
+			clientsMock.API.On(
 				GetAppStatus,
 				mock.Anything,
 				mock.Anything,
@@ -249,7 +249,7 @@ func TestGetTeamApps(t *testing.T) {
 				tt.mockGetAppStatusResponse,
 				tt.mockGetAppStatusError,
 			)
-			clientsMock.APIInterface.On(
+			clientsMock.API.On(
 				"ValidateSession",
 				mock.Anything,
 				mock.Anything,
@@ -374,7 +374,7 @@ func TestGetTokenApp(t *testing.T) {
 			clientsMock := shared.NewClientsMock()
 			clientsMock.AuthInterface.On(AuthWithToken, mock.Anything, test.tokenFlag).
 				Return(test.tokenAuth, test.tokenErr)
-			clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			clientsMock.API.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 				Return(test.appStatus, test.statusErr)
 			clientsMock.AddDefaultMocks()
 
@@ -452,7 +452,7 @@ func Test_FilterAuthsByToken_Flags(t *testing.T) {
 	clientsMock.AuthInterface.On(AuthWithToken, mock.Anything, team2Token).
 		Return(mockAuthTeam2, nil)
 
-	clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.GetAppStatusResult{}, nil)
+	clientsMock.API.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.GetAppStatusResult{}, nil)
 	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
 	clientsMock.AuthInterface.On(SetAuth, mock.Anything).Return(types.SlackAuth{}, nil)
 	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, errors.New(slackerror.ErrCredentialsNotFound))
@@ -581,7 +581,7 @@ func TestPrompt_AppSelectPrompt_SelectedAuthExpired_UserReAuthenticates(t *testi
 	// Auth is present but invalid
 	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
 	mockReauthentication(clientsMock)
-	clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+	clientsMock.API.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 		api.GetAppStatusResult{}, nil)
 	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
 
@@ -612,7 +612,7 @@ func TestPrompt_AppSelectPrompt_SelectedAuthExpired_UserReAuthenticates(t *testi
 	require.NoError(t, err)
 	selection.Auth.LastUpdated = time.Time{} // ignore time for this test
 	require.Equal(t, fakeAuthsByTeamDomain[team1TeamDomain], selection.Auth)
-	clientsMock.APIInterface.AssertCalled(t, "ExchangeAuthTicket", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	clientsMock.API.AssertCalled(t, "ExchangeAuthTicket", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
 func TestPrompt_AppSelectPrompt_AuthsNoApps(t *testing.T) {
@@ -620,7 +620,7 @@ func TestPrompt_AppSelectPrompt_AuthsNoApps(t *testing.T) {
 	// Set up mocks
 	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
-	clientsMock.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
+	clientsMock.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
 	clients := shared.NewClientFactory(clientsMock.MockClientFactory())
 
 	clientsMock.AddDefaultMocks()
@@ -695,7 +695,7 @@ func TestPrompt_AppSelectPrompt_TokenAppFlag(t *testing.T) {
 			clientsMock := shared.NewClientsMock()
 			clientsMock.AuthInterface.On(AuthWithToken, mock.Anything, test.tokenFlag).
 				Return(test.tokenAuth, nil)
-			clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			clientsMock.API.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 				Return(test.appStatus, test.statusErr)
 			clientsMock.AddDefaultMocks()
 
@@ -725,13 +725,13 @@ func TestPrompt_AppSelectPrompt_AuthsWithDeployedAppInstalled_ShowAllApps(t *tes
 	// Set up mocks
 	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
-	clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+	clientsMock.API.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 		api.GetAppStatusResult{
 			Apps: []api.AppStatusResultAppInfo{{AppID: "A1EXAMPLE01", Installed: true}},
 		}, nil)
 	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
 	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
-	clientsMock.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
+	clientsMock.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
 	clientsMock.AddDefaultMocks()
 
 	clients := shared.NewClientFactory(clientsMock.MockClientFactory())
@@ -772,13 +772,13 @@ func TestPrompt_AppSelectPrompt_AuthsWithDeployedAppInstalled_ShowInstalledAppsO
 	// Set up mocks
 	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
-	clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+	clientsMock.API.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 		api.GetAppStatusResult{
 			Apps: []api.AppStatusResultAppInfo{{AppID: "A1EXAMPLE01", Installed: true}},
 		}, nil)
 	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
 	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
-	clientsMock.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
+	clientsMock.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
 	clientsMock.AddDefaultMocks()
 
 	clients := shared.NewClientFactory(clientsMock.MockClientFactory())
@@ -820,13 +820,13 @@ func TestPrompt_AppSelectPrompt_AuthsWithDeployedAppInstalled_InstalledAppOnly_F
 	// Set up mocks
 	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
-	clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+	clientsMock.API.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 		api.GetAppStatusResult{
 			Apps: []api.AppStatusResultAppInfo{{AppID: "A1EXAMPLE01", Installed: true}},
 		}, nil)
 	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
 	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
-	clientsMock.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
+	clientsMock.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
 	clientsMock.AddDefaultMocks()
 
 	clients := shared.NewClientFactory(clientsMock.MockClientFactory())
@@ -946,7 +946,7 @@ func TestPrompt_AppSelectPrompt_AuthsWithBothEnvsInstalled_InstalledAppOnly_Flag
 	mockAuthTeam2.Token = team2Token
 
 	clientsMock := shared.NewClientsMock()
-	clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+	clientsMock.API.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 		api.GetAppStatusResult{
 			Apps: []api.AppStatusResultAppInfo{
 				{AppID: "A1EXAMPLE01", Installed: true},
@@ -956,7 +956,7 @@ func TestPrompt_AppSelectPrompt_AuthsWithBothEnvsInstalled_InstalledAppOnly_Flag
 	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
 	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mockAuthTeam1.TeamID).Return(mockAuthTeam1, nil)
 	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mockAuthTeam2.TeamID).Return(mockAuthTeam2, nil)
-	clientsMock.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
+	clientsMock.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
 
 	clientsMock.AuthInterface.On(AuthWithToken, mock.Anything, team1Token).
 		Return(mockAuthTeam1, nil)
@@ -1098,7 +1098,7 @@ func TestPrompt_AppSelectPrompt_AuthsWithBothEnvsInstalled_MultiWorkspaceAllApps
 	// Set up mocks
 	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
-	clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+	clientsMock.API.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 		api.GetAppStatusResult{
 			Apps: []api.AppStatusResultAppInfo{
 				{AppID: "A1EXAMPLE01", Installed: true},
@@ -1107,7 +1107,7 @@ func TestPrompt_AppSelectPrompt_AuthsWithBothEnvsInstalled_MultiWorkspaceAllApps
 			}}, nil)
 	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
 	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
-	clientsMock.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
+	clientsMock.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
 	clientsMock.AddDefaultMocks()
 
 	clients := shared.NewClientFactory(clientsMock.MockClientFactory())
@@ -1224,7 +1224,7 @@ func TestPrompt_AppSelectPrompt_AuthsWithHostedInstalled_AllApps_CreateNew(t *te
 	// Set up mocks
 	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
-	clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+	clientsMock.API.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 		api.GetAppStatusResult{
 			Apps: []api.AppStatusResultAppInfo{
 				{AppID: "A1EXAMPLE01", Installed: true},
@@ -1232,7 +1232,7 @@ func TestPrompt_AppSelectPrompt_AuthsWithHostedInstalled_AllApps_CreateNew(t *te
 			}}, nil)
 	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
 	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
-	clientsMock.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
+	clientsMock.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
 	clientsMock.AddDefaultMocks()
 
 	clients := shared.NewClientFactory(clientsMock.MockClientFactory())
@@ -1303,8 +1303,8 @@ func TestPrompt_AppSelectPrompt_ShowExpectedLabels(t *testing.T) {
 		})
 		clientsMock.AuthInterface.On(Auths, mock.Anything).Return(auths, nil)
 		clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
-		clientsMock.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
-		clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+		clientsMock.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
+		clientsMock.API.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 			api.GetAppStatusResult{
 				Apps: []api.AppStatusResultAppInfo{
 					{AppID: deployedTeam1InstalledAppID, Installed: deployedTeam1AppIsInstalled},
@@ -1685,7 +1685,7 @@ func TestPrompt_AppSelectPrompt_GetApps(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := shared.NewClientsMock()
-			clientsMock.APIInterface.On(
+			clientsMock.API.On(
 				GetAppStatus,
 				mock.Anything,
 				mock.Anything,
@@ -1695,7 +1695,7 @@ func TestPrompt_AppSelectPrompt_GetApps(t *testing.T) {
 				tt.mockTeam1Status,
 				tt.mockTeam1StatusError,
 			)
-			clientsMock.APIInterface.On(
+			clientsMock.API.On(
 				GetAppStatus,
 				mock.Anything,
 				mock.Anything,
@@ -1705,7 +1705,7 @@ func TestPrompt_AppSelectPrompt_GetApps(t *testing.T) {
 				tt.mockTeam2Status,
 				tt.mockTeam2StatusError,
 			)
-			clientsMock.APIInterface.On(
+			clientsMock.API.On(
 				"ValidateSession",
 				mock.Anything,
 				mock.Anything,
@@ -2302,7 +2302,7 @@ func TestPrompt_AppSelectPrompt_FlatAppSelectPrompt(t *testing.T) {
 				tt.mockAuthWithToken,
 				nil,
 			)
-			clientsMock.APIInterface.On(
+			clientsMock.API.On(
 				"ValidateSession",
 				mock.Anything,
 				mock.Anything,
@@ -2310,7 +2310,7 @@ func TestPrompt_AppSelectPrompt_FlatAppSelectPrompt(t *testing.T) {
 				api.AuthSession{},
 				nil,
 			)
-			clientsMock.APIInterface.On(
+			clientsMock.API.On(
 				GetAppStatus,
 				mock.Anything,
 				mock.Anything,
@@ -2334,7 +2334,7 @@ func TestPrompt_AppSelectPrompt_FlatAppSelectPrompt(t *testing.T) {
 				},
 				nil,
 			)
-			clientsMock.APIInterface.On(
+			clientsMock.API.On(
 				GetAppStatus,
 				mock.Anything,
 				mock.Anything,
@@ -2353,7 +2353,7 @@ func TestPrompt_AppSelectPrompt_FlatAppSelectPrompt(t *testing.T) {
 				},
 				nil,
 			)
-			clientsMock.APIInterface.On(
+			clientsMock.API.On(
 				GetAppStatus,
 				mock.Anything,
 				mock.Anything,
@@ -2372,7 +2372,7 @@ func TestPrompt_AppSelectPrompt_FlatAppSelectPrompt(t *testing.T) {
 				},
 				nil,
 			)
-			clientsMock.APIInterface.On(
+			clientsMock.API.On(
 				GetAppStatus,
 				mock.Anything,
 				mock.Anything,
@@ -2396,7 +2396,7 @@ func TestPrompt_AppSelectPrompt_FlatAppSelectPrompt(t *testing.T) {
 				},
 				nil,
 			)
-			clientsMock.APIInterface.On(
+			clientsMock.API.On(
 				GetAppStatus,
 				mock.Anything,
 				mock.Anything,
@@ -2415,7 +2415,7 @@ func TestPrompt_AppSelectPrompt_FlatAppSelectPrompt(t *testing.T) {
 				},
 				nil,
 			)
-			clientsMock.APIInterface.On(
+			clientsMock.API.On(
 				GetAppStatus,
 				mock.Anything,
 				mock.Anything,
@@ -2515,7 +2515,7 @@ func TestPrompt_TeamAppSelectPrompt_SelectedAuthExpired_UserReAuthenticates(t *t
 	// Auth is present but invalid
 	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
 	mockReauthentication(clientsMock)
-	clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+	clientsMock.API.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 		api.GetAppStatusResult{}, nil)
 	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
 
@@ -2538,7 +2538,7 @@ func TestPrompt_TeamAppSelectPrompt_SelectedAuthExpired_UserReAuthenticates(t *t
 	require.NoError(t, err)
 	selection.Auth.LastUpdated = time.Time{} // ignore time for this test
 	require.Equal(t, fakeAuthsByTeamDomain[team1TeamDomain], selection.Auth)
-	clientsMock.APIInterface.AssertCalled(t, "ExchangeAuthTicket", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	clientsMock.API.AssertCalled(t, "ExchangeAuthTicket", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
 func TestPrompt_TeamAppSelectPrompt_NoAuths_UserReAuthenticates(t *testing.T) {
@@ -2548,7 +2548,7 @@ func TestPrompt_TeamAppSelectPrompt_NoAuths_UserReAuthenticates(t *testing.T) {
 	// No auths present
 	clientsMock.AuthInterface.On(Auths, mock.Anything).Return([]types.SlackAuth{}, nil)
 	mockReauthentication(clientsMock)
-	clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+	clientsMock.API.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 		api.GetAppStatusResult{}, nil)
 	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
 
@@ -2680,7 +2680,7 @@ func TestPrompt_TeamAppSelectPrompt_TokenAppFlag(t *testing.T) {
 			clientsMock := shared.NewClientsMock()
 			clientsMock.AuthInterface.On(AuthWithToken, mock.Anything, test.tokenFlag).
 				Return(test.tokenAuth, nil)
-			clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			clientsMock.API.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 				Return(test.appStatus, test.statusErr)
 			clientsMock.AddDefaultMocks()
 
@@ -2746,7 +2746,7 @@ func TestPrompt_TeamAppSelectPrompt_NoApps(t *testing.T) {
 	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
 	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, team1TeamID).Return(fakeAuthsByTeamDomain[team1TeamDomain], nil)
 	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, team2TeamID).Return(fakeAuthsByTeamDomain[team2TeamDomain], nil)
-	clientsMock.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
+	clientsMock.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
 	clientsMock.AddDefaultMocks()
 
 	clients := shared.NewClientFactory(clientsMock.MockClientFactory())
@@ -3062,7 +3062,7 @@ func TestPrompt_TeamAppSelectPrompt_TokenFlag(t *testing.T) {
 
 		clientsMock := shared.NewClientsMock()
 
-		clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+		clientsMock.API.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 			api.GetAppStatusResult{Apps: appInstallStatus}, nil)
 		clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
 		clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mock.Anything).
@@ -3098,12 +3098,12 @@ func TestPrompt_TeamAppSelectPrompt_HostedAppsOnly(t *testing.T) {
 	// Set up mocks
 	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
-	clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+	clientsMock.API.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 		api.GetAppStatusResult{
 			Apps: []api.AppStatusResultAppInfo{{AppID: "A1EXAMPLE01", Installed: true}, {AppID: "A124", Installed: true}},
 		}, nil)
 	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
-	clientsMock.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
+	clientsMock.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
 	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
 	clientsMock.AddDefaultMocks()
 
@@ -3179,7 +3179,7 @@ func TestPrompt_TeamAppSelectPrompt_HostedAppsOnly_TeamFlagDomain(t *testing.T) 
 	// Set up mocks
 	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
-	clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+	clientsMock.API.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 		api.GetAppStatusResult{
 			Apps: []api.AppStatusResultAppInfo{{AppID: "A1EXAMPLE01", Installed: true}},
 		}, nil)
@@ -3227,7 +3227,7 @@ func TestPrompt_TeamAppSelectPrompt_HostedAppsOnly_TeamFlagID(t *testing.T) {
 	// Set up mocks
 	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
-	clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+	clientsMock.API.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 		api.GetAppStatusResult{
 			Apps: []api.AppStatusResultAppInfo{{AppID: "A1EXAMPLE01", Installed: true}},
 		}, nil)
@@ -3275,12 +3275,12 @@ func TestPrompt_TeamAppSelectPrompt_LocalAppsOnly(t *testing.T) {
 	// Set up mocks
 	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
-	clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+	clientsMock.API.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 		api.GetAppStatusResult{
 			Apps: []api.AppStatusResultAppInfo{{AppID: "A1EXAMPLE01", Installed: true}, {AppID: "A124", Installed: true}},
 		}, nil)
 	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
-	clientsMock.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
+	clientsMock.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
 	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, team1TeamID).Return(fakeAuthsByTeamDomain[team1TeamDomain], nil)
 	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, team2TeamID).Return(fakeAuthsByTeamDomain[team2TeamDomain], nil)
 	clientsMock.AddDefaultMocks()
@@ -3359,7 +3359,7 @@ func TestPrompt_TeamAppSelectPrompt_LocalAppsOnly_TeamFlagDomain(t *testing.T) {
 	// Set up mocks
 	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
-	clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+	clientsMock.API.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 		api.GetAppStatusResult{
 			Apps: []api.AppStatusResultAppInfo{{AppID: "A124", Installed: true}},
 		}, nil)
@@ -3410,7 +3410,7 @@ func TestPrompt_TeamAppSelectPrompt_LocalAppsOnly_TeamFlagID(t *testing.T) {
 	// Set up mocks
 	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
-	clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+	clientsMock.API.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 		api.GetAppStatusResult{
 			Apps: []api.AppStatusResultAppInfo{{AppID: "A124", Installed: true}},
 		}, nil)
@@ -3461,7 +3461,7 @@ func TestPrompt_TeamAppSelectPrompt_AllApps(t *testing.T) {
 	// Set up mocks
 	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
-	clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+	clientsMock.API.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 		api.GetAppStatusResult{
 			Apps: []api.AppStatusResultAppInfo{
 				{AppID: "A1EXAMPLE01", Installed: true},
@@ -3471,7 +3471,7 @@ func TestPrompt_TeamAppSelectPrompt_AllApps(t *testing.T) {
 			},
 		}, nil)
 	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
-	clientsMock.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
+	clientsMock.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
 	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
 	clientsMock.AddDefaultMocks()
 
@@ -3553,7 +3553,7 @@ func TestPrompt_TeamAppSelectPrompt_LegacyDevApps(t *testing.T) {
 	// Set up mocks
 	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
-	clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+	clientsMock.API.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 		api.GetAppStatusResult{
 			Apps: []api.AppStatusResultAppInfo{
 				{AppID: "A1EXAMPLE01dev", Installed: true},
@@ -3561,7 +3561,7 @@ func TestPrompt_TeamAppSelectPrompt_LegacyDevApps(t *testing.T) {
 			},
 		}, nil)
 	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
-	clientsMock.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
+	clientsMock.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
 	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
 	clientsMock.AddDefaultMocks()
 
@@ -3637,7 +3637,7 @@ func TestPrompt_TeamAppSelectPrompt_ShowExpectedLabels(t *testing.T) {
 
 	setupClientsMock := func() *shared.ClientsMock {
 		clientsMock := shared.NewClientsMock()
-		clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
+		clientsMock.API.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 			api.GetAppStatusResult{
 				Apps: []api.AppStatusResultAppInfo{
 					{AppID: deployedTeam1InstalledAppID, Installed: deployedTeam1AppIsInstalled},
@@ -3653,7 +3653,7 @@ func TestPrompt_TeamAppSelectPrompt_ShowExpectedLabels(t *testing.T) {
 			Token:      "xoxe.xoxp-2-token",
 		})
 		clientsMock.AuthInterface.On(Auths, mock.Anything).Return(auths, nil)
-		clientsMock.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
+		clientsMock.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
 		clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
 		clientsMock.AddDefaultMocks()
 
@@ -3818,7 +3818,7 @@ func TestPrompt_TeamAppSelectPrompt_AllApps_TeamFlagID(t *testing.T) {
 	// Set up mocks
 	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
-	clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.GetAppStatusResult{}, nil)
+	clientsMock.API.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.GetAppStatusResult{}, nil)
 	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
 	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
 	clientsMock.AddDefaultMocks()
@@ -3866,7 +3866,7 @@ func TestPrompt_TeamAppSelectPrompt_AllApps_Flags(t *testing.T) {
 	// Set up mocks
 	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
-	clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.GetAppStatusResult{}, nil)
+	clientsMock.API.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.GetAppStatusResult{}, nil)
 	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
 	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
 	clientsMock.AddDefaultMocks()
@@ -4032,7 +4032,7 @@ func TestPrompt_TeamAppSelectPrompt_AppSelectPrompt_EnterpriseWorkspaceApps_HasW
 	// Set up mocks
 	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
-	clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.GetAppStatusResult{}, nil)
+	clientsMock.API.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.GetAppStatusResult{}, nil)
 
 	// Auths
 	// Enterprise (org) Auth
@@ -4058,7 +4058,7 @@ func TestPrompt_TeamAppSelectPrompt_AppSelectPrompt_EnterpriseWorkspaceApps_HasW
 	// Return one auth
 	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, team1TeamID).Return(authTeam1, nil)
 	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, enterprise1TeamID).Return(authEnterprise1, nil)
-	clientsMock.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
+	clientsMock.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
 
 	//
 	// This test uses a single auth - Mock the underlying auth
@@ -4239,7 +4239,7 @@ func TestPrompt_TeamAppSelectPrompt_AppSelectPrompt_EnterpriseWorkspaceApps_Miss
 	// Set up mocks
 	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
-	clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.GetAppStatusResult{}, nil)
+	clientsMock.API.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.GetAppStatusResult{}, nil)
 
 	mockReauthentication(clientsMock)
 
@@ -4428,7 +4428,7 @@ func TestPrompt_TeamAppSelectPrompt_EnterpriseWorkspaceApps_MissingWorkspaceAuth
 	// Set up mocks
 	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
-	clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.GetAppStatusResult{}, nil)
+	clientsMock.API.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.GetAppStatusResult{}, nil)
 
 	// Auths
 	// Enterprise (org) Auth
@@ -4454,7 +4454,7 @@ func TestPrompt_TeamAppSelectPrompt_EnterpriseWorkspaceApps_MissingWorkspaceAuth
 	// For this test we want to make sure that no auth is found for team1, and a credentials not found
 	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, team1TeamID).Return(types.SlackAuth{}, slackerror.New(slackerror.ErrCredentialsNotFound))
 	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, enterprise1TeamID).Return(authEnterprise1, nil)
-	clientsMock.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
+	clientsMock.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
 
 	// This test uses a single auth - the enterprise auth
 	clientsMock.AuthInterface.On(Auths, mock.Anything).Return([]types.SlackAuth{
@@ -4606,7 +4606,7 @@ func TestPrompt_AppSelectPrompt_EnterpriseWorkspaceApps_MissingWorkspaceAuth_Has
 	// Set up mocks
 	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
-	clientsMock.APIInterface.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.GetAppStatusResult{}, nil)
+	clientsMock.API.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.GetAppStatusResult{}, nil)
 
 	// Auths
 	// Enterprise (org) Auth
@@ -4632,7 +4632,7 @@ func TestPrompt_AppSelectPrompt_EnterpriseWorkspaceApps_MissingWorkspaceAuth_Has
 	// For this test we want to make sure that no auth is found for team1, and a credentials not found
 	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, team1TeamID).Return(types.SlackAuth{}, slackerror.New(slackerror.ErrCredentialsNotFound))
 	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, enterprise1TeamID).Return(authEnterprise1, nil)
-	clientsMock.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
+	clientsMock.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
 
 	// This test uses a single auth - the enterprise auth
 	clientsMock.AuthInterface.On(Auths, mock.Anything).Return([]types.SlackAuth{
@@ -4898,7 +4898,7 @@ func Test_ValidateGetOrgWorkspaceGrant(t *testing.T) {
 				Auth: types.SlackAuth{IsEnterpriseInstall: true},
 			},
 			mockPrompt: func(clientsMock *shared.ClientsMock) {
-				clientsMock.APIInterface.On("AuthTeamsList", mock.Anything, mock.Anything, mock.Anything).Return(
+				clientsMock.API.On("AuthTeamsList", mock.Anything, mock.Anything, mock.Anything).Return(
 					[]types.TeamInfo{
 						{ID: "T1", Name: "team1"},
 						{ID: "T2", Name: "team2"},
@@ -4923,7 +4923,7 @@ func Test_ValidateGetOrgWorkspaceGrant(t *testing.T) {
 				Auth: types.SlackAuth{IsEnterpriseInstall: true},
 			},
 			mockPrompt: func(clientsMock *shared.ClientsMock) {
-				clientsMock.APIInterface.On("AuthTeamsList", mock.Anything, mock.Anything, mock.Anything).Return(
+				clientsMock.API.On("AuthTeamsList", mock.Anything, mock.Anything, mock.Anything).Return(
 					[]types.TeamInfo{
 						{ID: "T1", Name: "team1"},
 						{ID: "T2", Name: "team2"},
@@ -4948,7 +4948,7 @@ func Test_ValidateGetOrgWorkspaceGrant(t *testing.T) {
 				Auth: types.SlackAuth{IsEnterpriseInstall: true},
 			},
 			mockPrompt: func(clientsMock *shared.ClientsMock) {
-				clientsMock.APIInterface.On("AuthTeamsList", mock.Anything, mock.Anything, mock.Anything).Return(
+				clientsMock.API.On("AuthTeamsList", mock.Anything, mock.Anything, mock.Anything).Return(
 					[]types.TeamInfo{
 						{ID: "T1", Name: "team1"},
 						{ID: "T2", Name: "team2"},
@@ -5085,7 +5085,7 @@ func Test_ValidateAuth(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := shared.NewClientsMock()
-			clientsMock.APIInterface.On(
+			clientsMock.API.On(
 				"ExchangeAuthTicket",
 				mock.Anything,
 				mock.Anything,
@@ -5095,7 +5095,7 @@ func Test_ValidateAuth(t *testing.T) {
 				tt.apiExchangeAuthTicketResultResponse,
 				tt.apiExchangeAuthTicketResultError,
 			)
-			clientsMock.APIInterface.On(
+			clientsMock.API.On(
 				"GenerateAuthTicket",
 				mock.Anything,
 				mock.Anything,
@@ -5105,17 +5105,17 @@ func Test_ValidateAuth(t *testing.T) {
 				tt.apiGenerateAuthTicketResultError,
 			)
 			if tt.authProvided.APIHost != nil {
-				clientsMock.APIInterface.On(
+				clientsMock.API.On(
 					"Host",
 				).Return(
 					*tt.authProvided.APIHost,
 				)
 			}
-			clientsMock.APIInterface.On(
+			clientsMock.API.On(
 				"SetHost",
 				mock.Anything,
 			)
-			clientsMock.APIInterface.On(
+			clientsMock.API.On(
 				"ValidateSession",
 				mock.Anything,
 				tt.authProvided.Token,
@@ -5175,7 +5175,7 @@ func Test_ValidateAuth(t *testing.T) {
 			tt.authProvided.LastUpdated = time.Time{} // ignore time for this test
 			assert.Equal(t, tt.expectedErr, err)
 			if tt.authExpected.APIHost != nil {
-				clientsMock.APIInterface.AssertCalled(t, "SetHost", *tt.authExpected.APIHost)
+				clientsMock.API.AssertCalled(t, "SetHost", *tt.authExpected.APIHost)
 			}
 			assert.Equal(t, tt.authExpected, tt.authProvided)
 		})
@@ -5186,20 +5186,20 @@ func Test_ValidateAuth(t *testing.T) {
 func mockReauthentication(clientsMock *shared.ClientsMock) {
 	// Default mocks
 	clientsMock.Os.AddDefaultMocks()
-	clientsMock.APIInterface.AddDefaultMocks()
+	clientsMock.API.AddDefaultMocks()
 	// Enable interactivity
 	clientsMock.IO.On("IsTTY").Return(true)
 	clientsMock.IO.AddDefaultMocks()
 
 	// Mock invalid auth response
-	clientsMock.APIInterface.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, fmt.Errorf(slackerror.ErrInvalidAuth))
+	clientsMock.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, fmt.Errorf(slackerror.ErrInvalidAuth))
 	clientsMock.AuthInterface.On("FilterKnownAuthErrors", mock.Anything, mock.Anything).Return(true, nil)
 	// Mocks for reauthentication
-	clientsMock.APIInterface.On("GenerateAuthTicket", mock.Anything, mock.Anything, mock.Anything).Return(api.GenerateAuthTicketResult{}, nil)
+	clientsMock.API.On("GenerateAuthTicket", mock.Anything, mock.Anything, mock.Anything).Return(api.GenerateAuthTicketResult{}, nil)
 	clientsMock.IO.On("InputPrompt", mock.Anything, "Enter challenge code", iostreams.InputPromptConfig{
 		Required: true,
 	}).Return("challengeCode", nil)
-	clientsMock.APIInterface.On("ExchangeAuthTicket", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.ExchangeAuthTicketResult{Token: fakeAuthsByTeamDomain[team1TeamDomain].Token, TeamDomain: team1TeamDomain,
+	clientsMock.API.On("ExchangeAuthTicket", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.ExchangeAuthTicketResult{Token: fakeAuthsByTeamDomain[team1TeamDomain].Token, TeamDomain: team1TeamDomain,
 		TeamID: team1TeamID, UserID: "U1"}, nil)
 	clientsMock.AuthInterface.On("IsAPIHostSlackProd", mock.Anything).Return(true)
 	clientsMock.AuthInterface.On("SetAuth", mock.Anything, mock.Anything).Return(types.SlackAuth{}, "", nil)

--- a/internal/shared/clients.go
+++ b/internal/shared/clients.go
@@ -97,7 +97,7 @@ func NewClientFactory(options ...func(*ClientFactory)) *ClientFactory {
 		IO: clients.IO,
 	}
 	clients.EventTracker = tracking.NewEventTracker()
-	clients.API = clients.defaultAPIInterfaceFunc
+	clients.API = clients.defaultAPIFunc
 	clients.AppClient = clients.defaultAppClientFunc
 	clients.AuthInterface = clients.defaultAuthInterfaceFunc
 	clients.Browser = clients.defaultBrowserFunc
@@ -129,8 +129,8 @@ func (c *ClientFactory) defaultAPIClientFunc() *api.Client {
 	return api.NewClient(nil, c.Config.APIHostResolved, c.IO)
 }
 
-// defaultAPIInterfaceFunc return a new API Client using the ConfigAPIHost
-func (c *ClientFactory) defaultAPIInterfaceFunc() api.APIInterface {
+// defaultAPIFunc return a new API Client using the ConfigAPIHost
+func (c *ClientFactory) defaultAPIFunc() api.APIInterface {
 	return c.defaultAPIClientFunc()
 }
 

--- a/internal/shared/clients_mock.go
+++ b/internal/shared/clients_mock.go
@@ -32,7 +32,7 @@ import (
 // ClientsMock defines mocks that will override aspects of clients for testing purposes.
 type ClientsMock struct {
 	mock.Mock
-	APIInterface  *api.APIMock
+	API           *api.APIMock
 	AuthInterface *auth.AuthMock
 	AppClient     *app.Client
 	Browser       *slackdeps.BrowserMock
@@ -52,7 +52,7 @@ func NewClientsMock() *ClientsMock {
 	clientsMock := &ClientsMock{}
 
 	// Set the mocked members
-	clientsMock.APIInterface = &api.APIMock{}
+	clientsMock.API = &api.APIMock{}
 	clientsMock.AuthInterface = &auth.AuthMock{}
 	clientsMock.Browser = slackdeps.NewBrowserMock()
 	clientsMock.Cobra = slackdeps.NewCobraMock()
@@ -71,7 +71,7 @@ func NewClientsMock() *ClientsMock {
 
 // AddDefaultMocks installs the default mock actions to fallback on.
 func (m *ClientsMock) AddDefaultMocks() {
-	m.APIInterface.AddDefaultMocks()
+	m.API.AddDefaultMocks()
 	m.AuthInterface.AddDefaultMocks()
 	m.Browser.AddDefaultMocks()
 	m.Cobra.AddDefaultMocks()
@@ -91,7 +91,7 @@ func (m *ClientsMock) MockClientFactory() func(c *ClientFactory) {
 		clients.Os = m.Os
 		clients.IO = m.IO
 		clients.Fs = m.Fs
-		clients.API = func() api.APIInterface { return m.APIInterface }
+		clients.API = func() api.APIInterface { return m.API }
 		clients.AuthInterface = func() auth.AuthInterface { return m.AuthInterface }
 		clients.AppClient = func() *app.Client { return m.AppClient }
 		clients.HookExecutor = &m.HookExecutor

--- a/internal/shared/clients_mock.go
+++ b/internal/shared/clients_mock.go
@@ -91,7 +91,7 @@ func (m *ClientsMock) MockClientFactory() func(c *ClientFactory) {
 		clients.Os = m.Os
 		clients.IO = m.IO
 		clients.Fs = m.Fs
-		clients.APIInterface = func() api.APIInterface { return m.APIInterface }
+		clients.API = func() api.APIInterface { return m.APIInterface }
 		clients.AuthInterface = func() auth.AuthInterface { return m.AuthInterface }
 		clients.AppClient = func() *app.Client { return m.AppClient }
 		clients.HookExecutor = &m.HookExecutor


### PR DESCRIPTION
### Summary

This pull request renames the function `clients.APIInterface()` to `clients.API()`. 

The motivation is that the name is shorter and more accurate. The `clients.API()` returns an instance of `api.Client` that implements the `api.APIInterface` interface. It doesn't return an interface. Alternatively, we could name it `clients.APIClient()` but I think we're trying to move away from this naming pattern.

There was no change  functionality was changed.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).