### PR TITLE
feat(bolt-install): set manifest source to remote for non-rosi projects

### DIFF
--- a/internal/pkg/create/create.go
+++ b/internal/pkg/create/create.go
@@ -464,13 +464,10 @@ func InstallProjectDependencies(
 
 	// When the BoltInstall experiment is enabled, set non-ROSI projects to ManifestSourceRemote.
 	if clients.Config.WithExperimentOn(experiment.BoltInstall) {
-		// TODO: should check if Slack hosted project, but the SDKConfig has not been initialized yet
+		// TODO: should check if Slack hosted project, but the SDKConfig has not been initialized yet.
 		isDenoProject := strings.Contains(strings.ToLower(clients.Runtime.Name()), "deno")
 		if !isDenoProject {
 			manifestSource = config.ManifestSourceRemote
-			if err := clients.Config.ProjectConfig.SetManifestSource(ctx, manifestSource); err != nil {
-				clients.IO.PrintDebug(ctx, "Error setting manifest source in project-level config: %s", err)
-			}
 		}
 	}
 


### PR DESCRIPTION
### CHANGELOG

> **Experimental Feature: `--experiment bolt-install`** 
>
> When creating or initializing a project, Bolt Framework projects now use "app settings" (remote) as the manifest source. This means that Bolt Framework projects now treat the app settings as the source of truth. The `manifest.json` file is only used when creating a new app for the project.
> - `slack create --experiment bolt-install`
> - `slack init --experiment bolt-install`

### Summary

This pull request updates `slack create --experiment bolt-install` and `slack init --experiment bolt-install` to set a different manifest source depending the runtime:
* **Deno SDK**: `manifest.source: "local"`
* **Bolt Frameworks**: `manifest.source: "remote"`

Previously, all runtimes used `manifest.source: "local"`.

### Requirements

* [x ] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).