### PR TITLE
feat(bolt-install): added --experiment=bolt-install

### DIFF
--- a/cmd/app/add_test.go
+++ b/cmd/app/add_test.go
@@ -103,7 +103,7 @@ func TestAppAddCommandPreRun(t *testing.T) {
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
 				cf.SDKConfig.WorkingDirectory = "."
 				cm.AddDefaultMocks()
-				cm.Config.ExperimentsFlag = append(cm.Config.ExperimentsFlag, experiment.BoltFrameworks)
+				cm.Config.ExperimentsFlag = append(cm.Config.ExperimentsFlag, string(experiment.BoltFrameworks))
 				cm.Config.LoadExperiments(ctx, cm.IO.PrintDebug)
 				mockProjectConfig := config.NewProjectConfigMock()
 				mockProjectConfig.On("GetManifestSource", mock.Anything).Return(config.ManifestSourceRemote, nil)
@@ -115,7 +115,7 @@ func TestAppAddCommandPreRun(t *testing.T) {
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
 				cf.SDKConfig.WorkingDirectory = "."
 				cm.AddDefaultMocks()
-				cm.Config.ExperimentsFlag = append(cm.Config.ExperimentsFlag, experiment.BoltFrameworks)
+				cm.Config.ExperimentsFlag = append(cm.Config.ExperimentsFlag, string(experiment.BoltFrameworks))
 				cm.Config.LoadExperiments(ctx, cm.IO.PrintDebug)
 				mockProjectConfig := config.NewProjectConfigMock()
 				mockProjectConfig.On("GetManifestSource", mock.Anything).Return(config.ManifestSourceLocal, nil)

--- a/cmd/manifest/info_test.go
+++ b/cmd/manifest/info_test.go
@@ -133,7 +133,7 @@ func TestInfoCommand(t *testing.T) {
 					},
 				}, nil)
 				cf.AppClient().Manifest = manifestMock
-				cm.Config.ExperimentsFlag = append(cm.Config.ExperimentsFlag, experiment.BoltFrameworks)
+				cm.Config.ExperimentsFlag = append(cm.Config.ExperimentsFlag, string(experiment.BoltFrameworks))
 				cm.Config.LoadExperiments(ctx, cm.IO.PrintDebug)
 				mockProjectConfig := config.NewProjectConfigMock()
 				mockProjectConfig.On("GetManifestSource", mock.Anything).Return(config.ManifestSourceLocal, nil)
