### PR TITLE
refactor: loop over a range of integers starting from zero in shorthand

### DIFF
--- a/internal/api/icon_test.go
+++ b/internal/api/icon_test.go
@@ -73,8 +73,8 @@ func TestClient_IconSuccess(t *testing.T) {
 	myimage := image.NewRGBA(image.Rectangle{image.Point{0, 0}, image.Point{100, 100}})
 
 	// This loop just fills the image with random data
-	for x := 0; x < 100; x++ {
-		for y := 0; y < 100; y++ {
+	for x := range 100 {
+		for y := range 100 {
 			c := color.RGBA{uint8(rand.Intn(255)), uint8(rand.Intn(255)), uint8(rand.Intn(255)), 255}
 			myimage.Set(x, y, c)
 		}

--- a/internal/hooks/hook_executor_v2.go
+++ b/internal/hooks/hook_executor_v2.go
@@ -100,7 +100,7 @@ func generateMD5FromRandomString() string {
 	const length = 10
 
 	randomBytes := make([]byte, 0)
-	for i := 0; i < length; i++ {
+	for range length {
 		num, err := rand.Int(rand.Reader, big.NewInt(int64(len(alphanumericCharacters))))
 		if err != nil {
 			return "3561f3a3c5576e2ce0dc0d1e268bb9b2" // Return default value to continue execution


### PR DESCRIPTION
### Summary

This PR replaces longform loop expressions with a shorthand range when iterating across integers starting from zero.

No change to functionalities!

### Notes

- 📚 https://go.dev/wiki/Range
- AFAICT the following is not supported in `go`. Perhaps for good reason I believe:

```go
for i := range 1..100 { /* */ }
```

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).