### PR TITLE
docs: surround remediation flags with backticks for prompted feedback

### DIFF
--- a/internal/slackerror/errors.go
+++ b/internal/slackerror/errors.go
@@ -729,7 +729,7 @@ Otherwise start your app for local development with: %s`,
 		Code:    ErrFeedbackNameRequired,
 		Message: "The name of the feedback is required",
 		Remediation: strings.Join([]string{
-			"Please provide a --name <string> flag or remove the --no-prompt flag",
+			"Please provide a `--name <string>` flag or remove the `--no-prompt` flag",
 			fmt.Sprintf("View feedback options with %s", style.Commandf("feedback --help", false)),
 		}, "\n"),
 	},


### PR DESCRIPTION
### Summary

This error has unescaped `<` in its description which our docs sites does not like.

### Requirements

* [X] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).