@@ -162,7 +162,7 @@ func TestInfoCommand(t *testing.T) {
 				cf.SDKConfig.WorkingDirectory = "."
 				cm.IO.AddDefaultMocks()
 				cm.Os.AddDefaultMocks()
-				cm.Config.ExperimentsFlag = append(cm.Config.ExperimentsFlag, experiment.BoltFrameworks)
+				cm.Config.ExperimentsFlag = append(cm.Config.ExperimentsFlag, string(experiment.BoltFrameworks))
 				cm.Config.LoadExperiments(ctx, cm.IO.PrintDebug)
 				mockProjectConfig := config.NewProjectConfigMock()
 				mockProjectConfig.On("GetManifestSource", mock.Anything).

--- a/docs/guides/using-slack-cli-with-bolt-frameworks.md
+++ b/docs/guides/using-slack-cli-with-bolt-frameworks.md
@@ -26,7 +26,7 @@ View more samples
 
 You will then be prompted to choose between **Bolt for JavaScript** or **Bolt for Python**. Choose your favorite flavor.
 
-Your app will be cloned from the respective [JavaScript](https://github.com/slack-samples/bolt-js-starter-template) or [Python](https://github.com/slack-samples/bolt-python-starter-template) project template on our Slack Platform Sample Code repository, and its project dependencies will be installed. Then, `cd` into your project folder. 
+Your app will be cloned from the respective [JavaScript](https://github.com/slack-samples/bolt-js-starter-template) or [Python](https://github.com/slack-samples/bolt-python-starter-template) project template on our Slack Platform Sample Code repository, and its project dependencies will be installed. Then, `cd` into your project folder.
 
 :::info
 
@@ -34,7 +34,7 @@ For Bolt for Python projects, automatic project dependency installation is curre
 
 :::
 
-To run your new app, use the `slack run` command with the experiment flag as follows:
+To run your new app, use the `slack run` command as follows:
 
 ```
 slack run

--- a/docs/reference/experiments.md
+++ b/docs/reference/experiments.md
@@ -6,4 +6,5 @@ The Slack CLI has an experiment flag, behind which we put features under develop
 
 The following is a list of currently available experiments. We may remove an experiment once the feature is released.
 
+* `bolt-install`: enables creating, installing, and running Bolt projects that manage their app manifest on app settings (remote manifest).
 * `read-only-collaborators`: enables creating and modifying collaborator permissions via the `slack collaborator` commands.

--- a/internal/experiment/experiment.go
+++ b/internal/experiment/experiment.go
@@ -32,7 +32,11 @@ type Experiment string
 const (
 	// BoltFrameworks experiment adds CLI support for Bolt JavaScript & Bolt Python.
 	// These frameworks will be introducing remote function support.
-	BoltFrameworks = "bolt"
+	BoltFrameworks Experiment = "bolt"
+
+	// BoltInstall experiment enables developerInstall to work with Bolt projects that
+	//  manage their app manifest on app settings (remote manifest).
+	BoltInstall Experiment = "bolt-install"
 
 	// The ReadOnlyAppCollaborators experiment enables creating and modifying collaborator
 	// permissions via the `collaborator` commands.
@@ -46,6 +50,7 @@ const (
 // AllExperiment is a list of all available experiments that can be enabled
 var AllExperiments = []Experiment{
 	BoltFrameworks,
+	BoltInstall,
 	ReadOnlyAppCollaborators,
 	Placeholder,
 }

--- a/internal/pkg/apps/install_test.go
+++ b/internal/pkg/apps/install_test.go
@@ -539,7 +539,7 @@ func TestInstall(t *testing.T) {
 			clientsMock.AppClient.Manifest = manifestMock
 			mockProjectConfig := config.NewProjectConfigMock()
 			if tt.mockBoltExperiment {
-				clientsMock.Config.ExperimentsFlag = append(clientsMock.Config.ExperimentsFlag, experiment.BoltFrameworks)
+				clientsMock.Config.ExperimentsFlag = append(clientsMock.Config.ExperimentsFlag, string(experiment.BoltFrameworks))
 				clientsMock.Config.LoadExperiments(ctx, clientsMock.IO.PrintDebug)
 				mockProjectConfig.On("GetManifestSource", mock.Anything).Return(tt.mockManifestSource, nil)
 			}
@@ -982,7 +982,7 @@ func TestInstallLocalApp(t *testing.T) {
 			clientsMock.AppClient.Manifest = manifestMock
 			mockProjectConfig := config.NewProjectConfigMock()
 			if tt.mockBoltExperiment {
-				clientsMock.Config.ExperimentsFlag = append(clientsMock.Config.ExperimentsFlag, experiment.BoltFrameworks)
+				clientsMock.Config.ExperimentsFlag = append(clientsMock.Config.ExperimentsFlag, string(experiment.BoltFrameworks))
 				clientsMock.Config.LoadExperiments(ctx, clientsMock.IO.PrintDebug)
 				mockProjectConfig.On("GetManifestSource", mock.Anything).Return(tt.mockManifestSource, nil)
 			}


### PR DESCRIPTION
### CHANGELOG

> Added the experiment `--experiment bolt-install` to enable creating, installing, and running Bolt projects that manage their app manifest on app settings (remote manifest).

### Summary

This pull request adds the `--experiment bolt-install` to begin work on creating, installing, and running Bolt projects that manage their app manifest on app settings (remote manifest).

The following changes were made:
* Added the `BoltInstall` experiment name
* Cast the `BoltFramework` experiment as `Experiment` instead of `String`, causing updates to tests
* Added `bolt-install` to the experiment documentation

### Reviewers

@zimeg @lukegalbraithrussell @technically-tracy **How should we document the `--experiment bolt-install`?** 

We learned from the `bolt` experiment that it was difficult to track changes across multiple releases and especially hard to write a nice "Bolt Support" CHANGELOG when the experiment was removed. I think this is a chance for us to improve, especially since the docs are now part of the repo. A few ideas:
  1. Release Notes would auto-generate an "Experiment" section, so that experiment PRs are separate from the normal release notes.
  2. We can updates the `experiments.md` to document the new experiment (this PR has done it)
  3. It would be nice to have a place to document the current features of the experiment, since it's an evolving work-in-progress the description in `experiments.md` is the vision rather than the current state. One idea is to add sub-bullet points under the experiment in `experiments.md` to document what's available. This could become a go-to source for the release that announces the removal of the experiment (e.g. "Bolt Support").

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).