### PR TITLE
build: sign macos binaries for arm and amd architectures and universal packagings

### DIFF
--- a/.circleci/runner/src/scripts/mac/code-sign.sh
+++ b/.circleci/runner/src/scripts/mac/code-sign.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2022-2025 Salesforce, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,29 +15,14 @@
 
 set -euo pipefail
 
-APP_ZIP_PATTERN="${PROD_NAME}*macOS_64-bit.zip"
+cd "${ARTIFACTS_DIR}"
 
-cd ${ARTIFACTS_DIR} && APP_ZIP=$(find . -type f -iname "${APP_ZIP_PATTERN}");
-
-echo $APP_ZIP
-
-APP_ZIP_NAME=${APP_ZIP:2}
-
-echo "$APP_ZIP_NAME"
-
-unzip $APP_ZIP_NAME
-
-rm $APP_ZIP_NAME
-
-ls -l ${ARTIFACTS_DIR}
-
-codesign --force --deep --verbose --verify --sign "Developer ID Application: SLACK TECHNOLOGIES L.L.C. (BQR82RBBHL)" --options runtime "${PROD_NAME}"
-
-codesign -vvv --deep --strict "${PROD_NAME}"
-
-zip -r "${APP_ZIP_NAME}" "${PROD_NAME}"
-
-xcrun notarytool submit "${APP_ZIP_NAME}" -p "HERMES_NOTARY"
-
-
-
+for package in "${PROD_NAME}"*macOS_*.zip; do
+    echo "Signing: ${package}"
+    unzip "${package}"
+    codesign --force --deep --verbose --verify --sign "Developer ID Application: SLACK TECHNOLOGIES L.L.C. (BQR82RBBHL)" --options runtime "${PROD_NAME}"
+    codesign -vvv --deep --strict "${PROD_NAME}"
+    zip -r "${package}" "${PROD_NAME}"
+    rm "${PROD_NAME}"
+    xcrun notarytool submit "${package}" -p "HERMES_NOTARY"
+done


### PR DESCRIPTION
### Summary

This PR attempts to sign all macOS binaries before packaging these into development and latest bundles for a tarball.

### Notes

A feature build will be tagged in this PR to test this!

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).