### PR TITLE
fix: gather manifest info from the configured source after parsing flags

### DIFF
--- a/cmd/manifest/info.go
+++ b/cmd/manifest/info.go
@@ -73,7 +73,7 @@ func NewInfoCommand(clients *shared.ClientFactory) *cobra.Command {
 	cmd.Flags().StringVar(
 		&manifestFlags.source,
 		manifestFlagSource,
-		config.ManifestSourceLocal.String(),
+		"",
 		fmt.Sprintf(
 			"source of the app manifest (\"%s\" or \"%s\")",
 			config.ManifestSourceLocal.String(),


### PR DESCRIPTION
> **Changelog**
>
> Setting the `source` in flag for the manifest `info` command now takes precedence to project configurations, which are now used to determine the default source.

### Summary

This PR uses project configurations to determine the default manifest source of the manifest `info` command instead of defaulting to "local" because that might error for projects using a remote manifest!

🏁 Also changed is the order of parsing for this value, preferring flags before file configurations.

🧪 Reference of the `bolt` experiment are also removed from this section of the code as part of these changes.

### Reviewers

Using the changes with the `bolt-install` experiment, run these commands:

```sh
$ slack create asdf -t slack-samples/bolt-js-starter-template
$ cd asdf
$ slack run
$ slack manifest info --help
$ slack manifest --help
$ slack manifest              # This now defaults to the "remote" manifest
$ slack manifest info         # This too defaults to the "remote" manifest
$ slack manifest --source local
$ slack delete
```

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).