### PR TITLE
refactor: rename clients.AuthInterface() to clients.Auth()

### DIFF
--- a/cmd/app/add_test.go
+++ b/cmd/app/add_test.go
@@ -478,9 +478,9 @@ func TestAppAddCommand(t *testing.T) {
 func prepareAddMocks(t *testing.T, clients *shared.ClientFactory, clientsMock *shared.ClientsMock) {
 	clientsMock.AddDefaultMocks()
 
-	clientsMock.AuthInterface.On("ResolveAPIHost", mock.Anything, mock.Anything, mock.Anything).
+	clientsMock.Auth.On("ResolveAPIHost", mock.Anything, mock.Anything, mock.Anything).
 		Return("api host")
-	clientsMock.AuthInterface.On("ResolveLogstashHost", mock.Anything, mock.Anything, mock.Anything).
+	clientsMock.Auth.On("ResolveLogstashHost", mock.Anything, mock.Anything, mock.Anything).
 		Return("logstash host")
 
 	manifestMock := &app.ManifestMockObject{}

--- a/cmd/app/delete_test.go
+++ b/cmd/app/delete_test.go
@@ -162,9 +162,9 @@ func TestAppsDeleteCommand(t *testing.T) {
 func prepareCommonDeleteMocks(t *testing.T, cf *shared.ClientFactory, cm *shared.ClientsMock) {
 	cm.AddDefaultMocks()
 
-	cm.AuthInterface.On("ResolveAPIHost", mock.Anything, mock.Anything, mock.Anything).
+	cm.Auth.On("ResolveAPIHost", mock.Anything, mock.Anything, mock.Anything).
 		Return("api host")
-	cm.AuthInterface.On("ResolveLogstashHost", mock.Anything, mock.Anything, mock.Anything).
+	cm.Auth.On("ResolveLogstashHost", mock.Anything, mock.Anything, mock.Anything).
 		Return("logstash host")
 
 	// Mock list command

--- a/cmd/app/link.go
+++ b/cmd/app/link.go
@@ -292,7 +292,7 @@ func promptExistingApp(ctx context.Context, clients *shared.ClientFactory) (type
 
 // promptTeamSlackAuth retrieves an authenticated team from input
 func promptTeamSlackAuth(ctx context.Context, clients *shared.ClientFactory) (*types.SlackAuth, error) {
-	allAuths, err := clients.AuthInterface().Auths(ctx)
+	allAuths, err := clients.Auth().Auths(ctx)
 	if err != nil {
 		return &types.SlackAuth{}, err
 	}
@@ -322,7 +322,7 @@ func promptTeamSlackAuth(ctx context.Context, clients *shared.ClientFactory) (*t
 		return &types.SlackAuth{}, err
 	}
 	if selection.Prompt {
-		clients.AuthInterface().SetSelectedAuth(ctx, allAuths[selection.Index], clients.Config, clients.Os)
+		clients.Auth().SetSelectedAuth(ctx, allAuths[selection.Index], clients.Config, clients.Os)
 		return &allAuths[selection.Index], nil
 	}
 	teamMatch := false
@@ -341,7 +341,7 @@ func promptTeamSlackAuth(ctx context.Context, clients *shared.ClientFactory) (*t
 	if !teamMatch {
 		return &types.SlackAuth{}, slackerror.New(slackerror.ErrCredentialsNotFound)
 	}
-	clients.AuthInterface().SetSelectedAuth(ctx, allAuths[teamIndex], clients.Config, clients.Os)
+	clients.Auth().SetSelectedAuth(ctx, allAuths[teamIndex], clients.Config, clients.Os)
 	return &allAuths[teamIndex], nil
 }
 

--- a/cmd/app/link_test.go
+++ b/cmd/app/link_test.go
@@ -57,7 +57,7 @@ func Test_Apps_Link(t *testing.T) {
 	testutil.TableTestCommand(t, testutil.CommandTests{
 		"saves information about the provided deployed app": {
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
-				cm.AuthInterface.On("Auths", mock.Anything).Return([]types.SlackAuth{
+				cm.Auth.On("Auths", mock.Anything).Return([]types.SlackAuth{
 					mockLinkSlackAuth2,
 					mockLinkSlackAuth1,
 				}, nil)
@@ -114,7 +114,7 @@ func Test_Apps_Link(t *testing.T) {
 		},
 		"saves information about the provided local app": {
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
-				cm.AuthInterface.On("Auths", mock.Anything).Return([]types.SlackAuth{
+				cm.Auth.On("Auths", mock.Anything).Return([]types.SlackAuth{
 					mockLinkSlackAuth2,
 					mockLinkSlackAuth1,
 				}, nil)
@@ -173,7 +173,7 @@ func Test_Apps_Link(t *testing.T) {
 		},
 		"avoids overwriting an app saved in json without confirmation": {
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
-				cm.AuthInterface.On("Auths", mock.Anything).Return([]types.SlackAuth{
+				cm.Auth.On("Auths", mock.Anything).Return([]types.SlackAuth{
 					mockLinkSlackAuth1,
 					mockLinkSlackAuth2,
 				}, nil)
@@ -242,7 +242,7 @@ func Test_Apps_Link(t *testing.T) {
 		},
 		"avoids overwriting a matching app id for the team without confirmation": {
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
-				cm.AuthInterface.On("Auths", mock.Anything).Return([]types.SlackAuth{
+				cm.Auth.On("Auths", mock.Anything).Return([]types.SlackAuth{
 					mockLinkSlackAuth1,
 					mockLinkSlackAuth2,
 				}, nil)
@@ -317,7 +317,7 @@ func Test_Apps_Link(t *testing.T) {
 		},
 		"completes overwriting an app saved in json with confirmation": {
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
-				cm.AuthInterface.On("Auths", mock.Anything).Return([]types.SlackAuth{
+				cm.Auth.On("Auths", mock.Anything).Return([]types.SlackAuth{
 					mockLinkSlackAuth1,
 					mockLinkSlackAuth2,
 				}, nil)
@@ -385,7 +385,7 @@ func Test_Apps_Link(t *testing.T) {
 		},
 		"refuses to write an app with app id not existing upstream": {
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
-				cm.AuthInterface.On("Auths", mock.Anything).Return([]types.SlackAuth{
+				cm.Auth.On("Auths", mock.Anything).Return([]types.SlackAuth{
 					mockLinkSlackAuth1,
 					mockLinkSlackAuth2,
 				}, nil)
@@ -433,7 +433,7 @@ func Test_Apps_Link(t *testing.T) {
 		},
 		"accepting manifest source prompt should save information about the provided deployed app": {
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
-				cm.AuthInterface.On("Auths", mock.Anything).Return([]types.SlackAuth{
+				cm.Auth.On("Auths", mock.Anything).Return([]types.SlackAuth{
 					mockLinkSlackAuth2,
 					mockLinkSlackAuth1,
 				}, nil)
@@ -540,7 +540,7 @@ func Test_Apps_Link(t *testing.T) {
 		},
 		"manifest source prompt should not display for Run-on-Slack apps with local manifest source": {
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
-				cm.AuthInterface.On("Auths", mock.Anything).Return([]types.SlackAuth{
+				cm.Auth.On("Auths", mock.Anything).Return([]types.SlackAuth{
 					mockLinkSlackAuth1,
 					mockLinkSlackAuth2,
 				}, nil)
@@ -617,7 +617,7 @@ func Test_Apps_Link(t *testing.T) {
 		},
 		"manifest source prompt should display for GBP apps with local manifest source": {
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
-				cm.AuthInterface.On("Auths", mock.Anything).Return([]types.SlackAuth{
+				cm.Auth.On("Auths", mock.Anything).Return([]types.SlackAuth{
 					mockLinkSlackAuth1,
 					mockLinkSlackAuth2,
 				}, nil)

--- a/cmd/app/uninstall_test.go
+++ b/cmd/app/uninstall_test.go
@@ -102,9 +102,9 @@ func prepareCommonUninstallMocks(ctx context.Context, clients *shared.ClientFact
 	appSelectMock.On("AppSelectPrompt").Return(selectedProdApp, nil)
 
 	// Mock API calls
-	clientsMock.AuthInterface.On("ResolveAPIHost", mock.Anything, mock.Anything, mock.Anything).
+	clientsMock.Auth.On("ResolveAPIHost", mock.Anything, mock.Anything, mock.Anything).
 		Return("api host")
-	clientsMock.AuthInterface.On("ResolveLogstashHost", mock.Anything, mock.Anything, mock.Anything).
+	clientsMock.Auth.On("ResolveLogstashHost", mock.Anything, mock.Anything, mock.Anything).
 		Return("logstash host")
 
 	clientsMock.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{

--- a/cmd/auth/login_test.go
+++ b/cmd/auth/login_test.go
@@ -60,8 +60,8 @@ func TestLoginCommand(t *testing.T) {
 					TeamName: &mockOrgAuth.TeamDomain,
 					URL:      &mockOrgAuthURL,
 				}, nil)
-				cm.AuthInterface.On("IsAPIHostSlackProd", mock.Anything).Return(true)
-				cm.AuthInterface.On(
+				cm.Auth.On("IsAPIHostSlackProd", mock.Anything).Return(true)
+				cm.Auth.On(
 					"AuthWithTeamDomain",
 					mock.Anything,
 					mock.Anything,
@@ -94,8 +94,8 @@ func TestLoginCommand(t *testing.T) {
 					},
 					nil,
 				)
-				cm.AuthInterface.On("IsAPIHostSlackProd", mock.Anything).Return(true)
-				cm.AuthInterface.On(
+				cm.Auth.On("IsAPIHostSlackProd", mock.Anything).Return(true)
+				cm.Auth.On(
 					"SetAuth",
 					mock.Anything,
 					mock.Anything,
@@ -124,8 +124,8 @@ func TestLoginCommand(t *testing.T) {
 					},
 					nil,
 				)
-				cm.AuthInterface.On("IsAPIHostSlackProd", mock.Anything).Return(true)
-				cm.AuthInterface.On(
+				cm.Auth.On("IsAPIHostSlackProd", mock.Anything).Return(true)
+				cm.Auth.On(
 					"SetAuth",
 					mock.Anything,
 					mock.Anything,
@@ -146,8 +146,8 @@ func TestLoginCommand(t *testing.T) {
 					Required: true,
 				}).Return(mockChallengeCode, nil)
 				cm.API.On("ExchangeAuthTicket", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.ExchangeAuthTicketResult{}, nil)
-				cm.AuthInterface.On("IsAPIHostSlackProd", mock.Anything).Return(true)
-				cm.AuthInterface.On(
+				cm.Auth.On("IsAPIHostSlackProd", mock.Anything).Return(true)
+				cm.Auth.On(
 					"SetAuth",
 					mock.Anything,
 					mock.Anything,

--- a/cmd/auth/logout.go
+++ b/cmd/auth/logout.go
@@ -94,31 +94,31 @@ func handleAuthRemoval(ctx context.Context, clients *shared.ClientFactory, auth 
 	defer span.Finish()
 
 	// Update the API Host and Logstash Host to be the selected/default auth
-	clients.Config.APIHostResolved = clients.AuthInterface().ResolveAPIHost(ctx, clients.Config.APIHostFlag, &auth)
-	clients.Config.LogstashHostResolved = clients.AuthInterface().ResolveLogstashHost(ctx, clients.Config.APIHostResolved, clients.Config.Version)
+	clients.Config.APIHostResolved = clients.Auth().ResolveAPIHost(ctx, clients.Config.APIHostFlag, &auth)
+	clients.Config.LogstashHostResolved = clients.Auth().ResolveLogstashHost(ctx, clients.Config.APIHostResolved, clients.Config.Version)
 
 	// First, try to revoke the xoxe-xoxp (auth) token credential
 	var xoxpToken = auth.Token
-	if err := clients.AuthInterface().RevokeToken(ctx, xoxpToken); err != nil {
+	if err := clients.Auth().RevokeToken(ctx, xoxpToken); err != nil {
 		return err
 	}
 
 	// Next, try to revoke the refresh token xoxe-1 credential
 	var refreshToken = auth.RefreshToken
 	if refreshToken != "" {
-		if err := clients.AuthInterface().RevokeToken(ctx, refreshToken); err != nil {
+		if err := clients.Auth().RevokeToken(ctx, refreshToken); err != nil {
 			return err
 		}
 	}
 
 	// Once successfully revoked, remove from credentials.json
-	if _, err := clients.AuthInterface().DeleteAuth(ctx, auth); err != nil {
+	if _, err := clients.Auth().DeleteAuth(ctx, auth); err != nil {
 		return err
 	}
 
 	// Update the API Host and Logstash Host to be the selected/default auth
-	clients.Config.APIHostResolved = clients.AuthInterface().ResolveAPIHost(ctx, clients.Config.APIHostFlag, nil)
-	clients.Config.LogstashHostResolved = clients.AuthInterface().ResolveLogstashHost(ctx, clients.Config.APIHostResolved, clients.Config.Version)
+	clients.Config.APIHostResolved = clients.Auth().ResolveAPIHost(ctx, clients.Config.APIHostFlag, nil)
+	clients.Config.LogstashHostResolved = clients.Auth().ResolveLogstashHost(ctx, clients.Config.APIHostResolved, clients.Config.Version)
 
 	return nil
 }
@@ -136,7 +136,7 @@ func promptUserLogout(ctx context.Context, clients *shared.ClientFactory, cmd *c
 	}
 
 	// Gather all available auths
-	auths, err := clients.AuthInterface().Auths(ctx)
+	auths, err := clients.Auth().Auths(ctx)
 	if err != nil {
 		return []types.SlackAuth{}, err
 	}

--- a/cmd/auth/logout_test.go
+++ b/cmd/auth/logout_test.go
@@ -36,72 +36,72 @@ func TestLogoutCommand(t *testing.T) {
 		"logout of all teams": {
 			CmdArgs: []string{"--all"},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.AuthInterface.On("ResolveAPIHost", mock.Anything, mock.Anything, mock.Anything).Return("api.slack.com")
-				clientsMock.AuthInterface.On("ResolveLogstashHost", mock.Anything, mock.Anything, mock.Anything).Return("logstash.slack.com")
-				clientsMock.AuthInterface.On("Auths", mock.Anything).Return(fakeAuthsByTeamSlice, nil)
-				clientsMock.AuthInterface.On("RevokeToken", mock.Anything, fakeAuthsByTeamSlice[0].Token).Return(nil)
-				clientsMock.AuthInterface.On("RevokeToken", mock.Anything, fakeAuthsByTeamSlice[0].RefreshToken).Return(nil)
-				clientsMock.AuthInterface.On("RevokeToken", mock.Anything, fakeAuthsByTeamSlice[1].Token).Return(nil)
-				clientsMock.AuthInterface.On("RevokeToken", mock.Anything, fakeAuthsByTeamSlice[1].RefreshToken).Return(nil)
-				clientsMock.AuthInterface.On("DeleteAuth", mock.Anything, fakeAuthsByTeamSlice[0]).Return(types.SlackAuth{}, nil)
-				clientsMock.AuthInterface.On("DeleteAuth", mock.Anything, fakeAuthsByTeamSlice[1]).Return(types.SlackAuth{}, nil)
+				clientsMock.Auth.On("ResolveAPIHost", mock.Anything, mock.Anything, mock.Anything).Return("api.slack.com")
+				clientsMock.Auth.On("ResolveLogstashHost", mock.Anything, mock.Anything, mock.Anything).Return("logstash.slack.com")
+				clientsMock.Auth.On("Auths", mock.Anything).Return(fakeAuthsByTeamSlice, nil)
+				clientsMock.Auth.On("RevokeToken", mock.Anything, fakeAuthsByTeamSlice[0].Token).Return(nil)
+				clientsMock.Auth.On("RevokeToken", mock.Anything, fakeAuthsByTeamSlice[0].RefreshToken).Return(nil)
+				clientsMock.Auth.On("RevokeToken", mock.Anything, fakeAuthsByTeamSlice[1].Token).Return(nil)
+				clientsMock.Auth.On("RevokeToken", mock.Anything, fakeAuthsByTeamSlice[1].RefreshToken).Return(nil)
+				clientsMock.Auth.On("DeleteAuth", mock.Anything, fakeAuthsByTeamSlice[0]).Return(types.SlackAuth{}, nil)
+				clientsMock.Auth.On("DeleteAuth", mock.Anything, fakeAuthsByTeamSlice[1]).Return(types.SlackAuth{}, nil)
 			},
 			ExpectedOutputs: []string{"Authorization successfully revoked for all teams"},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clients *shared.ClientsMock) {
-				clients.AuthInterface.AssertCalled(t, "RevokeToken", mock.Anything, fakeAuthsByTeamSlice[0].Token)
-				clients.AuthInterface.AssertCalled(t, "RevokeToken", mock.Anything, fakeAuthsByTeamSlice[0].RefreshToken)
-				clients.AuthInterface.AssertCalled(t, "RevokeToken", mock.Anything, fakeAuthsByTeamSlice[1].Token)
-				clients.AuthInterface.AssertCalled(t, "RevokeToken", mock.Anything, fakeAuthsByTeamSlice[1].RefreshToken)
-				clients.AuthInterface.AssertCalled(t, "DeleteAuth", mock.Anything, fakeAuthsByTeamSlice[0])
-				clients.AuthInterface.AssertCalled(t, "DeleteAuth", mock.Anything, fakeAuthsByTeamSlice[1])
+				clients.Auth.AssertCalled(t, "RevokeToken", mock.Anything, fakeAuthsByTeamSlice[0].Token)
+				clients.Auth.AssertCalled(t, "RevokeToken", mock.Anything, fakeAuthsByTeamSlice[0].RefreshToken)
+				clients.Auth.AssertCalled(t, "RevokeToken", mock.Anything, fakeAuthsByTeamSlice[1].Token)
+				clients.Auth.AssertCalled(t, "RevokeToken", mock.Anything, fakeAuthsByTeamSlice[1].RefreshToken)
+				clients.Auth.AssertCalled(t, "DeleteAuth", mock.Anything, fakeAuthsByTeamSlice[0])
+				clients.Auth.AssertCalled(t, "DeleteAuth", mock.Anything, fakeAuthsByTeamSlice[1])
 				clients.IO.AssertNotCalled(t, "SelectPrompt", mock.Anything, "Select an authorization to revoke", mock.Anything, mock.Anything)
 			},
 		},
 		"logout of single team by named domain via flag": {
 			CmdArgs: []string{"--team", "team1"},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.AuthInterface.On("ResolveAPIHost", mock.Anything, mock.Anything, mock.Anything).Return("api.slack.com")
-				clientsMock.AuthInterface.On("ResolveLogstashHost", mock.Anything, mock.Anything, mock.Anything).Return("logstash.slack.com")
-				clientsMock.AuthInterface.On("Auths", mock.Anything).Return(fakeAuthsByTeamSlice, nil)
+				clientsMock.Auth.On("ResolveAPIHost", mock.Anything, mock.Anything, mock.Anything).Return("api.slack.com")
+				clientsMock.Auth.On("ResolveLogstashHost", mock.Anything, mock.Anything, mock.Anything).Return("logstash.slack.com")
+				clientsMock.Auth.On("Auths", mock.Anything).Return(fakeAuthsByTeamSlice, nil)
 				clientsMock.IO.On("SelectPrompt", mock.Anything, "Select an authorization to revoke", mock.Anything, iostreams.MatchPromptConfig(iostreams.SelectPromptConfig{
 					Flag: clientsMock.Config.Flags.Lookup("team"),
 				})).Return(iostreams.SelectPromptResponse{
 					Flag:   true,
 					Option: "team1",
 				}, nil)
-				clientsMock.AuthInterface.On("RevokeToken", mock.Anything, fakeAuthsByTeamSlice[0].Token).Return(nil)
-				clientsMock.AuthInterface.On("RevokeToken", mock.Anything, fakeAuthsByTeamSlice[0].RefreshToken).Return(nil)
-				clientsMock.AuthInterface.On("DeleteAuth", mock.Anything, fakeAuthsByTeamSlice[0]).Return(types.SlackAuth{}, nil)
+				clientsMock.Auth.On("RevokeToken", mock.Anything, fakeAuthsByTeamSlice[0].Token).Return(nil)
+				clientsMock.Auth.On("RevokeToken", mock.Anything, fakeAuthsByTeamSlice[0].RefreshToken).Return(nil)
+				clientsMock.Auth.On("DeleteAuth", mock.Anything, fakeAuthsByTeamSlice[0]).Return(types.SlackAuth{}, nil)
 			},
 			ExpectedOutputs: []string{"Authorization successfully revoked for team1"},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clients *shared.ClientsMock) {
-				clients.AuthInterface.AssertCalled(t, "RevokeToken", mock.Anything, fakeAuthsByTeamSlice[0].Token)
-				clients.AuthInterface.AssertCalled(t, "RevokeToken", mock.Anything, fakeAuthsByTeamSlice[0].RefreshToken)
-				clients.AuthInterface.AssertCalled(t, "DeleteAuth", mock.Anything, fakeAuthsByTeamSlice[0])
+				clients.Auth.AssertCalled(t, "RevokeToken", mock.Anything, fakeAuthsByTeamSlice[0].Token)
+				clients.Auth.AssertCalled(t, "RevokeToken", mock.Anything, fakeAuthsByTeamSlice[0].RefreshToken)
+				clients.Auth.AssertCalled(t, "DeleteAuth", mock.Anything, fakeAuthsByTeamSlice[0])
 				clients.IO.AssertCalled(t, "SelectPrompt", mock.Anything, "Select an authorization to revoke", mock.Anything, mock.Anything)
 			},
 		},
 		"logout of single team by id via flag": {
 			CmdArgs: []string{"--team", "T2"},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.AuthInterface.On("ResolveAPIHost", mock.Anything, mock.Anything, mock.Anything).Return("api.slack.com")
-				clientsMock.AuthInterface.On("ResolveLogstashHost", mock.Anything, mock.Anything, mock.Anything).Return("logstash.slack.com")
+				clientsMock.Auth.On("ResolveAPIHost", mock.Anything, mock.Anything, mock.Anything).Return("api.slack.com")
+				clientsMock.Auth.On("ResolveLogstashHost", mock.Anything, mock.Anything, mock.Anything).Return("logstash.slack.com")
 				clientsMock.IO.On("SelectPrompt", mock.Anything, "Select an authorization to revoke", mock.Anything, iostreams.MatchPromptConfig(iostreams.SelectPromptConfig{
 					Flag: clientsMock.Config.Flags.Lookup("team"),
 				})).Return(iostreams.SelectPromptResponse{
 					Flag:   true,
 					Option: "T2",
 				}, nil)
-				clientsMock.AuthInterface.On("Auths", mock.Anything).Return(fakeAuthsByTeamSlice, nil)
-				clientsMock.AuthInterface.On("RevokeToken", mock.Anything, fakeAuthsByTeamSlice[1].Token).Return(nil)
-				clientsMock.AuthInterface.On("RevokeToken", mock.Anything, fakeAuthsByTeamSlice[1].RefreshToken).Return(nil)
-				clientsMock.AuthInterface.On("DeleteAuth", mock.Anything, fakeAuthsByTeamSlice[1]).Return(types.SlackAuth{}, nil)
+				clientsMock.Auth.On("Auths", mock.Anything).Return(fakeAuthsByTeamSlice, nil)
+				clientsMock.Auth.On("RevokeToken", mock.Anything, fakeAuthsByTeamSlice[1].Token).Return(nil)
+				clientsMock.Auth.On("RevokeToken", mock.Anything, fakeAuthsByTeamSlice[1].RefreshToken).Return(nil)
+				clientsMock.Auth.On("DeleteAuth", mock.Anything, fakeAuthsByTeamSlice[1]).Return(types.SlackAuth{}, nil)
 			},
 			ExpectedOutputs: []string{"Authorization successfully revoked for team2"},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clients *shared.ClientsMock) {
-				clients.AuthInterface.AssertCalled(t, "RevokeToken", mock.Anything, fakeAuthsByTeamSlice[1].Token)
-				clients.AuthInterface.AssertCalled(t, "RevokeToken", mock.Anything, fakeAuthsByTeamSlice[1].RefreshToken)
-				clients.AuthInterface.AssertCalled(t, "DeleteAuth", mock.Anything, fakeAuthsByTeamSlice[1])
+				clients.Auth.AssertCalled(t, "RevokeToken", mock.Anything, fakeAuthsByTeamSlice[1].Token)
+				clients.Auth.AssertCalled(t, "RevokeToken", mock.Anything, fakeAuthsByTeamSlice[1].RefreshToken)
+				clients.Auth.AssertCalled(t, "DeleteAuth", mock.Anything, fakeAuthsByTeamSlice[1])
 				clients.IO.AssertCalled(t, "SelectPrompt", mock.Anything, "Select an authorization to revoke", mock.Anything, mock.Anything)
 			},
 		},
@@ -109,14 +109,14 @@ func TestLogoutCommand(t *testing.T) {
 			CmdArgs:              []string{"--team", ""},
 			ExpectedErrorStrings: []string{"The argument is missing from the --team flag (missing_flag)"},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clients *shared.ClientsMock) {
-				clients.AuthInterface.AssertNotCalled(t, "RevokeToken")
+				clients.Auth.AssertNotCalled(t, "RevokeToken")
 				clients.IO.AssertNotCalled(t, "SelectPrompt", mock.Anything, "Select an workspace authorization to revoke", mock.Anything, mock.Anything)
 			},
 		},
 		"require a known team value is used in flag": {
 			CmdArgs: []string{"--team", "randomteamdomain"},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.AuthInterface.On("Auths", mock.Anything).Return(fakeAuthsByTeamSlice, nil)
+				clientsMock.Auth.On("Auths", mock.Anything).Return(fakeAuthsByTeamSlice, nil)
 				clientsMock.IO.On("SelectPrompt", mock.Anything, "Select an authorization to revoke", mock.Anything, iostreams.MatchPromptConfig(iostreams.SelectPromptConfig{
 					Flag: clientsMock.Config.Flags.Lookup("team"),
 				})).Return(iostreams.SelectPromptResponse{
@@ -126,16 +126,16 @@ func TestLogoutCommand(t *testing.T) {
 			},
 			ExpectedErrorStrings: []string{"invalid_auth", "Cannot revoke authentication tokens for 'randomteamdomain'"},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clients *shared.ClientsMock) {
-				clients.AuthInterface.AssertNotCalled(t, "RevokeToken")
+				clients.Auth.AssertNotCalled(t, "RevokeToken")
 				clients.IO.AssertCalled(t, "SelectPrompt", mock.Anything, "Select an authorization to revoke", mock.Anything, mock.Anything)
 			},
 		},
 		"logout of a workspace by prompt": {
 			CmdArgs: []string{},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.AuthInterface.On("ResolveAPIHost", mock.Anything, mock.Anything, mock.Anything).Return("api.slack.com")
-				clientsMock.AuthInterface.On("ResolveLogstashHost", mock.Anything, mock.Anything, mock.Anything).Return("logstash.slack.com")
-				clientsMock.AuthInterface.On("Auths", mock.Anything).Return(fakeAuthsByTeamSlice, nil)
+				clientsMock.Auth.On("ResolveAPIHost", mock.Anything, mock.Anything, mock.Anything).Return("api.slack.com")
+				clientsMock.Auth.On("ResolveLogstashHost", mock.Anything, mock.Anything, mock.Anything).Return("logstash.slack.com")
+				clientsMock.Auth.On("Auths", mock.Anything).Return(fakeAuthsByTeamSlice, nil)
 				clientsMock.IO.On("SelectPrompt", mock.Anything, "Select an authorization to revoke", []string{
 					FormatAuthLabel(fakeAuthsByTeamSlice[0]),
 					FormatAuthLabel(fakeAuthsByTeamSlice[1]),
@@ -146,42 +146,42 @@ func TestLogoutCommand(t *testing.T) {
 					Option: fakeAuthsByTeamSlice[1].TeamDomain,
 					Index:  1,
 				}, nil)
-				clientsMock.AuthInterface.On("RevokeToken", mock.Anything, fakeAuthsByTeamSlice[1].Token).Return(nil)
-				clientsMock.AuthInterface.On("RevokeToken", mock.Anything, fakeAuthsByTeamSlice[1].RefreshToken).Return(nil)
-				clientsMock.AuthInterface.On("DeleteAuth", mock.Anything, fakeAuthsByTeamSlice[1]).Return(types.SlackAuth{}, nil)
+				clientsMock.Auth.On("RevokeToken", mock.Anything, fakeAuthsByTeamSlice[1].Token).Return(nil)
+				clientsMock.Auth.On("RevokeToken", mock.Anything, fakeAuthsByTeamSlice[1].RefreshToken).Return(nil)
+				clientsMock.Auth.On("DeleteAuth", mock.Anything, fakeAuthsByTeamSlice[1]).Return(types.SlackAuth{}, nil)
 			},
 			ExpectedOutputs: []string{"Authorization successfully revoked for team2"},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clients *shared.ClientsMock) {
-				clients.AuthInterface.AssertCalled(t, "RevokeToken", mock.Anything, fakeAuthsByTeamSlice[1].Token)
-				clients.AuthInterface.AssertCalled(t, "RevokeToken", mock.Anything, fakeAuthsByTeamSlice[1].RefreshToken)
-				clients.AuthInterface.AssertCalled(t, "DeleteAuth", mock.Anything, fakeAuthsByTeamSlice[1])
+				clients.Auth.AssertCalled(t, "RevokeToken", mock.Anything, fakeAuthsByTeamSlice[1].Token)
+				clients.Auth.AssertCalled(t, "RevokeToken", mock.Anything, fakeAuthsByTeamSlice[1].RefreshToken)
+				clients.Auth.AssertCalled(t, "DeleteAuth", mock.Anything, fakeAuthsByTeamSlice[1])
 				clients.IO.AssertCalled(t, "SelectPrompt", mock.Anything, "Select an authorization to revoke", mock.Anything, mock.Anything)
 			},
 		},
 		"automatically logout of the only available workspace available": {
 			CmdArgs: []string{},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.AuthInterface.On("ResolveAPIHost", mock.Anything, mock.Anything, mock.Anything).Return("api.slack.com")
-				clientsMock.AuthInterface.On("ResolveLogstashHost", mock.Anything, mock.Anything, mock.Anything).Return("logstash.slack.com")
-				clientsMock.AuthInterface.On("Auths", mock.Anything).Return([]types.SlackAuth{
+				clientsMock.Auth.On("ResolveAPIHost", mock.Anything, mock.Anything, mock.Anything).Return("api.slack.com")
+				clientsMock.Auth.On("ResolveLogstashHost", mock.Anything, mock.Anything, mock.Anything).Return("logstash.slack.com")
+				clientsMock.Auth.On("Auths", mock.Anything).Return([]types.SlackAuth{
 					fakeAuthsByTeamSlice[0],
 				}, nil)
-				clientsMock.AuthInterface.On("RevokeToken", mock.Anything, fakeAuthsByTeamSlice[0].Token).Return(nil)
-				clientsMock.AuthInterface.On("RevokeToken", mock.Anything, fakeAuthsByTeamSlice[0].RefreshToken).Return(nil)
-				clientsMock.AuthInterface.On("DeleteAuth", mock.Anything, fakeAuthsByTeamSlice[0]).Return(types.SlackAuth{}, nil)
+				clientsMock.Auth.On("RevokeToken", mock.Anything, fakeAuthsByTeamSlice[0].Token).Return(nil)
+				clientsMock.Auth.On("RevokeToken", mock.Anything, fakeAuthsByTeamSlice[0].RefreshToken).Return(nil)
+				clientsMock.Auth.On("DeleteAuth", mock.Anything, fakeAuthsByTeamSlice[0]).Return(types.SlackAuth{}, nil)
 			},
 			ExpectedOutputs: []string{"Authorization successfully revoked for team1"},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clients *shared.ClientsMock) {
-				clients.AuthInterface.AssertCalled(t, "RevokeToken", mock.Anything, fakeAuthsByTeamSlice[0].Token)
-				clients.AuthInterface.AssertCalled(t, "RevokeToken", mock.Anything, fakeAuthsByTeamSlice[0].RefreshToken)
-				clients.AuthInterface.AssertCalled(t, "DeleteAuth", mock.Anything, fakeAuthsByTeamSlice[0])
+				clients.Auth.AssertCalled(t, "RevokeToken", mock.Anything, fakeAuthsByTeamSlice[0].Token)
+				clients.Auth.AssertCalled(t, "RevokeToken", mock.Anything, fakeAuthsByTeamSlice[0].RefreshToken)
+				clients.Auth.AssertCalled(t, "DeleteAuth", mock.Anything, fakeAuthsByTeamSlice[0])
 				clients.IO.AssertNotCalled(t, "SelectPrompt", mock.Anything, "Select an authorization to revoke", mock.Anything, mock.Anything)
 			},
 		},
 		"verify the only available auth matches a team flag": {
 			CmdArgs: []string{"--team", "anotherteam"},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.AuthInterface.On("Auths", mock.Anything).Return([]types.SlackAuth{
+				clientsMock.Auth.On("Auths", mock.Anything).Return([]types.SlackAuth{
 					fakeAuthsByTeamSlice[0],
 				}, nil)
 				clientsMock.IO.On("SelectPrompt", mock.Anything, "Select an authorization to revoke", mock.Anything, iostreams.MatchPromptConfig(iostreams.SelectPromptConfig{
@@ -193,25 +193,25 @@ func TestLogoutCommand(t *testing.T) {
 			},
 			ExpectedErrorStrings: []string{"invalid_auth", "Cannot revoke authentication tokens for 'anotherteam'"},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clients *shared.ClientsMock) {
-				clients.AuthInterface.AssertNotCalled(t, "RevokeToken")
+				clients.Auth.AssertNotCalled(t, "RevokeToken")
 				clients.IO.AssertCalled(t, "SelectPrompt", mock.Anything, "Select an authorization to revoke", mock.Anything, mock.Anything)
 			},
 		},
 		"confirm authorizations are revoked if none exist": {
 			CmdArgs: []string{},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.AuthInterface.On("Auths", mock.Anything).Return([]types.SlackAuth{}, nil)
+				clientsMock.Auth.On("Auths", mock.Anything).Return([]types.SlackAuth{}, nil)
 			},
 			ExpectedOutputs: []string{"All authorizations successfully revoked"},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clients *shared.ClientsMock) {
-				clients.AuthInterface.AssertNotCalled(t, "RevokeToken")
+				clients.Auth.AssertNotCalled(t, "RevokeToken")
 				clients.IO.AssertNotCalled(t, "SelectPrompt", mock.Anything, "Select an authorization to revoke", mock.Anything, mock.Anything)
 			},
 		},
 		"error if a team flag is provided without auths": {
 			CmdArgs: []string{"--team", "someteam"},
 			Setup: func(t *testing.T, ctx context.Context, clientsMock *shared.ClientsMock, clients *shared.ClientFactory) {
-				clientsMock.AuthInterface.On("Auths", mock.Anything).Return([]types.SlackAuth{}, nil)
+				clientsMock.Auth.On("Auths", mock.Anything).Return([]types.SlackAuth{}, nil)
 				clientsMock.IO.On("SelectPrompt", mock.Anything, "Select an authorization to revoke", mock.Anything, iostreams.MatchPromptConfig(iostreams.SelectPromptConfig{
 					Flag: clientsMock.Config.Flags.Lookup("team"),
 				})).Return(iostreams.SelectPromptResponse{
@@ -220,7 +220,7 @@ func TestLogoutCommand(t *testing.T) {
 				}, nil)
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clients *shared.ClientsMock) {
-				clients.AuthInterface.AssertNotCalled(t, "RevokeToken")
+				clients.Auth.AssertNotCalled(t, "RevokeToken")
 				clients.IO.AssertCalled(t, "SelectPrompt", mock.Anything, "Select an authorization to revoke", mock.Anything, mock.Anything)
 			},
 			ExpectedErrorStrings: []string{"Cannot revoke authentication tokens for 'someteam'"},

--- a/cmd/auth/revoke.go
+++ b/cmd/auth/revoke.go
@@ -43,7 +43,7 @@ func NewRevokeCommand(clients *shared.ClientFactory) *cobra.Command {
 				return slackerror.New("Failed to collect a token to revoke").WithCode(slackerror.ErrNoTokenFound).WithRootCause(err)
 			}
 
-			if err := clients.AuthInterface().RevokeToken(ctx, token); err != nil {
+			if err := clients.Auth().RevokeToken(ctx, token); err != nil {
 				return err
 			}
 			printRevokeSuccess(ctx, clients)

--- a/cmd/auth/revoke_test.go
+++ b/cmd/auth/revoke_test.go
@@ -38,11 +38,11 @@ func TestRevokeCommand(t *testing.T) {
 					Flag:  true,
 					Value: "xoxp-example-1234",
 				}, nil)
-				clientsMock.AuthInterface.On("RevokeToken", mock.Anything, "xoxp-example-1234").Return(nil)
+				clientsMock.Auth.On("RevokeToken", mock.Anything, "xoxp-example-1234").Return(nil)
 			},
 			ExpectedOutputs: []string{"Authorization successfully revoked"},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clients *shared.ClientsMock) {
-				clients.AuthInterface.AssertCalled(t, "RevokeToken", mock.Anything, "xoxp-example-1234")
+				clients.Auth.AssertCalled(t, "RevokeToken", mock.Anything, "xoxp-example-1234")
 			},
 		},
 		"require a set token value with the flag": {
@@ -54,7 +54,7 @@ func TestRevokeCommand(t *testing.T) {
 			},
 			ExpectedErrorStrings: []string{"Failed to collect a token to revoke", "no_token_found", "missing_flag"},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clients *shared.ClientsMock) {
-				clients.AuthInterface.AssertNotCalled(t, "RevokeToken")
+				clients.Auth.AssertNotCalled(t, "RevokeToken")
 			},
 		},
 		"revoke a token input by prompt": {
@@ -66,11 +66,11 @@ func TestRevokeCommand(t *testing.T) {
 					Prompt: true,
 					Value:  "xoxp-example-1234",
 				}, nil)
-				clientsMock.AuthInterface.On("RevokeToken", mock.Anything, "xoxp-example-1234").Return(nil)
+				clientsMock.Auth.On("RevokeToken", mock.Anything, "xoxp-example-1234").Return(nil)
 			},
 			ExpectedOutputs: []string{"Authorization successfully revoked"},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clients *shared.ClientsMock) {
-				clients.AuthInterface.AssertCalled(t, "RevokeToken", mock.Anything, "xoxp-example-1234")
+				clients.Auth.AssertCalled(t, "RevokeToken", mock.Anything, "xoxp-example-1234")
 			},
 		},
 		"verify errors are gracefully handled during the revoke": {
@@ -82,11 +82,11 @@ func TestRevokeCommand(t *testing.T) {
 					Prompt: true,
 					Value:  "xoxp-example-1234",
 				}, nil)
-				clientsMock.AuthInterface.On("RevokeToken", mock.Anything, "xoxp-example-1234").Return(slackerror.New(slackerror.ErrNotAuthed))
+				clientsMock.Auth.On("RevokeToken", mock.Anything, "xoxp-example-1234").Return(slackerror.New(slackerror.ErrNotAuthed))
 			},
 			ExpectedError: slackerror.New(slackerror.ErrNotAuthed),
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, clients *shared.ClientsMock) {
-				clients.AuthInterface.AssertCalled(t, "RevokeToken", mock.Anything, "xoxp-example-1234")
+				clients.Auth.AssertCalled(t, "RevokeToken", mock.Anything, "xoxp-example-1234")
 				clients.IO.AssertNotCalled(t, "PrintTrace", mock.Anything, slacktrace.AuthRevokeSuccess)
 			},
 		},

--- a/cmd/auth/token_test.go
+++ b/cmd/auth/token_test.go
@@ -34,8 +34,8 @@ func TestTokenCommand(t *testing.T) {
 		TeamID:   &mockOrgAuth.TeamID,
 		TeamName: &mockOrgAuth.TeamDomain,
 		URL:      &mockOrgAuthURL}, nil)
-	clientsMock.AuthInterface.On("AuthWithTeamDomain", mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
-	clientsMock.AuthInterface.On("IsAPIHostSlackProd", mock.Anything).Return(true)
+	clientsMock.Auth.On("AuthWithTeamDomain", mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
+	clientsMock.Auth.On("IsAPIHostSlackProd", mock.Anything).Return(true)
 	clientsMock.AddDefaultMocks()
 	clients := shared.NewClientFactory(clientsMock.MockClientFactory())
 

--- a/cmd/doctor/check.go
+++ b/cmd/doctor/check.go
@@ -260,7 +260,7 @@ func checkCLIConfig(ctx context.Context, clients *shared.ClientFactory) (Section
 func checkCLICreds(ctx context.Context, clients *shared.ClientFactory) (Section, error) {
 	section := Section{"Credentials", "your Slack authentication", []Section{}, []slackerror.Error{}}
 
-	authList, err := clients.AuthInterface().Auths(ctx)
+	authList, err := clients.Auth().Auths(ctx)
 	if err != nil {
 		return Section{}, slackerror.New(slackerror.ErrAuthToken).WithRootCause(err)
 	}
@@ -300,7 +300,7 @@ func checkCLICreds(ctx context.Context, clients *shared.ClientFactory) (Section,
 			// TODO :: .ValidateSession() utilizes the host (APIHost) assigned to the client making
 			// the call. This results in incorrectly deeming tokens invalid if using multiple workspaces
 			// with different API hosts. (cc: @mbrooks)
-			clients.Config.APIHostResolved = clients.AuthInterface().ResolveAPIHost(ctx, clients.Config.APIHostFlag, &authInfo)
+			clients.Config.APIHostResolved = clients.Auth().ResolveAPIHost(ctx, clients.Config.APIHostFlag, &authInfo)
 			_, err := clients.API().ValidateSession(ctx, authInfo.Token)
 			if err != nil {
 				validitySection.Value = "Invalid"

--- a/cmd/doctor/doctor_test.go
+++ b/cmd/doctor/doctor_test.go
@@ -53,8 +53,8 @@ func TestDoctorCommand(t *testing.T) {
 	t.Run("creates a complete report", func(t *testing.T) {
 		ctx := slackcontext.MockContext(t.Context())
 		clientsMock := shared.NewClientsMock()
-		clientsMock.AuthInterface.On("Auths", mock.Anything).Return([]types.SlackAuth{expectedCredentials}, nil)
-		clientsMock.AuthInterface.On("ResolveAPIHost", mock.Anything, mock.Anything, mock.Anything).Return("api.slack.com")
+		clientsMock.Auth.On("Auths", mock.Anything).Return([]types.SlackAuth{expectedCredentials}, nil)
+		clientsMock.Auth.On("ResolveAPIHost", mock.Anything, mock.Anything, mock.Anything).Return("api.slack.com")
 		clientsMock.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
 		clientsMock.AddDefaultMocks()
 		pcm := &config.ProjectConfigMock{}

--- a/cmd/manifest/validate.go
+++ b/cmd/manifest/validate.go
@@ -129,10 +129,10 @@ func newValidateLogger(clients *shared.ClientFactory, cmd *cobra.Command) *logge
 func gatherAuthenticationToken(ctx context.Context, clients *shared.ClientFactory) (auth types.SlackAuth, err error) {
 	defer func() {
 		if err == nil {
-			clients.AuthInterface().SetSelectedAuth(ctx, auth, clients.Config, clients.Os)
+			clients.Auth().SetSelectedAuth(ctx, auth, clients.Config, clients.Os)
 		}
 	}()
-	auths, err := clients.AuthInterface().Auths(ctx)
+	auths, err := clients.Auth().Auths(ctx)
 	if err != nil {
 		return types.SlackAuth{}, err
 	}

--- a/cmd/manifest/validate_test.go
+++ b/cmd/manifest/validate_test.go
@@ -93,7 +93,7 @@ func TestManifestValidateCommand_HandleMissingAppInstallError_ZeroUserAuth(t *te
 
 	// Mock zero user auths
 	mockAuths := []types.SlackAuth{}
-	clientsMock.AuthInterface.On("Auths", mock.Anything).Return(mockAuths, nil)
+	clientsMock.Auth.On("Auths", mock.Anything).Return(mockAuths, nil)
 	clientsMock.AddDefaultMocks()
 
 	// A failed selection/prompt should raise an error
@@ -118,7 +118,7 @@ func TestManifestValidateCommand_HandleMissingAppInstallError_OneUserAuth(t *tes
 			ExpiresAt:    0,
 		},
 	}
-	clientsMock.AuthInterface.On("Auths", mock.Anything).Return(mockAuths, nil)
+	clientsMock.Auth.On("Auths", mock.Anything).Return(mockAuths, nil)
 	clientsMock.AddDefaultMocks()
 
 	// Create clients that is mocked for testing
@@ -143,7 +143,7 @@ func TestManifestValidateCommand_HandleMissingAppInstallError_OneUserAuth(t *tes
 	// Should execute without error
 	err := cmd.ExecuteContext(ctx)
 	require.NoError(t, err)
-	clientsMock.AuthInterface.AssertCalled(t, "SetSelectedAuth", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	clientsMock.Auth.AssertCalled(t, "SetSelectedAuth", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
 func TestManifestValidateCommand_HandleMissingAppInstallError_MoreThanOneUserAuth(t *testing.T) {
@@ -193,8 +193,8 @@ func TestManifestValidateCommand_HandleMissingAppInstallError_MoreThanOneUserAut
 			ExpiresAt:    0,
 		},
 	}
-	clientsMock.AuthInterface.On("Auths", mock.Anything).Return(mockAuths, nil)
-	clientsMock.AuthInterface.On("AuthWithTeamDomain", mock.Anything, "mock2").Return(mockAuths[1], nil)
+	clientsMock.Auth.On("Auths", mock.Anything).Return(mockAuths, nil)
+	clientsMock.Auth.On("AuthWithTeamDomain", mock.Anything, "mock2").Return(mockAuths[1], nil)
 	clientsMock.AddDefaultMocks()
 
 	// Mock the manifest validate package
@@ -205,7 +205,7 @@ func TestManifestValidateCommand_HandleMissingAppInstallError_MoreThanOneUserAut
 	// Should execute without error
 	err := cmd.ExecuteContext(ctx)
 	require.NoError(t, err)
-	clientsMock.AuthInterface.AssertCalled(t, "SetSelectedAuth", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	clientsMock.Auth.AssertCalled(t, "SetSelectedAuth", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 }
 
 func TestManifestValidateCommand_HandleOtherErrors(t *testing.T) {

--- a/cmd/project/init_test.go
+++ b/cmd/project/init_test.go
@@ -110,7 +110,7 @@ func Test_Project_InitCommand(t *testing.T) {
 			CmdArgs: []string{},
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
 				// Mocks auths to match against team and app
-				cm.AuthInterface.On("Auths", mock.Anything).Return([]types.SlackAuth{
+				cm.Auth.On("Auths", mock.Anything).Return([]types.SlackAuth{
 					mockLinkSlackAuth2,
 					mockLinkSlackAuth1,
 				}, nil)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -259,8 +259,8 @@ func InitConfig(ctx context.Context, clients *shared.ClientFactory, rootCmd *cob
 	clients.Config.TrustUnknownSources = trustSources
 
 	// Init clients that use flags
-	clients.Config.APIHostResolved = clients.AuthInterface().ResolveAPIHost(ctx, clients.Config.APIHostFlag, nil)
-	clients.Config.LogstashHostResolved = clients.AuthInterface().ResolveLogstashHost(ctx, clients.Config.APIHostResolved, clients.CLIVersion)
+	clients.Config.APIHostResolved = clients.Auth().ResolveAPIHost(ctx, clients.Config.APIHostFlag, nil)
+	clients.Config.LogstashHostResolved = clients.Auth().ResolveLogstashHost(ctx, clients.Config.APIHostResolved, clients.CLIVersion)
 
 	// Init System ID
 	if systemID, err := clients.Config.SystemConfig.InitSystemID(ctx); err != nil {
@@ -294,7 +294,7 @@ func InitConfig(ctx context.Context, clients *shared.ClientFactory, rootCmd *cob
 	clients.Config.Version = clients.CLIVersion
 
 	// The domain auths (token->domain) shouldn't change for the execution of the CLI so preload them into config!
-	clients.Config.DomainAuthTokens = clients.AuthInterface().MapAuthTokensToDomains(ctx)
+	clients.Config.DomainAuthTokens = clients.Auth().MapAuthTokensToDomains(ctx)
 
 	// Load the project CLI/SDK Configuration file
 	if err = clients.InitSDKConfig(ctx, workingDirPath); err != nil {

--- a/internal/pkg/apps/delete.go
+++ b/internal/pkg/apps/delete.go
@@ -88,8 +88,8 @@ func getAuthSession(ctx context.Context, clients *shared.ClientFactory, auth typ
 	// Update the APIHost with the selected login, this is important for commands that use the Login to temporarily
 	// get an auth without updating the default auth. It's less important for the Login command that terminals afterward,
 	// because on start up, the root command resolves the auth's current APIHost.
-	clients.Config.APIHostResolved = clients.AuthInterface().ResolveAPIHost(ctx, clients.Config.APIHostFlag, &auth)
-	clients.Config.LogstashHostResolved = clients.AuthInterface().ResolveLogstashHost(ctx, clients.Config.APIHostResolved, clients.Config.Version)
+	clients.Config.APIHostResolved = clients.Auth().ResolveAPIHost(ctx, clients.Config.APIHostFlag, &auth)
+	clients.Config.LogstashHostResolved = clients.Auth().ResolveLogstashHost(ctx, clients.Config.APIHostResolved, clients.Config.Version)
 
 	authSession, err := clients.API().ValidateSession(ctx, token)
 	if err != nil {

--- a/internal/pkg/apps/delete_test.go
+++ b/internal/pkg/apps/delete_test.go
@@ -81,8 +81,8 @@ func TestAppsDelete(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := shared.NewClientsMock()
-			clientsMock.AuthInterface.On("ResolveAPIHost", mock.Anything, mock.Anything, mock.Anything).Return("api host")
-			clientsMock.AuthInterface.On("ResolveLogstashHost", mock.Anything, mock.Anything, mock.Anything).Return("logstash host")
+			clientsMock.Auth.On("ResolveAPIHost", mock.Anything, mock.Anything, mock.Anything).Return("api host")
+			clientsMock.Auth.On("ResolveLogstashHost", mock.Anything, mock.Anything, mock.Anything).Return("logstash host")
 			clientsMock.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{
 				TeamName: &tt.auth.TeamDomain,
 				TeamID:   &tt.auth.TeamID,

--- a/internal/pkg/apps/list.go
+++ b/internal/pkg/apps/list.go
@@ -45,7 +45,7 @@ func List(ctx context.Context, clients *shared.ClientFactory) ([]types.App, stri
 	}
 	// Update local run app names to include domain (when possible)
 	for i, devApp := range devApps {
-		if auth, err := clients.AuthInterface().AuthWithTeamID(ctx, devApp.TeamID); err == nil {
+		if auth, err := clients.Auth().AuthWithTeamID(ctx, devApp.TeamID); err == nil {
 			// modify for display
 			devApps[i].TeamDomain = fmt.Sprintf("%s %s", auth.TeamDomain, style.LocalRunNameTag)
 
@@ -102,12 +102,12 @@ func FetchAppInstallStates(ctx context.Context, clients *shared.ClientFactory, a
 	}
 
 	// Get all available authed workspaces
-	auths, err := clients.AuthInterface().Auths(ctx)
+	auths, err := clients.Auth().Auths(ctx)
 	if err != nil {
 		return []types.App{}, err
 	}
 	if clients.Config.TokenFlag != "" {
-		if tokenAuth, err := clients.AuthInterface().AuthWithToken(ctx, clients.Config.TokenFlag); err != nil {
+		if tokenAuth, err := clients.Auth().AuthWithToken(ctx, clients.Config.TokenFlag); err != nil {
 			return []types.App{}, err
 		} else {
 			auths = append(auths, tokenAuth)

--- a/internal/pkg/apps/list_test.go
+++ b/internal/pkg/apps/list_test.go
@@ -112,7 +112,7 @@ func TestAppsList_FetchInstallStates_HasEnterpriseApp_HasEnterpriseAuth(t *testi
 	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
 
-	clientsMock.AuthInterface.On("Auths", mock.Anything).Return([]types.SlackAuth{
+	clientsMock.Auth.On("Auths", mock.Anything).Return([]types.SlackAuth{
 		authEnterprise1,
 	}, nil)
 	clientsMock.AddDefaultMocks()
@@ -138,9 +138,9 @@ func TestAppsList_FetchInstallStates_TokenFlag(t *testing.T) {
 	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
 
-	clientsMock.AuthInterface.On("Auths", mock.Anything).
+	clientsMock.Auth.On("Auths", mock.Anything).
 		Return([]types.SlackAuth{authTeam1}, nil)
-	clientsMock.AuthInterface.On("AuthWithToken", mock.Anything, team2Token).
+	clientsMock.Auth.On("AuthWithToken", mock.Anything, team2Token).
 		Return(authTeam2, nil)
 
 	clientsMock.API.On("GetAppStatus", mock.Anything, team1Token, []string{team1DeployedApp.AppID}, team1TeamID).Return(
@@ -175,9 +175,9 @@ func TestAppsList_FetchInstallStates_TokenFlag(t *testing.T) {
 func TestAppsList_FetchInstallStates_InvalidTokenFlag(t *testing.T) {
 	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
-	clientsMock.AuthInterface.On("Auths", mock.Anything).
+	clientsMock.Auth.On("Auths", mock.Anything).
 		Return([]types.SlackAuth{}, nil)
-	clientsMock.AuthInterface.On("AuthWithToken", mock.Anything, mock.Anything).
+	clientsMock.Auth.On("AuthWithToken", mock.Anything, mock.Anything).
 		Return(types.SlackAuth{}, slackerror.New(slackerror.ErrHTTPRequestFailed))
 	clientsMock.AddDefaultMocks()
 	clients := shared.NewClientFactory(clientsMock.MockClientFactory())

--- a/internal/pkg/auth/list.go
+++ b/internal/pkg/auth/list.go
@@ -31,7 +31,7 @@ func List(ctx context.Context, clients *shared.ClientFactory, log *logger.Logger
 	defer span.Finish()
 
 	// Get a sorted list of userAuths
-	auths, err := clients.AuthInterface().Auths(ctx)
+	auths, err := clients.Auth().Auths(ctx)
 	if err != nil {
 		return []types.SlackAuth{}, slackerror.Wrap(err, "Failed to get a list of user authorizations")
 	}

--- a/internal/pkg/auth/list_test.go
+++ b/internal/pkg/auth/list_test.go
@@ -49,7 +49,7 @@ func TestAuthList(t *testing.T) {
 	mockAuths := []types.SlackAuth{
 		authMockA,
 	}
-	clientsMock.AuthInterface.On("Auths", mock.Anything).Return(mockAuths, errors.New("There was an error"))
+	clientsMock.Auth.On("Auths", mock.Anything).Return(mockAuths, errors.New("There was an error"))
 
 	t.Run("Handles error getting auth slice", func(t *testing.T) {
 		_, err := List(ctx, clients, &logger.Logger{})
@@ -92,7 +92,7 @@ func TestAuthList_SortedAuths(t *testing.T) {
 		authB,
 	}
 
-	clientsMock.AuthInterface.On("Auths", mock.Anything).Return(mockAuths, nil)
+	clientsMock.Auth.On("Auths", mock.Anything).Return(mockAuths, nil)
 
 	_, err := List(ctx, clients, &logger.Logger{})
 	require.NoError(t, err)

--- a/internal/pkg/auth/login.go
+++ b/internal/pkg/auth/login.go
@@ -37,7 +37,7 @@ const InvalidNoPromptFlags = "Invalid arguments, both --ticket and --challenge f
 
 // LoginWithClients ...
 func LoginWithClients(ctx context.Context, clients *shared.ClientFactory, userToken string, noRotation bool) (auth types.SlackAuth, credentialsPath string, err error) {
-	return Login(ctx, clients.API(), clients.AuthInterface(), clients.IO, userToken, noRotation)
+	return Login(ctx, clients.API(), clients.Auth(), clients.IO, userToken, noRotation)
 }
 
 // Login takes the user through the Slack CLI login process
@@ -254,7 +254,7 @@ func LoginNoPrompt(ctx context.Context, clients *shared.ClientFactory, ticketArg
 		if err != nil || !authExchangeRes.IsReady {
 			return types.SlackAuth{}, "", err
 		}
-		savedAuth, credentialsPath, err := saveNewAuth(ctx, clients.API(), clients.AuthInterface(), authExchangeRes, noRotation)
+		savedAuth, credentialsPath, err := saveNewAuth(ctx, clients.API(), clients.Auth(), authExchangeRes, noRotation)
 		if err != nil {
 			return types.SlackAuth{}, "", err
 		}

--- a/internal/pkg/platform/deploy.go
+++ b/internal/pkg/platform/deploy.go
@@ -177,7 +177,7 @@ func deployApp(ctx context.Context, clients *shared.ClientFactory, log *logger.L
 	//
 	// Note: This errors silently to continue deployment without any problem
 	var apiHost = clients.Config.APIHostResolved
-	if clients.AuthInterface().IsAPIHostSlackDev(apiHost) {
+	if clients.Auth().IsAPIHostSlackDev(apiHost) {
 		apiHostURL := fmt.Sprintf("%s/api/", apiHost)
 		_ = clients.API().AddVariable(ctx, token, app.AppID, "SLACK_API_URL", apiHostURL)
 	}

--- a/internal/prompts/app_select.go
+++ b/internal/prompts/app_select.go
@@ -228,13 +228,13 @@ func getApps(ctx context.Context, clients *shared.ClientFactory) (map[string]Sel
 		if appIDs[saved.AppID].App.AppID != "" {
 			continue
 		}
-		resolvedAuth, err := clients.AuthInterface().AuthWithTeamID(ctx, saved.TeamID)
+		resolvedAuth, err := clients.Auth().AuthWithTeamID(ctx, saved.TeamID)
 		if err != nil {
 			if slackerror.ToSlackError(err).Code != slackerror.ErrCredentialsNotFound {
 				return map[string]SelectedApp{}, err
 			}
 			if saved.IsEnterpriseWorkspaceApp() {
-				resolvedAuth, err = clients.AuthInterface().AuthWithTeamID(ctx, saved.EnterpriseID)
+				resolvedAuth, err = clients.Auth().AuthWithTeamID(ctx, saved.EnterpriseID)
 				if err != nil && slackerror.ToSlackError(err).Code != slackerror.ErrCredentialsNotFound {
 					return map[string]SelectedApp{}, err
 				}
@@ -251,13 +251,13 @@ func getApps(ctx context.Context, clients *shared.ClientFactory) (map[string]Sel
 		if appIDs[saved.AppID].App.AppID != "" {
 			continue
 		}
-		resolvedAuth, err := clients.AuthInterface().AuthWithTeamID(ctx, saved.TeamID)
+		resolvedAuth, err := clients.Auth().AuthWithTeamID(ctx, saved.TeamID)
 		if err != nil {
 			if slackerror.ToSlackError(err).Code != slackerror.ErrCredentialsNotFound {
 				return map[string]SelectedApp{}, err
 			}
 			if saved.IsEnterpriseWorkspaceApp() {
-				resolvedAuth, err = clients.AuthInterface().AuthWithTeamID(ctx, saved.EnterpriseID)
+				resolvedAuth, err = clients.Auth().AuthWithTeamID(ctx, saved.EnterpriseID)
 				if err != nil && slackerror.ToSlackError(err).Code != slackerror.ErrCredentialsNotFound {
 					return map[string]SelectedApp{}, err
 				}
@@ -314,16 +314,16 @@ func getApps(ctx context.Context, clients *shared.ClientFactory) (map[string]Sel
 
 // getAuths returns the available authentications for the selection
 func getAuths(ctx context.Context, clients *shared.ClientFactory) ([]types.SlackAuth, error) {
-	allAuths, err := clients.AuthInterface().Auths(ctx)
+	allAuths, err := clients.Auth().Auths(ctx)
 	if err != nil {
 		return nil, err
 	}
 	if clients.Config.TokenFlag != "" {
-		tokenAuth, err := clients.AuthInterface().AuthWithToken(ctx, clients.Config.TokenFlag)
+		tokenAuth, err := clients.Auth().AuthWithToken(ctx, clients.Config.TokenFlag)
 		if err != nil {
 			return []types.SlackAuth{}, err
 		}
-		_, err = clients.AuthInterface().AuthWithTeamID(ctx, tokenAuth.TeamID)
+		_, err = clients.Auth().AuthWithTeamID(ctx, tokenAuth.TeamID)
 		if err != nil {
 			if slackerror.ToSlackError(err).Code == slackerror.ErrCredentialsNotFound {
 				allAuths = append(allAuths, tokenAuth)
@@ -425,7 +425,7 @@ func getTeamApps(ctx context.Context, clients *shared.ClientFactory) (map[string
 		var resolvedAuth types.SlackAuth
 
 		// Try to find an auth that matches the app's team id
-		_, err := clients.AuthInterface().AuthWithTeamID(ctx, deployedApp.TeamID)
+		_, err := clients.Auth().AuthWithTeamID(ctx, deployedApp.TeamID)
 		if err == nil {
 			continue
 		} else {
@@ -437,7 +437,7 @@ func getTeamApps(ctx context.Context, clients *shared.ClientFactory) (map[string
 				// in credentials.json. If found, use that auth as the resolved auth
 				// for this workspace app
 
-				resolvedAuth, err = clients.AuthInterface().AuthWithTeamID(ctx, deployedApp.EnterpriseID)
+				resolvedAuth, err = clients.Auth().AuthWithTeamID(ctx, deployedApp.EnterpriseID)
 				if err != nil && slackerror.ToSlackError(err).Code != slackerror.ErrCredentialsNotFound {
 					// Fetching an auth by team id failed for some other reason than credentials not being found
 					return map[string]TeamApps{}, err
@@ -485,7 +485,7 @@ func getTeamApps(ctx context.Context, clients *shared.ClientFactory) (map[string
 		}
 		var resolvedAuth types.SlackAuth
 
-		_, err = clients.AuthInterface().AuthWithTeamID(ctx, localApp.TeamID)
+		_, err = clients.Auth().AuthWithTeamID(ctx, localApp.TeamID)
 		if err == nil {
 			continue
 		} else {
@@ -498,7 +498,7 @@ func getTeamApps(ctx context.Context, clients *shared.ClientFactory) (map[string
 				// in credentials.json. If found, use that auth as the resolved auth
 				// for this workspace app
 
-				resolvedAuth, err = clients.AuthInterface().AuthWithTeamID(ctx, localApp.EnterpriseID)
+				resolvedAuth, err = clients.Auth().AuthWithTeamID(ctx, localApp.EnterpriseID)
 
 				if err != nil && slackerror.ToSlackError(err).Code != slackerror.ErrCredentialsNotFound {
 					// Fetching an auth by team id failed for some other reason than credentials not being found
@@ -540,7 +540,7 @@ func getTeamApps(ctx context.Context, clients *shared.ClientFactory) (map[string
 
 // getTokenApp gathers app and auth info from the API using the token and app ID
 func getTokenApp(ctx context.Context, clients *shared.ClientFactory, token string, appID string) (SelectedApp, error) {
-	auth, err := clients.AuthInterface().AuthWithToken(ctx, token)
+	auth, err := clients.Auth().AuthWithToken(ctx, token)
 	if err != nil {
 		return SelectedApp{}, err
 	}
@@ -661,7 +661,7 @@ func filterAuthsByToken(ctx context.Context, clients *shared.ClientFactory, work
 	var appFlag = clients.Config.AppFlag   // an app_id, local, deploy, or deployed
 
 	// Fetch an existing Auth that matches supplied token OR return a brand new Auth object
-	auth, err := clients.AuthInterface().AuthWithToken(ctx, clients.Config.TokenFlag)
+	auth, err := clients.Auth().AuthWithToken(ctx, clients.Config.TokenFlag)
 	if err != nil {
 		return types.SlackAuth{}, err
 	}
@@ -1045,7 +1045,7 @@ func flatAppSelectPrompt(
 		if err != nil {
 			return
 		}
-		clients.AuthInterface().SetSelectedAuth(ctx, selected.Auth, clients.Config, clients.Os)
+		clients.Auth().SetSelectedAuth(ctx, selected.Auth, clients.Config, clients.Os)
 		if selected.App.IsNew() {
 			clients.IO.PrintInfo(ctx, false, "\n%s", style.Sectionf(appTransferDisclaimer))
 		}
@@ -1058,7 +1058,7 @@ func flatAppSelectPrompt(
 		if status == ShowInstalledAppsOnly && selection.App.InstallStatus != types.AppStatusInstalled {
 			return SelectedApp{}, slackerror.New(slackerror.ErrInstallationRequired)
 		}
-		clients.AuthInterface().SetSelectedAuth(ctx, selection.Auth, clients.Config, clients.Os)
+		clients.Auth().SetSelectedAuth(ctx, selection.Auth, clients.Config, clients.Os)
 		// The development status of an app cannot be determined when local app files
 		// do not exist. This defaults to "false" for these cases.
 		//
@@ -1078,7 +1078,7 @@ func flatAppSelectPrompt(
 	// teamFlag is set to a team ID if either the --team or --token flag is set
 	teamFlag := ""
 	if clients.Config.TokenFlag != "" {
-		token, err := clients.AuthInterface().AuthWithToken(ctx, clients.Config.TokenFlag)
+		token, err := clients.Auth().AuthWithToken(ctx, clients.Config.TokenFlag)
 		if err != nil {
 			return SelectedApp{}, err
 		}
@@ -1306,7 +1306,7 @@ func AppSelectPrompt(ctx context.Context, clients *shared.ClientFactory, status 
 		if status == ShowInstalledAppsOnly && selection.App.InstallStatus != types.AppStatusInstalled {
 			return SelectedApp{}, slackerror.New(slackerror.ErrInstallationRequired)
 		}
-		clients.AuthInterface().SetSelectedAuth(ctx, selection.Auth, clients.Config, clients.Os)
+		clients.Auth().SetSelectedAuth(ctx, selection.Auth, clients.Config, clients.Os)
 		return selection, nil
 	}
 
@@ -1405,7 +1405,7 @@ func AppSelectPrompt(ctx context.Context, clients *shared.ClientFactory, status 
 		return selectedApp, err
 	}
 
-	clients.AuthInterface().SetSelectedAuth(ctx, selectedApp.Auth, clients.Config, clients.Os)
+	clients.Auth().SetSelectedAuth(ctx, selectedApp.Auth, clients.Config, clients.Os)
 	return selectedApp, nil
 }
 
@@ -1425,7 +1425,7 @@ func flatTeamSelectPrompt(
 		if err != nil {
 			return
 		}
-		clients.AuthInterface().SetSelectedAuth(ctx, authentication, clients.Config, clients.Os)
+		clients.Auth().SetSelectedAuth(ctx, authentication, clients.Config, clients.Os)
 	}()
 	allAuths, err := getAuths(ctx, clients)
 	if err != nil {
@@ -1520,7 +1520,7 @@ func TeamAppSelectPrompt(ctx context.Context, clients *shared.ClientFactory, env
 		if status == ShowInstalledAppsOnly && selection.App.InstallStatus != types.AppStatusInstalled {
 			return SelectedApp{}, slackerror.New(slackerror.ErrInstallationRequired)
 		}
-		clients.AuthInterface().SetSelectedAuth(ctx, selection.Auth, clients.Config, clients.Os)
+		clients.Auth().SetSelectedAuth(ctx, selection.Auth, clients.Config, clients.Os)
 		// The development status of an app cannot be determined when local app files
 		// do not exist. This defaults to "false" for these cases.
 		//
@@ -1565,7 +1565,7 @@ func TeamAppSelectPrompt(ctx context.Context, clients *shared.ClientFactory, env
 			selection.App.InstallStatus != types.AppStatusInstalled {
 			return SelectedApp{}, slackerror.New(slackerror.ErrInstallationRequired)
 		}
-		clients.AuthInterface().SetSelectedAuth(ctx, selection.Auth, clients.Config, clients.Os)
+		clients.Auth().SetSelectedAuth(ctx, selection.Auth, clients.Config, clients.Os)
 		return selection, nil
 	}
 
@@ -1617,7 +1617,7 @@ func TeamAppSelectPrompt(ctx context.Context, clients *shared.ClientFactory, env
 				WithMessage("No credentials found for team \"%s\"", filteredByTeamFlag.authOrAppTeamDomain())
 		}
 
-		clients.AuthInterface().SetSelectedAuth(ctx, selection.Auth, clients.Config, clients.Os)
+		clients.Auth().SetSelectedAuth(ctx, selection.Auth, clients.Config, clients.Os)
 		return selection, err
 	}
 
@@ -1658,7 +1658,7 @@ func TeamAppSelectPrompt(ctx context.Context, clients *shared.ClientFactory, env
 		}
 
 		// Set the auth context and return the app
-		clients.AuthInterface().SetSelectedAuth(ctx, selection.Auth, clients.Config, clients.Os)
+		clients.Auth().SetSelectedAuth(ctx, selection.Auth, clients.Config, clients.Os)
 		return selection, nil
 	}
 
@@ -1676,8 +1676,8 @@ func TeamAppSelectPrompt(ctx context.Context, clients *shared.ClientFactory, env
 		return selection, err
 	}
 
-	if auth, err := clients.AuthInterface().AuthWithTeamID(ctx, selection.Auth.TeamID); err == nil {
-		clients.AuthInterface().SetSelectedAuth(ctx, auth, clients.Config, clients.Os)
+	if auth, err := clients.Auth().AuthWithTeamID(ctx, selection.Auth.TeamID); err == nil {
+		clients.Auth().SetSelectedAuth(ctx, auth, clients.Config, clients.Os)
 		return selection, err
 	}
 
@@ -1835,12 +1835,12 @@ func validateAuth(ctx context.Context, clients *shared.ClientFactory, auth *type
 	if err == nil {
 		return nil
 	}
-	_, unfilteredError := clients.AuthInterface().FilterKnownAuthErrors(ctx, err)
+	_, unfilteredError := clients.Auth().FilterKnownAuthErrors(ctx, err)
 	if unfilteredError != nil || !clients.IO.IsTTY() {
 		return err
 	}
 	clients.IO.PrintInfo(ctx, false, fmt.Sprintf("\n%sWhoops! Looks like your authentication may be expired or invalid", style.Emoji("lock")))
-	reauth, _, err := authpkg.Login(ctx, apiClient, clients.AuthInterface(), clients.IO, "", false)
+	reauth, _, err := authpkg.Login(ctx, apiClient, clients.Auth(), clients.IO, "", false)
 	if err != nil {
 		return err
 	}

--- a/internal/prompts/app_select_test.go
+++ b/internal/prompts/app_select_test.go
@@ -223,7 +223,7 @@ func TestGetTeamApps(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := shared.NewClientsMock()
-			clientsMock.AuthInterface.On(
+			clientsMock.Auth.On(
 				AuthWithToken,
 				mock.Anything,
 				mock.Anything,
@@ -231,7 +231,7 @@ func TestGetTeamApps(t *testing.T) {
 				tt.mockAuthWithTokenResponse,
 				tt.mockAuthWithTokenError,
 			)
-			clientsMock.AuthInterface.On(
+			clientsMock.Auth.On(
 				AuthWithTeamID,
 				mock.Anything,
 				tt.mockAuthWithTokenResponse.TeamID,
@@ -372,7 +372,7 @@ func TestGetTokenApp(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := shared.NewClientsMock()
-			clientsMock.AuthInterface.On(AuthWithToken, mock.Anything, test.tokenFlag).
+			clientsMock.Auth.On(AuthWithToken, mock.Anything, test.tokenFlag).
 				Return(test.tokenAuth, test.tokenErr)
 			clientsMock.API.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 				Return(test.appStatus, test.statusErr)
@@ -418,11 +418,11 @@ func TestFilterAuthsByToken_NoLogin(t *testing.T) {
 
 	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
-	clientsMock.AuthInterface.On(AuthWithToken, mock.Anything, test.TokenFlag).
+	clientsMock.Auth.On(AuthWithToken, mock.Anything, test.TokenFlag).
 		Return(test.expectedAuth, nil)
-	clientsMock.AuthInterface.On(Auths, mock.Anything).Return([]types.SlackAuth{}, nil)
-	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, errors.New(slackerror.ErrCredentialsNotFound))
-	clientsMock.AuthInterface.On(SetAuth, mock.Anything).Return(types.SlackAuth{}, nil)
+	clientsMock.Auth.On(Auths, mock.Anything).Return([]types.SlackAuth{}, nil)
+	clientsMock.Auth.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, errors.New(slackerror.ErrCredentialsNotFound))
+	clientsMock.Auth.On(SetAuth, mock.Anything).Return(types.SlackAuth{}, nil)
 	clientsMock.AddDefaultMocks()
 
 	clients := shared.NewClientFactory(clientsMock.MockClientFactory())
@@ -447,15 +447,15 @@ func Test_FilterAuthsByToken_Flags(t *testing.T) {
 	mockAuthTeam2.Token = team2Token
 
 	clientsMock := shared.NewClientsMock()
-	clientsMock.AuthInterface.On(AuthWithToken, mock.Anything, team1Token).
+	clientsMock.Auth.On(AuthWithToken, mock.Anything, team1Token).
 		Return(mockAuthTeam1, nil)
-	clientsMock.AuthInterface.On(AuthWithToken, mock.Anything, team2Token).
+	clientsMock.Auth.On(AuthWithToken, mock.Anything, team2Token).
 		Return(mockAuthTeam2, nil)
 
 	clientsMock.API.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.GetAppStatusResult{}, nil)
-	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
-	clientsMock.AuthInterface.On(SetAuth, mock.Anything).Return(types.SlackAuth{}, nil)
-	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, errors.New(slackerror.ErrCredentialsNotFound))
+	clientsMock.Auth.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
+	clientsMock.Auth.On(SetAuth, mock.Anything).Return(types.SlackAuth{}, nil)
+	clientsMock.Auth.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, errors.New(slackerror.ErrCredentialsNotFound))
 
 	clientsMock.AddDefaultMocks()
 
@@ -579,11 +579,11 @@ func TestPrompt_AppSelectPrompt_SelectedAuthExpired_UserReAuthenticates(t *testi
 	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
 	// Auth is present but invalid
-	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
+	clientsMock.Auth.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
 	mockReauthentication(clientsMock)
 	clientsMock.API.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 		api.GetAppStatusResult{}, nil)
-	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
+	clientsMock.Auth.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
 
 	clientsMock.IO.On(SelectPrompt, mock.Anything, "Choose an app environment", mock.Anything, iostreams.MatchPromptConfig(iostreams.SelectPromptConfig{
 		Flag: clientsMock.Config.Flags.Lookup("app"),
@@ -693,7 +693,7 @@ func TestPrompt_AppSelectPrompt_TokenAppFlag(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := shared.NewClientsMock()
-			clientsMock.AuthInterface.On(AuthWithToken, mock.Anything, test.tokenFlag).
+			clientsMock.Auth.On(AuthWithToken, mock.Anything, test.tokenFlag).
 				Return(test.tokenAuth, nil)
 			clientsMock.API.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 				Return(test.appStatus, test.statusErr)
@@ -729,8 +729,8 @@ func TestPrompt_AppSelectPrompt_AuthsWithDeployedAppInstalled_ShowAllApps(t *tes
 		api.GetAppStatusResult{
 			Apps: []api.AppStatusResultAppInfo{{AppID: "A1EXAMPLE01", Installed: true}},
 		}, nil)
-	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
-	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
+	clientsMock.Auth.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
+	clientsMock.Auth.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
 	clientsMock.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
 	clientsMock.AddDefaultMocks()
 
@@ -776,8 +776,8 @@ func TestPrompt_AppSelectPrompt_AuthsWithDeployedAppInstalled_ShowInstalledAppsO
 		api.GetAppStatusResult{
 			Apps: []api.AppStatusResultAppInfo{{AppID: "A1EXAMPLE01", Installed: true}},
 		}, nil)
-	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
-	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
+	clientsMock.Auth.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
+	clientsMock.Auth.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
 	clientsMock.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
 	clientsMock.AddDefaultMocks()
 
@@ -824,8 +824,8 @@ func TestPrompt_AppSelectPrompt_AuthsWithDeployedAppInstalled_InstalledAppOnly_F
 		api.GetAppStatusResult{
 			Apps: []api.AppStatusResultAppInfo{{AppID: "A1EXAMPLE01", Installed: true}},
 		}, nil)
-	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
-	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
+	clientsMock.Auth.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
+	clientsMock.Auth.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
 	clientsMock.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
 	clientsMock.AddDefaultMocks()
 
@@ -953,14 +953,14 @@ func TestPrompt_AppSelectPrompt_AuthsWithBothEnvsInstalled_InstalledAppOnly_Flag
 				{AppID: "A1EXAMPLE02", Installed: true},
 			},
 		}, nil)
-	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
-	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mockAuthTeam1.TeamID).Return(mockAuthTeam1, nil)
-	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mockAuthTeam2.TeamID).Return(mockAuthTeam2, nil)
+	clientsMock.Auth.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
+	clientsMock.Auth.On(AuthWithTeamID, mock.Anything, mockAuthTeam1.TeamID).Return(mockAuthTeam1, nil)
+	clientsMock.Auth.On(AuthWithTeamID, mock.Anything, mockAuthTeam2.TeamID).Return(mockAuthTeam2, nil)
 	clientsMock.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
 
-	clientsMock.AuthInterface.On(AuthWithToken, mock.Anything, team1Token).
+	clientsMock.Auth.On(AuthWithToken, mock.Anything, team1Token).
 		Return(mockAuthTeam1, nil)
-	clientsMock.AuthInterface.On(AuthWithToken, mock.Anything, team2Token).
+	clientsMock.Auth.On(AuthWithToken, mock.Anything, team2Token).
 		Return(mockAuthTeam2, nil)
 
 	clientsMock.AddDefaultMocks()
@@ -1105,8 +1105,8 @@ func TestPrompt_AppSelectPrompt_AuthsWithBothEnvsInstalled_MultiWorkspaceAllApps
 				{AppID: "A1EXAMPLE02", Installed: true},
 				{AppID: "A1EXAMPLE03", Installed: true},
 			}}, nil)
-	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
-	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
+	clientsMock.Auth.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
+	clientsMock.Auth.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
 	clientsMock.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
 	clientsMock.AddDefaultMocks()
 
@@ -1230,8 +1230,8 @@ func TestPrompt_AppSelectPrompt_AuthsWithHostedInstalled_AllApps_CreateNew(t *te
 				{AppID: "A1EXAMPLE01", Installed: true},
 				{AppID: "A1EXAMPLE02", Installed: true},
 			}}, nil)
-	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
-	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
+	clientsMock.Auth.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
+	clientsMock.Auth.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
 	clientsMock.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
 	clientsMock.AddDefaultMocks()
 
@@ -1301,8 +1301,8 @@ func TestPrompt_AppSelectPrompt_ShowExpectedLabels(t *testing.T) {
 			UserID:     "U3",
 			Token:      "xoxe.xoxp-2-token",
 		})
-		clientsMock.AuthInterface.On(Auths, mock.Anything).Return(auths, nil)
-		clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
+		clientsMock.Auth.On(Auths, mock.Anything).Return(auths, nil)
+		clientsMock.Auth.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
 		clientsMock.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
 		clientsMock.API.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 			api.GetAppStatusResult{
@@ -1713,14 +1713,14 @@ func TestPrompt_AppSelectPrompt_GetApps(t *testing.T) {
 				api.AuthSession{},
 				nil,
 			)
-			clientsMock.AuthInterface.On(
+			clientsMock.Auth.On(
 				Auths,
 				mock.Anything,
 			).Return(
 				tt.mockAuths,
 				nil,
 			)
-			clientsMock.AuthInterface.On(
+			clientsMock.Auth.On(
 				AuthWithTeamID,
 				mock.Anything,
 				team2TeamID,
@@ -1728,7 +1728,7 @@ func TestPrompt_AppSelectPrompt_GetApps(t *testing.T) {
 				tt.mockTeam2SavedAuth,
 				tt.mockTeam2SavedAuthError,
 			)
-			clientsMock.AuthInterface.On(
+			clientsMock.Auth.On(
 				AuthWithTeamID,
 				mock.Anything,
 				team1TeamID,
@@ -1736,7 +1736,7 @@ func TestPrompt_AppSelectPrompt_GetApps(t *testing.T) {
 				tt.mockTeam1SavedAuth,
 				tt.mockTeam1SavedAuthError,
 			)
-			clientsMock.AuthInterface.On(
+			clientsMock.Auth.On(
 				AuthWithTeamID,
 				mock.Anything,
 				enterprise1TeamID,
@@ -2279,14 +2279,14 @@ func TestPrompt_AppSelectPrompt_FlatAppSelectPrompt(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := shared.NewClientsMock()
-			clientsMock.AuthInterface.On(
+			clientsMock.Auth.On(
 				Auths,
 				mock.Anything,
 			).Return(
 				tt.mockAuths,
 				nil,
 			)
-			clientsMock.AuthInterface.On(
+			clientsMock.Auth.On(
 				AuthWithTeamID,
 				mock.Anything,
 				tt.mockAuthWithTeamIDTeamID,
@@ -2294,7 +2294,7 @@ func TestPrompt_AppSelectPrompt_FlatAppSelectPrompt(t *testing.T) {
 				types.SlackAuth{},
 				tt.mockAuthWithTeamIDError,
 			)
-			clientsMock.AuthInterface.On(
+			clientsMock.Auth.On(
 				AuthWithToken,
 				mock.Anything,
 				tt.mockFlagToken,
@@ -2513,11 +2513,11 @@ func TestPrompt_TeamAppSelectPrompt_SelectedAuthExpired_UserReAuthenticates(t *t
 	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
 	// Auth is present but invalid
-	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
+	clientsMock.Auth.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
 	mockReauthentication(clientsMock)
 	clientsMock.API.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 		api.GetAppStatusResult{}, nil)
-	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
+	clientsMock.Auth.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
 
 	clientsMock.IO.On(SelectPrompt, mock.Anything, "Choose a deployed environment", mock.Anything, iostreams.MatchPromptConfig(iostreams.SelectPromptConfig{
 		Flag: clientsMock.Config.Flags.Lookup("team"),
@@ -2546,11 +2546,11 @@ func TestPrompt_TeamAppSelectPrompt_NoAuths_UserReAuthenticates(t *testing.T) {
 	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
 	// No auths present
-	clientsMock.AuthInterface.On(Auths, mock.Anything).Return([]types.SlackAuth{}, nil)
+	clientsMock.Auth.On(Auths, mock.Anything).Return([]types.SlackAuth{}, nil)
 	mockReauthentication(clientsMock)
 	clientsMock.API.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 		api.GetAppStatusResult{}, nil)
-	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
+	clientsMock.Auth.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
 
 	clientsMock.IO.On(SelectPrompt, mock.Anything, "Choose a deployed environment", mock.Anything, iostreams.MatchPromptConfig(iostreams.SelectPromptConfig{
 		Flag: clientsMock.Config.Flags.Lookup("team"),
@@ -2678,7 +2678,7 @@ func TestPrompt_TeamAppSelectPrompt_TokenAppFlag(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := shared.NewClientsMock()
-			clientsMock.AuthInterface.On(AuthWithToken, mock.Anything, test.tokenFlag).
+			clientsMock.Auth.On(AuthWithToken, mock.Anything, test.tokenFlag).
 				Return(test.tokenAuth, nil)
 			clientsMock.API.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 				Return(test.appStatus, test.statusErr)
@@ -2713,7 +2713,7 @@ func TestPrompt_TeamAppSelectPrompt_TeamNotFoundFor_TeamFlag(t *testing.T) {
 	// Set up mocks
 	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
-	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
+	clientsMock.Auth.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
 	clientsMock.AddDefaultMocks()
 
 	clients := shared.NewClientFactory(clientsMock.MockClientFactory())
@@ -2743,9 +2743,9 @@ func TestPrompt_TeamAppSelectPrompt_NoApps(t *testing.T) {
 	// Set up mocks
 	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
-	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
-	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, team1TeamID).Return(fakeAuthsByTeamDomain[team1TeamDomain], nil)
-	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, team2TeamID).Return(fakeAuthsByTeamDomain[team2TeamDomain], nil)
+	clientsMock.Auth.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
+	clientsMock.Auth.On(AuthWithTeamID, mock.Anything, team1TeamID).Return(fakeAuthsByTeamDomain[team1TeamDomain], nil)
+	clientsMock.Auth.On(AuthWithTeamID, mock.Anything, team2TeamID).Return(fakeAuthsByTeamDomain[team2TeamDomain], nil)
 	clientsMock.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
 	clientsMock.AddDefaultMocks()
 
@@ -2802,7 +2802,7 @@ func TestPrompt_TeamAppSelectPrompt_NoInstalls_TeamFlagDomain(t *testing.T) {
 	// Set up mocks
 	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
-	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
+	clientsMock.Auth.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
 	clientsMock.AddDefaultMocks()
 
 	clients := shared.NewClientFactory(clientsMock.MockClientFactory())
@@ -2836,7 +2836,7 @@ func TestPrompt_TeamAppSelectPrompt_NoInstalls_TeamFlagID(t *testing.T) {
 	// Set up mocks
 	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
-	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
+	clientsMock.Auth.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
 
 	clientsMock.AddDefaultMocks()
 
@@ -2871,7 +2871,7 @@ func TestPrompt_TeamAppSelectPrompt_NoInstalls_Flags(t *testing.T) {
 	// Set up mocks
 	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
-	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
+	clientsMock.Auth.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
 	clientsMock.AddDefaultMocks()
 
 	clients := shared.NewClientFactory(clientsMock.MockClientFactory())
@@ -3064,10 +3064,10 @@ func TestPrompt_TeamAppSelectPrompt_TokenFlag(t *testing.T) {
 
 		clientsMock.API.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 			api.GetAppStatusResult{Apps: appInstallStatus}, nil)
-		clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
-		clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mock.Anything).
+		clientsMock.Auth.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
+		clientsMock.Auth.On(AuthWithTeamID, mock.Anything, mock.Anything).
 			Return(types.SlackAuth{}, slackerror.New(slackerror.ErrCredentialsNotFound))
-		clientsMock.AuthInterface.On(AuthWithToken, mock.Anything, test.token).
+		clientsMock.Auth.On(AuthWithToken, mock.Anything, test.token).
 			Return(mockAuth, nil)
 		clientsMock.AddDefaultMocks()
 
@@ -3102,9 +3102,9 @@ func TestPrompt_TeamAppSelectPrompt_HostedAppsOnly(t *testing.T) {
 		api.GetAppStatusResult{
 			Apps: []api.AppStatusResultAppInfo{{AppID: "A1EXAMPLE01", Installed: true}, {AppID: "A124", Installed: true}},
 		}, nil)
-	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
+	clientsMock.Auth.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
 	clientsMock.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
-	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
+	clientsMock.Auth.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
 	clientsMock.AddDefaultMocks()
 
 	clients := shared.NewClientFactory(clientsMock.MockClientFactory())
@@ -3183,8 +3183,8 @@ func TestPrompt_TeamAppSelectPrompt_HostedAppsOnly_TeamFlagDomain(t *testing.T) 
 		api.GetAppStatusResult{
 			Apps: []api.AppStatusResultAppInfo{{AppID: "A1EXAMPLE01", Installed: true}},
 		}, nil)
-	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
-	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
+	clientsMock.Auth.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
+	clientsMock.Auth.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
 	clientsMock.AddDefaultMocks()
 
 	clients := shared.NewClientFactory(clientsMock.MockClientFactory())
@@ -3231,8 +3231,8 @@ func TestPrompt_TeamAppSelectPrompt_HostedAppsOnly_TeamFlagID(t *testing.T) {
 		api.GetAppStatusResult{
 			Apps: []api.AppStatusResultAppInfo{{AppID: "A1EXAMPLE01", Installed: true}},
 		}, nil)
-	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
-	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
+	clientsMock.Auth.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
+	clientsMock.Auth.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
 	clientsMock.AddDefaultMocks()
 
 	clients := shared.NewClientFactory(clientsMock.MockClientFactory())
@@ -3279,10 +3279,10 @@ func TestPrompt_TeamAppSelectPrompt_LocalAppsOnly(t *testing.T) {
 		api.GetAppStatusResult{
 			Apps: []api.AppStatusResultAppInfo{{AppID: "A1EXAMPLE01", Installed: true}, {AppID: "A124", Installed: true}},
 		}, nil)
-	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
+	clientsMock.Auth.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
 	clientsMock.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
-	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, team1TeamID).Return(fakeAuthsByTeamDomain[team1TeamDomain], nil)
-	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, team2TeamID).Return(fakeAuthsByTeamDomain[team2TeamDomain], nil)
+	clientsMock.Auth.On(AuthWithTeamID, mock.Anything, team1TeamID).Return(fakeAuthsByTeamDomain[team1TeamDomain], nil)
+	clientsMock.Auth.On(AuthWithTeamID, mock.Anything, team2TeamID).Return(fakeAuthsByTeamDomain[team2TeamDomain], nil)
 	clientsMock.AddDefaultMocks()
 
 	clients := shared.NewClientFactory(clientsMock.MockClientFactory())
@@ -3363,9 +3363,9 @@ func TestPrompt_TeamAppSelectPrompt_LocalAppsOnly_TeamFlagDomain(t *testing.T) {
 		api.GetAppStatusResult{
 			Apps: []api.AppStatusResultAppInfo{{AppID: "A124", Installed: true}},
 		}, nil)
-	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
-	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, team1TeamID).Return(fakeAuthsByTeamDomain[team1TeamDomain], nil)
-	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, team2TeamID).Return(fakeAuthsByTeamDomain[team2TeamDomain], nil)
+	clientsMock.Auth.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
+	clientsMock.Auth.On(AuthWithTeamID, mock.Anything, team1TeamID).Return(fakeAuthsByTeamDomain[team1TeamDomain], nil)
+	clientsMock.Auth.On(AuthWithTeamID, mock.Anything, team2TeamID).Return(fakeAuthsByTeamDomain[team2TeamDomain], nil)
 	clientsMock.AddDefaultMocks()
 
 	clients := shared.NewClientFactory(clientsMock.MockClientFactory())
@@ -3414,9 +3414,9 @@ func TestPrompt_TeamAppSelectPrompt_LocalAppsOnly_TeamFlagID(t *testing.T) {
 		api.GetAppStatusResult{
 			Apps: []api.AppStatusResultAppInfo{{AppID: "A124", Installed: true}},
 		}, nil)
-	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
-	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, team1TeamID).Return(fakeAuthsByTeamDomain[team1TeamDomain], nil)
-	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, team2TeamID).Return(fakeAuthsByTeamDomain[team2TeamDomain], nil)
+	clientsMock.Auth.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
+	clientsMock.Auth.On(AuthWithTeamID, mock.Anything, team1TeamID).Return(fakeAuthsByTeamDomain[team1TeamDomain], nil)
+	clientsMock.Auth.On(AuthWithTeamID, mock.Anything, team2TeamID).Return(fakeAuthsByTeamDomain[team2TeamDomain], nil)
 	clientsMock.AddDefaultMocks()
 
 	clients := shared.NewClientFactory(clientsMock.MockClientFactory())
@@ -3470,9 +3470,9 @@ func TestPrompt_TeamAppSelectPrompt_AllApps(t *testing.T) {
 				{AppID: "A124dev", Installed: true},
 			},
 		}, nil)
-	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
+	clientsMock.Auth.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
 	clientsMock.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
-	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
+	clientsMock.Auth.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
 	clientsMock.AddDefaultMocks()
 
 	clients := shared.NewClientFactory(clientsMock.MockClientFactory())
@@ -3560,9 +3560,9 @@ func TestPrompt_TeamAppSelectPrompt_LegacyDevApps(t *testing.T) {
 				{AppID: "A124dev", Installed: true},
 			},
 		}, nil)
-	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
+	clientsMock.Auth.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
 	clientsMock.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
-	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
+	clientsMock.Auth.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
 	clientsMock.AddDefaultMocks()
 
 	clients := shared.NewClientFactory(clientsMock.MockClientFactory())
@@ -3652,9 +3652,9 @@ func TestPrompt_TeamAppSelectPrompt_ShowExpectedLabels(t *testing.T) {
 			UserID:     "U3",
 			Token:      "xoxe.xoxp-2-token",
 		})
-		clientsMock.AuthInterface.On(Auths, mock.Anything).Return(auths, nil)
+		clientsMock.Auth.On(Auths, mock.Anything).Return(auths, nil)
 		clientsMock.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
-		clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
+		clientsMock.Auth.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
 		clientsMock.AddDefaultMocks()
 
 		return clientsMock
@@ -3819,8 +3819,8 @@ func TestPrompt_TeamAppSelectPrompt_AllApps_TeamFlagID(t *testing.T) {
 	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
 	clientsMock.API.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.GetAppStatusResult{}, nil)
-	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
-	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
+	clientsMock.Auth.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
+	clientsMock.Auth.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
 	clientsMock.AddDefaultMocks()
 
 	clients := shared.NewClientFactory(clientsMock.MockClientFactory())
@@ -3867,8 +3867,8 @@ func TestPrompt_TeamAppSelectPrompt_AllApps_Flags(t *testing.T) {
 	ctx := slackcontext.MockContext(t.Context())
 	clientsMock := shared.NewClientsMock()
 	clientsMock.API.On(GetAppStatus, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.GetAppStatusResult{}, nil)
-	clientsMock.AuthInterface.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
-	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
+	clientsMock.Auth.On(Auths, mock.Anything).Return(fakeAuthsByTeamDomainSlice, nil)
+	clientsMock.Auth.On(AuthWithTeamID, mock.Anything, mock.Anything).Return(types.SlackAuth{}, nil)
 	clientsMock.AddDefaultMocks()
 
 	clients := shared.NewClientFactory(clientsMock.MockClientFactory())
@@ -4056,14 +4056,14 @@ func TestPrompt_TeamAppSelectPrompt_AppSelectPrompt_EnterpriseWorkspaceApps_HasW
 	authTeam1.EnterpriseID = authEnterprise1.TeamID
 
 	// Return one auth
-	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, team1TeamID).Return(authTeam1, nil)
-	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, enterprise1TeamID).Return(authEnterprise1, nil)
+	clientsMock.Auth.On(AuthWithTeamID, mock.Anything, team1TeamID).Return(authTeam1, nil)
+	clientsMock.Auth.On(AuthWithTeamID, mock.Anything, enterprise1TeamID).Return(authEnterprise1, nil)
 	clientsMock.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
 
 	//
 	// This test uses a single auth - Mock the underlying auth
 	//
-	clientsMock.AuthInterface.On(Auths, mock.Anything).Return([]types.SlackAuth{
+	clientsMock.Auth.On(Auths, mock.Anything).Return([]types.SlackAuth{
 		authTeam1,
 	}, nil)
 
@@ -4176,7 +4176,7 @@ func TestPrompt_TeamAppSelectPrompt_AppSelectPrompt_EnterpriseWorkspaceApps_HasW
 		clients.Config.TeamFlag = test.teamFlag
 
 		// Return the auth state depending on test specs
-		clientsMock.AuthInterface.On(Auths, mock.Anything).Return([]types.SlackAuth{
+		clientsMock.Auth.On(Auths, mock.Anything).Return([]types.SlackAuth{
 			authTeam1,
 		}, nil)
 
@@ -4265,11 +4265,11 @@ func TestPrompt_TeamAppSelectPrompt_AppSelectPrompt_EnterpriseWorkspaceApps_Miss
 	authTeam1.EnterpriseID = authEnterprise1.TeamID
 
 	// Return one auth
-	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, team1TeamID).Return(authTeam1, nil)
-	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, enterprise1TeamID).Return(authEnterprise1, nil)
+	clientsMock.Auth.On(AuthWithTeamID, mock.Anything, team1TeamID).Return(authTeam1, nil)
+	clientsMock.Auth.On(AuthWithTeamID, mock.Anything, enterprise1TeamID).Return(authEnterprise1, nil)
 
 	// This test uses zero auths
-	clientsMock.AuthInterface.On(Auths, mock.Anything).Return([]types.SlackAuth{}, nil)
+	clientsMock.Auth.On(Auths, mock.Anything).Return([]types.SlackAuth{}, nil)
 
 	clientsMock.AddDefaultMocks()
 
@@ -4452,12 +4452,12 @@ func TestPrompt_TeamAppSelectPrompt_EnterpriseWorkspaceApps_MissingWorkspaceAuth
 	authTeam1.EnterpriseID = authEnterprise1.TeamID
 
 	// For this test we want to make sure that no auth is found for team1, and a credentials not found
-	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, team1TeamID).Return(types.SlackAuth{}, slackerror.New(slackerror.ErrCredentialsNotFound))
-	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, enterprise1TeamID).Return(authEnterprise1, nil)
+	clientsMock.Auth.On(AuthWithTeamID, mock.Anything, team1TeamID).Return(types.SlackAuth{}, slackerror.New(slackerror.ErrCredentialsNotFound))
+	clientsMock.Auth.On(AuthWithTeamID, mock.Anything, enterprise1TeamID).Return(authEnterprise1, nil)
 	clientsMock.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
 
 	// This test uses a single auth - the enterprise auth
-	clientsMock.AuthInterface.On(Auths, mock.Anything).Return([]types.SlackAuth{
+	clientsMock.Auth.On(Auths, mock.Anything).Return([]types.SlackAuth{
 		authEnterprise1,
 	}, nil)
 
@@ -4630,12 +4630,12 @@ func TestPrompt_AppSelectPrompt_EnterpriseWorkspaceApps_MissingWorkspaceAuth_Has
 	authTeam1.EnterpriseID = authEnterprise1.TeamID
 
 	// For this test we want to make sure that no auth is found for team1, and a credentials not found
-	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, team1TeamID).Return(types.SlackAuth{}, slackerror.New(slackerror.ErrCredentialsNotFound))
-	clientsMock.AuthInterface.On(AuthWithTeamID, mock.Anything, enterprise1TeamID).Return(authEnterprise1, nil)
+	clientsMock.Auth.On(AuthWithTeamID, mock.Anything, team1TeamID).Return(types.SlackAuth{}, slackerror.New(slackerror.ErrCredentialsNotFound))
+	clientsMock.Auth.On(AuthWithTeamID, mock.Anything, enterprise1TeamID).Return(authEnterprise1, nil)
 	clientsMock.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
 
 	// This test uses a single auth - the enterprise auth
-	clientsMock.AuthInterface.On(Auths, mock.Anything).Return([]types.SlackAuth{
+	clientsMock.Auth.On(Auths, mock.Anything).Return([]types.SlackAuth{
 		authEnterprise1,
 	}, nil)
 
@@ -5123,7 +5123,7 @@ func Test_ValidateAuth(t *testing.T) {
 				tt.apiValidateSessionResponse,
 				tt.apiValidateSessionError,
 			)
-			clientsMock.AuthInterface.On(
+			clientsMock.Auth.On(
 				"FilterKnownAuthErrors",
 				mock.Anything,
 				tt.apiValidateSessionError,
@@ -5131,13 +5131,13 @@ func Test_ValidateAuth(t *testing.T) {
 				tt.authFilteredKnownAuthErrorsResponse,
 				tt.authFilteredKnownAuthErrorsError,
 			)
-			clientsMock.AuthInterface.On(
+			clientsMock.Auth.On(
 				"IsAPIHostSlackProd",
 				mock.Anything,
 			).Return(
 				tt.authIsAPIHostSlackProdResponse,
 			)
-			clientsMock.AuthInterface.On(
+			clientsMock.Auth.On(
 				"SetAuth",
 				mock.Anything,
 				mock.Anything,
@@ -5146,7 +5146,7 @@ func Test_ValidateAuth(t *testing.T) {
 				"",
 				tt.authSetAuthError,
 			)
-			clientsMock.AuthInterface.On(
+			clientsMock.Auth.On(
 				"SetSelectedAuth",
 				mock.Anything,
 				mock.Anything,
@@ -5193,7 +5193,7 @@ func mockReauthentication(clientsMock *shared.ClientsMock) {
 
 	// Mock invalid auth response
 	clientsMock.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, fmt.Errorf(slackerror.ErrInvalidAuth))
-	clientsMock.AuthInterface.On("FilterKnownAuthErrors", mock.Anything, mock.Anything).Return(true, nil)
+	clientsMock.Auth.On("FilterKnownAuthErrors", mock.Anything, mock.Anything).Return(true, nil)
 	// Mocks for reauthentication
 	clientsMock.API.On("GenerateAuthTicket", mock.Anything, mock.Anything, mock.Anything).Return(api.GenerateAuthTicketResult{}, nil)
 	clientsMock.IO.On("InputPrompt", mock.Anything, "Enter challenge code", iostreams.InputPromptConfig{
@@ -5201,7 +5201,7 @@ func mockReauthentication(clientsMock *shared.ClientsMock) {
 	}).Return("challengeCode", nil)
 	clientsMock.API.On("ExchangeAuthTicket", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(api.ExchangeAuthTicketResult{Token: fakeAuthsByTeamDomain[team1TeamDomain].Token, TeamDomain: team1TeamDomain,
 		TeamID: team1TeamID, UserID: "U1"}, nil)
-	clientsMock.AuthInterface.On("IsAPIHostSlackProd", mock.Anything).Return(true)
-	clientsMock.AuthInterface.On("SetAuth", mock.Anything, mock.Anything).Return(types.SlackAuth{}, "", nil)
-	clientsMock.AuthInterface.On("SetSelectedAuth", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	clientsMock.Auth.On("IsAPIHostSlackProd", mock.Anything).Return(true)
+	clientsMock.Auth.On("SetAuth", mock.Anything, mock.Anything).Return(types.SlackAuth{}, "", nil)
+	clientsMock.Auth.On("SetSelectedAuth", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 }

--- a/internal/shared/clients.go
+++ b/internal/shared/clients.go
@@ -44,16 +44,16 @@ import (
 
 // ClientFactory are shared clients and configurations for use across the CLI commands (cmd) and handlers (pkg).
 type ClientFactory struct {
-	API           func() api.APIInterface
-	AppClient     func() *app.Client
-	AuthInterface func() auth.AuthInterface
-	CLIVersion    string
-	Config        *config.Config
-	EventTracker  tracking.TrackingManager
-	HookExecutor  hooks.HookExecutor
-	IO            iostreams.IOStreamer
-	Runtime       runtime.Runtime
-	SDKConfig     hooks.SDKCLIConfig
+	API          func() api.APIInterface
+	AppClient    func() *app.Client
+	Auth         func() auth.AuthInterface
+	CLIVersion   string
+	Config       *config.Config
+	EventTracker tracking.TrackingManager
+	HookExecutor hooks.HookExecutor
+	IO           iostreams.IOStreamer
+	Runtime      runtime.Runtime
+	SDKConfig    hooks.SDKCLIConfig
 
 	// Browser can display or open URLs as webpages on the internet
 	Browser func() slackdeps.Browser
@@ -99,7 +99,7 @@ func NewClientFactory(options ...func(*ClientFactory)) *ClientFactory {
 	clients.EventTracker = tracking.NewEventTracker()
 	clients.API = clients.defaultAPIFunc
 	clients.AppClient = clients.defaultAppClientFunc
-	clients.AuthInterface = clients.defaultAuthInterfaceFunc
+	clients.Auth = clients.defaultAuthFunc
 	clients.Browser = clients.defaultBrowserFunc
 
 	// Command-specific dependencies
@@ -144,8 +144,8 @@ func (c *ClientFactory) defaultAuthClientFunc() *auth.Client {
 	return auth.NewClient(c.API(), c.AppClient(), c.Config, c.IO, c.Fs)
 }
 
-// defaultAuthInterfaceFunc return a new Auth Interface
-func (c *ClientFactory) defaultAuthInterfaceFunc() auth.AuthInterface {
+// defaultAuthFunc return a new Auth Interface
+func (c *ClientFactory) defaultAuthFunc() auth.AuthInterface {
 	return c.defaultAuthClientFunc()
 }
 

--- a/internal/shared/clients_mock.go
+++ b/internal/shared/clients_mock.go
@@ -32,18 +32,18 @@ import (
 // ClientsMock defines mocks that will override aspects of clients for testing purposes.
 type ClientsMock struct {
 	mock.Mock
-	API           *api.APIMock
-	AuthInterface *auth.AuthMock
-	AppClient     *app.Client
-	Browser       *slackdeps.BrowserMock
-	Config        *config.Config
-	Cobra         *slackdeps.CobraMock
-	EventTracker  *tracking.EventTrackerMock
-	Fs            *slackdeps.FsMock
-	IO            *iostreams.IOStreamsMock
-	Os            *slackdeps.OsMock
-	Stdout        *bytes.Buffer
-	HookExecutor  hooks.MockHookExecutor
+	API          *api.APIMock
+	Auth         *auth.AuthMock
+	AppClient    *app.Client
+	Browser      *slackdeps.BrowserMock
+	Config       *config.Config
+	Cobra        *slackdeps.CobraMock
+	EventTracker *tracking.EventTrackerMock
+	Fs           *slackdeps.FsMock
+	IO           *iostreams.IOStreamsMock
+	Os           *slackdeps.OsMock
+	Stdout       *bytes.Buffer
+	HookExecutor hooks.MockHookExecutor
 }
 
 // NewClientsMock will create a new ClientsMock that is ready to be applied to an existing clients with .MockClientFactory().
@@ -53,7 +53,7 @@ func NewClientsMock() *ClientsMock {
 
 	// Set the mocked members
 	clientsMock.API = &api.APIMock{}
-	clientsMock.AuthInterface = &auth.AuthMock{}
+	clientsMock.Auth = &auth.AuthMock{}
 	clientsMock.Browser = slackdeps.NewBrowserMock()
 	clientsMock.Cobra = slackdeps.NewCobraMock()
 	clientsMock.EventTracker = &tracking.EventTrackerMock{}
@@ -72,7 +72,7 @@ func NewClientsMock() *ClientsMock {
 // AddDefaultMocks installs the default mock actions to fallback on.
 func (m *ClientsMock) AddDefaultMocks() {
 	m.API.AddDefaultMocks()
-	m.AuthInterface.AddDefaultMocks()
+	m.Auth.AddDefaultMocks()
 	m.Browser.AddDefaultMocks()
 	m.Cobra.AddDefaultMocks()
 	m.EventTracker.AddDefaultMocks()
@@ -92,7 +92,7 @@ func (m *ClientsMock) MockClientFactory() func(c *ClientFactory) {
 		clients.IO = m.IO
 		clients.Fs = m.Fs
 		clients.API = func() api.APIInterface { return m.API }
-		clients.AuthInterface = func() auth.AuthInterface { return m.AuthInterface }
+		clients.Auth = func() auth.AuthInterface { return m.Auth }
 		clients.AppClient = func() *app.Client { return m.AppClient }
 		clients.HookExecutor = &m.HookExecutor
 	}

--- a/main.go
+++ b/main.go
@@ -86,7 +86,7 @@ func recoveryFunc() {
 		ctx = slackcontext.SetSessionID(ctx, uuid.New().String())
 
 		// set host for logging
-		clients.Config.LogstashHostResolved = clients.AuthInterface().ResolveLogstashHost(ctx, clients.Config.APIHostResolved, clients.Config.Version)
+		clients.Config.LogstashHostResolved = clients.Auth().ResolveLogstashHost(ctx, clients.Config.APIHostResolved, clients.Config.Version)
 		clients.IO.PrintError(ctx, "Recovered from panic: %s\n%s", r, string(debug.Stack()))
 		os.Exit(int(iostreams.ExitError))
 	}


### PR DESCRIPTION
### Summary

This pull request follows #77 by updating `clients.AuthInterface()` to `clients.Auth()`.

The motivation is that the name is shorter and more accurate. The `clients.Auth()` returns an instance of `auth.Client` that implements the `auth.AuthInterface` interface. It doesn't return an interface.

There was no change functionality was changed, but our mocks were updated to match the same naming pattern.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).