### PR TITLE
ci: pin action hashes and escape variables with minimum permission

### DIFF
--- a/.github/workflows/delete-pr-build-on-close.yml
+++ b/.github/workflows/delete-pr-build-on-close.yml
@@ -13,7 +13,7 @@ name: Delete pre-release when a branch is deleted
 # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-pull_request-workflow-when-a-pull-request-merges
 # See https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request_target
 on:
-  pull_request_target:
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
     types:
       - closed
 

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -12,17 +12,18 @@ jobs:
     steps:
       - name: Gather credentials
         id: credentials
-        uses: actions/create-github-app-token@v2.0.6
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
         with:
           app-id: ${{ secrets.GH_APP_ID_RELEASER }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY_RELEASER }}
       - name: Checkout the repo
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
+          persist-credentials: true
           ref: main
           token: ${{ steps.credentials.outputs.token }}
       - name: Install Golang
-        uses: actions/setup-go@v5.5.0
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: "stable"
       - name: Get the latest version

--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Trigger CircleCI 'local' workflow
         if: ${{ github.event.inputs.status == 'false' }}
-        uses: promiseofcake/circleci-trigger-action@v1.7.8
+        uses: promiseofcake/circleci-trigger-action@31bce5a96436643ef4aa09acc954916d7316bb1b # v1.7.8
         with:
           user-token: ${{ secrets.CIRCLECI_TOKEN }}
           project-slug: slackapi/slack-cli
@@ -30,7 +30,7 @@ jobs:
           payload: '{"run_local_build_test_workflow": true}'
       - name: Trigger CircleCI 'e2e' workflow
         if: ${{ github.event.inputs.status == 'true' }}
-        uses: promiseofcake/circleci-trigger-action@v1.7.8
+        uses: promiseofcake/circleci-trigger-action@31bce5a96436643ef4aa09acc954916d7316bb1b # v1.7.8
         with:
           user-token: ${{ secrets.CIRCLECI_TOKEN }}
           project-slug: slackapi/slack-cli

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -13,15 +13,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          # Number of commits to fetch. 0 indicates all history for all branches and tags.
-          # Default: 1
-          # TODO - We should not fetch all history.
-          #        But we need to fetch the latest tag to run `make test` and `make build`.
-          #        This is a workaround until we fetch the latest tag using the Makefile.
-          fetch-depth: 0
+          persist-credentials: false
       - name: Check license headers
-        uses: apache/skywalking-eyes@v0.7.0
+        uses: apache/skywalking-eyes@5c5b974209f0de5d905f37deb69369068ebfc15c # v0.7.0
         with:
           config: .licenserc.yml

--- a/.github/workflows/sync-docs-from-cli-repo.yml
+++ b/.github/workflows/sync-docs-from-cli-repo.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Update docs in docs site repo
         run: |
-          rsync -av --delete ./docs/ ./docs_repo/content/$REPO/
+          rsync -av --delete ./docs/ "./docs_repo/content/$REPO/"
         env:
           REPO: ${{ github.event.repository.name }}
 

--- a/.github/workflows/sync-docs-from-cli-repo.yml
+++ b/.github/workflows/sync-docs-from-cli-repo.yml
@@ -22,17 +22,19 @@ jobs:
     steps:
       - name: Generate a GitHub token
         id: ghtoken
-        uses: actions/create-github-app-token@v2.0.6
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
         with:
           app-id: ${{ secrets.GH_APP_ID_DOCS }}
           owner: slackapi
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY_DOCS }}
 
       - name: Checkout the tool repo (source)
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
 
       - name: Checkout the docs site repo (destination)
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: slackapi/slackapi.github.io
           path: "docs_repo"
@@ -41,7 +43,9 @@ jobs:
 
       - name: Update docs in docs site repo
         run: |
-          rsync -av --delete ./docs/ ./docs_repo/content/${{ github.event.repository.name }}/
+          rsync -av --delete ./docs/ ./docs_repo/content/$REPO/
+        env:
+          REPO: ${{ github.event.repository.name }}
 
       - name: Install dependencies
         run: |
@@ -56,7 +60,7 @@ jobs:
       - name: Create a pull request
         if: ${{ github.ref_name == github.event.repository.default_branch || github.event_name == 'workflow_dispatch' }}
         id: site-pr
-        uses: peter-evans/create-pull-request@v7.0.8
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
         with:
           token: ${{ steps.ghtoken.outputs.token }}
           title: "From ${{ github.event.repository.name }}: ${{ github.event.pull_request.title || 'manual docs sync' }}"
@@ -72,4 +76,6 @@ jobs:
       - name: Output the pull request link
         if: ${{ steps.site-pr.outputs.pull-request-url }}
         run: |
-          echo "Pull request created: ${{ steps.site-pr.outputs.pull-request-url }}" >> $GITHUB_STEP_SUMMARY
+          echo "Pull request created: $URL" >> $GITHUB_STEP_SUMMARY
+        env:
+          URL: ${{ steps.site-pr.outputs.pull-request-url }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,30 +18,23 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          # Number of commits to fetch. 0 indicates all history for all branches and tags.
-          # Default: 1
-          # TODO - We should not fetch all history.
-          #        But we need to fetch the latest tag to run `make test` and `make build`.
-          #        This is a workaround until we fetch the latest tag using the Makefile.
           fetch-depth: 0
-
+          persist-credentials: false
       - name: Set up Go
-        uses: actions/setup-go@v5.5.0
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: "1.24.3"
       - name: Lint
-        uses: golangci/golangci-lint-action@v8.0.0
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
         with:
           version: latest
           args: --timeout=5m
-
       - name: Unit Tests
         run: make test
-
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5.4.3
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.out
@@ -55,13 +48,15 @@ jobs:
       checks: write
       contents: read
     steps:
-      - uses: actions/checkout@v4.2.2
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Set up Go
-        uses: actions/setup-go@v5.5.0
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: "1.24.3"
       - name: Report health score
-        uses: slackapi/slack-health-score@v0.1.1
+        uses: slackapi/slack-health-score@d58a419f15cdaff97e9aa7f09f95772830ab66f7 # v0.1.1
         with:
           extension: "go"
           codecov_token: ${{ secrets.ELAINES_CODECOV_API_TOKEN }}


### PR DESCRIPTION
### Summary

This PR uses the wonderful [`zizmor`](https://github.com/zizmorcore/zizmor) tool to audit our own workflows and [`pinact`](https://github.com/suzuki-shunsuke/pinact) for pinned versioning 👾

### Reviewers

A similar audit can be performed with the zizmor tool:

```
$ zizmor .
...
No findings to report. Good job! (1 ignored, 7 suppressed)
```

> The suppressed findings are expected permission blocks at the top-level of a workflow, but we set this for each job.

### Notes

Most changes I hope are repetitive, but I will comment on the more significant ones!

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).