### PR TITLE
fix: parse the latest deno release in installation script outputs as a tagged version

### DIFF
--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -274,7 +274,7 @@ install_deno() {
 
         echo -e -n "🔍 Searching for the latest released Deno version..."
         latest_deno_version=$(curl -fs https://api.github.com/repos/denoland/deno/releases/latest | grep '"tag_name":' | cut -d '"' -f 4)
-        if [ $? -eq 0 ] && [ "$latest_deno_version" -ne "" ]; then
+        if [ $? -eq 0 ] && [ -n "$latest_deno_version" ]; then
             delay 0.2 " Found: ${latest_deno_version}"
         else
             delay 0.2 " Found: Unknown"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -273,7 +273,7 @@ install_deno() {
 
         echo -e -n "🔍 Searching for the latest released Deno version..."
         latest_deno_version=$(curl -fs https://api.github.com/repos/denoland/deno/releases/latest | grep '"tag_name":' | cut -d '"' -f 4)
-        if [ $? -eq 0 ] && [ "$latest_deno_version" -ne "" ]; then
+        if [ $? -eq 0 ] && [ -n "$latest_deno_version" ]; then
             delay 0.2 " Found: ${latest_deno_version}"
         else
             delay 0.2 " Found: Unknown"


### PR DESCRIPTION
### Summary

Hi,  
This PR improves the console output in the Deno installation part by adjusting the version check logic to handle string values (e.g., v2.3.1). Replaced numeric comparison with a neutral string check. Thanks.

![Screenshot from 2025-05-14 10-27-25](https://github.com/user-attachments/assets/0ba80651-9570-4ee3-b16c-9f6ce07b041c)

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).