### PR TITLE
feat: output a link to the issue tracker if installation scripts fail

### DIFF
--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -354,7 +354,7 @@ feedback_message() {
                 echo -e "   Survey your development experience with \`$SLACK_CLI_NAME feedback\`"
         else
                 echo -e "\n💌 We would love to know how things are going. Really. All of it."
-                echo -e "   Share installation issues: https://github.com/slackapi/slack-cli/issues"
+                echo -e "   Submit installation issues: https://github.com/slackapi/slack-cli/issues"
         fi
 }
 

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -349,12 +349,15 @@ install_deno_vscode_extension() {
 }
 
 feedback_message() {
-        if [ $? -eq 0 ] && [ $(command -v $SLACK_CLI_NAME) ]; then
+        CODE=$?
+        if [ $CODE -eq 0 ] && [ $(command -v $SLACK_CLI_NAME) ]; then
                 echo -e "\n💌 We would love to know how things are going. Really. All of it."
                 echo -e "   Survey your development experience with \`$SLACK_CLI_NAME feedback\`"
         else
-                echo -e "\n💌 We would love to know how things are going. Really. All of it."
+                echo -e "\x1b[0m"
+                echo -e "💌 We would love to know how things are going. Really. All of it."
                 echo -e "   Submit installation issues: https://github.com/slackapi/slack-cli/issues"
+                exit $CODE
         fi
 }
 
@@ -374,7 +377,7 @@ next_step_message() {
 main() {
         trap 'feedback_message' ERR
 
-        set -e
+        set -eE
         install_slack_cli "$@"
 
         sleep 0.1

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -31,7 +31,7 @@ while getopts "v:d" flag; do
                                 SLACK_CLI_DEV_VERSION=$OPTARG
                         else
                                 echo "Slack CLI requires a valid semver version number." >&2
-                                exit 1
+                                return 1
                         fi
                         ;;
                 d)
@@ -102,8 +102,8 @@ install_slack_cli() {
 
                                 echo -e "🔖 Try using an alias when installing to avoid name conflicts:\n"
 
-                                echo -e "curl -fsSL https://downloads.slack-edge.com/slack-cli/install.sh | bash -s your-preferred-alias\n"
-                                exit 1
+                                echo -e "curl -fsSL https://downloads.slack-edge.com/slack-cli/install.sh | bash -s your-preferred-alias"
+                                return 1
                         fi
                 else
                         if [ "$SLACK_CLI_DEV_VERSION" == "dev" ]; then
@@ -140,7 +140,7 @@ install_slack_cli() {
                 echo "🛑 Error: This installer is only supported on Linux and macOS"
                 echo "🔖 Try using a different installation method:"
                 echo "🔗 https://tools.slack.dev/slack-cli"
-                exit 1
+                return 1
         fi
 
         slack_cli_install_dir="$HOME/.slack/dev-build"
@@ -169,15 +169,15 @@ install_slack_cli() {
         if [ ! -d /usr/local/bin ]; then
             echo -e "⚠️  The /usr/local/bin directory does not exist!"
             echo -e "🔐 Please create /usr/local/bin directory first and try again..."
-            exit 1
+            return 1
         fi
         if [ -w /usr/local/bin ]; then
                 ln -sf "$slack_cli_bin_path" "/usr/local/bin/$SLACK_CLI_NAME"
         else
                 echo -e "⚠️  Failed to create a symbolic link!"
                 delay 0.1 "🔖 The installer doesn't have write access to /usr/local/bin"
-                echo -e "🔐 Please check the permission and try again..."
-                exit 1
+                echo -e "🔐 Please check permission and try again..."
+                return 1
         fi
 
         if [ $(command -v $SLACK_CLI_NAME) ]; then
@@ -272,7 +272,7 @@ maybe_update_deno_version() {
                                                 [Yy]*) deno upgrade --version $MIN_DENO_VERSION ;;
                                                 *)
                                                         echo "Please upgrade deno manually to at least $MIN_DENO_VERSION and re-run this script."
-                                                        exit
+                                                        return
                                                         ;;
                                         esac
                                         ;;
@@ -323,7 +323,7 @@ install_deno() {
                                 ln -sf "$deno_path" /usr/local/bin/deno
                         else
                                 echo -e "Installer doesn't have write access to /usr/local/bin to create a symbolic link. Please check permission and try again"
-                                exit 1
+                                return 1
                         fi
                 fi
         fi
@@ -349,9 +349,12 @@ install_deno_vscode_extension() {
 }
 
 feedback_message() {
-        if [ $(command -v $SLACK_CLI_NAME) ]; then
+        if [ $? -eq 0 ] && [ $(command -v $SLACK_CLI_NAME) ]; then
                 echo -e "\n💌 We would love to know how things are going. Really. All of it."
                 echo -e "   Survey your development experience with \`$SLACK_CLI_NAME feedback\`"
+        else
+                echo -e "\n💌 We would love to know how things are going. Really. All of it."
+                echo -e "   Share installation issues: https://github.com/slackapi/slack-cli/issues"
         fi
 }
 
@@ -369,8 +372,11 @@ next_step_message() {
 }
 
 main() {
+        trap 'feedback_message' ERR
+
         set -e
         install_slack_cli "$@"
+
         sleep 0.1
         install_deno
 

--- a/scripts/install-windows-dev.ps1
+++ b/scripts/install-windows-dev.ps1
@@ -70,7 +70,7 @@ function check_slack_binary_exist() {
 
         Write-Host "`nTry using an alias when installing to avoid name conflicts:"
         Write-Host "`nirm https://downloads.slack-edge.com/slack-cli/install-windows.ps1 -Alias your-preferred-alias | iex"
-        Exit;
+        throw
       }
     }
     $message = "It is the same Slack CLI! Upgrading to the latest version..."
@@ -116,7 +116,8 @@ function install_slack_cli {
     }
   }
   catch {
-    throw "`nInstaller cannot find latest Slack CLI release version"
+    Write-Error "Installer cannot find latest Slack CLI release version"
+    throw
   }
 
   $slack_cli_dir = "${Home}\AppData\Local\slack-cli"
@@ -133,14 +134,16 @@ function install_slack_cli {
             $slack_cli_dir = $alternative_slack_cli_dir
           }
           catch {
-            throw "`nInstaller cannot create folder in $($alternative_slack_cli_dir). `nPlease manually create $($slack_cli_dir) folder and re-run the installation script"
+            Write-Error "Installer cannot create folder in $($alternative_slack_cli_dir). `nPlease manually create $($slack_cli_dir) folder and re-run the installation script"
+            throw
           }
         }
       }
     }
   }
   catch {
-    throw "`nInstaller cannot create folder for Slack CLI, `nPlease manually create $($slack_cli_dir) folder and re-run the installation script"
+    Write-Error "Installer cannot create folder for Slack CLI, `nPlease manually create $($slack_cli_dir) folder and re-run the installation script"
+    throw
   }
 
   if ($Version -eq "dev") {
@@ -153,7 +156,8 @@ function install_slack_cli {
     Invoke-WebRequest -Uri "https://downloads.slack-edge.com/slack-cli/slack_cli_$($SLACK_CLI_VERSION)_windows_64-bit.zip" -OutFile "$($slack_cli_dir)\slack_cli.zip"
   }
   catch {
-    throw "`nInstaller cannot download Slack CLI"
+    Write-Error "Installer cannot download Slack CLI"
+    throw
   }
 
   $slack_cli_bin_dir = "$($slack_cli_dir)\bin"
@@ -243,7 +247,8 @@ function install_deno {
         Write-Host "Comparing the currently installed Deno version... Found: v$deno_version_local"
       }
       else {
-        throw "Deno is not installed! Please install Deno to at least v$MIN_DENO_VERSION and try again."
+        Write-Error "Deno is not installed! Please install Deno to at least v$MIN_DENO_VERSION and try again."
+        throw
       }
 
       if ($deno_version_latest -eq "v$deno_version_local") {
@@ -262,7 +267,8 @@ function install_deno {
           Write-Host "Nice! Your Deno version has been updated and is ready!"
         }
         catch {
-          throw "`nDeno is not installed, please install deno manually to at least $MIN_DENO_VERSION and re-run this script."
+          Write-Error "Deno is not installed, please install deno manually to at least $MIN_DENO_VERSION and re-run this script."
+          throw
         }
       }
       else {
@@ -280,7 +286,8 @@ function install_deno {
         Write-Host "Your Deno version is compatible with the Slack CLI!"
       }
       catch {
-        throw "`nDeno is not installed, please install Deno manually to at least $MIN_DENO_VERSION and re-run this script."
+        Write-Error "Deno is not installed, please install Deno manually to at least $MIN_DENO_VERSION and re-run this script."
+        throw
       }
     }
   }
@@ -339,9 +346,17 @@ function next_step_message {
       Write-Host "   Then, authorize your CLI in your workspace with ``$confirmed_alias login``.`n"
     }
     catch {
-      throw "`nSlack CLI is not installed.`nPlease reach out to feedback@slack.com to share the issues you are facing.`nMeanwhile you can try the manual installation: https://tools.slack.dev/slack-cli.`n"
+      Write-Error "Slack CLI was not installed."
+      Write-Host "`nFind help troubleshooting: https://tools.slack.dev/slack-cli"
+      throw
     }
   }
+}
+
+trap {
+  Write-Host "`nWe would love to know how things are going. Really. All of it."
+  Write-Host "Share installation issues: https://github.com/slackapi/slack-cli/issues"
+  exit 1
 }
 
 install_slack_cli $Alias $Version

--- a/scripts/install-windows-dev.ps1
+++ b/scripts/install-windows-dev.ps1
@@ -355,7 +355,7 @@ function next_step_message {
 
 trap {
   Write-Host "`nWe would love to know how things are going. Really. All of it."
-  Write-Host "Share installation issues: https://github.com/slackapi/slack-cli/issues"
+  Write-Host "Submit installation issues: https://github.com/slackapi/slack-cli/issues"
   exit 1
 }
 

--- a/scripts/install-windows.ps1
+++ b/scripts/install-windows.ps1
@@ -346,7 +346,7 @@ function next_step_message {
 
 trap {
   Write-Host "`nWe would love to know how things are going. Really. All of it."
-  Write-Host "Share installation issues: https://github.com/slackapi/slack-cli/issues"
+  Write-Host "Submit installation issues: https://github.com/slackapi/slack-cli/issues"
   exit 1
 }
 

--- a/scripts/install-windows.ps1
+++ b/scripts/install-windows.ps1
@@ -113,7 +113,7 @@ function install_slack_cli {
     }
   }
   catch {
-    Write-Error "Installer cannot find latest Slack CLI release version!"
+    Write-Error "Installer cannot find latest Slack CLI release version"
     throw
   }
 
@@ -345,9 +345,9 @@ function next_step_message {
 }
 
 trap {
-    Write-Host "`nWe would love to know how things are going. Really. All of it."
-    Write-Host "Share installation issues: https://github.com/slackapi/slack-cli/issues"
-    exit 1
+  Write-Host "`nWe would love to know how things are going. Really. All of it."
+  Write-Host "Share installation issues: https://github.com/slackapi/slack-cli/issues"
+  exit 1
 }
 
 install_slack_cli $Alias $Version

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -28,7 +28,7 @@ while getopts "v:d" flag; do
                                 SLACK_CLI_VERSION=$OPTARG
                         else
                                 echo "Slack CLI requires a valid semver version number." >&2
-                                exit 1
+                                return 1
                         fi
                         ;;
                 d)
@@ -88,8 +88,8 @@ install_slack_cli() {
 
                                 echo -e "🔖 Try using an alias when installing to avoid name conflicts:\n"
 
-                                echo -e "curl -fsSL https://downloads.slack-edge.com/slack-cli/install.sh | bash -s your-preferred-alias\n"
-                                exit 1
+                                echo -e "curl -fsSL https://downloads.slack-edge.com/slack-cli/install.sh | bash -s your-preferred-alias"
+                                return 1
                         fi
                 else
                         if [ -z "$SLACK_CLI_VERSION" ]; then
@@ -110,7 +110,7 @@ install_slack_cli() {
                 if [ -z "$LATEST_SLACK_CLI_VERSION" ]; then
                     echo "🛑 Error: Installer cannot find the latest Slack CLI version!"
                     echo "🔖 Check the status of https://slack-status.com/ and try again"
-                    exit 1
+                    return 1
                 fi
                 echo -e "💾 Release v$LATEST_SLACK_CLI_VERSION was found! Downloading now..."
                 SLACK_CLI_VERSION=$LATEST_SLACK_CLI_VERSION
@@ -142,7 +142,7 @@ install_slack_cli() {
                 echo "🛑 Error: This installer is only supported on Linux and macOS"
                 echo "🔖 Try using a different installation method:"
                 echo "🔗 https://tools.slack.dev/slack-cli"
-                exit 1
+                return 1
         fi
 
         slack_cli_install_dir="$HOME/.slack"
@@ -167,7 +167,7 @@ install_slack_cli() {
         if [ ! -d /usr/local/bin ]; then
             echo -e "⚠️  The /usr/local/bin directory does not exist!"
             echo -e "🔐 Please create /usr/local/bin directory first and try again..."
-            exit 1
+            return 1
         fi
         if [ -w /usr/local/bin ]; then
                 ln -sf "$slack_cli_bin_path" "/usr/local/bin/$SLACK_CLI_NAME"
@@ -175,7 +175,7 @@ install_slack_cli() {
                 echo -e "⚠️  Failed to create a symbolic link!"
                 delay 0.1 "🔖 The installer doesn't have write access to /usr/local/bin"
                 echo -e "🔐 Please check permission and try again..."
-                exit 1
+                return 1
         fi
 
         if [ $(command -v $SLACK_CLI_NAME) ]; then
@@ -271,7 +271,7 @@ maybe_update_deno_version() {
                                                 [Yy]*) deno upgrade --version $MIN_DENO_VERSION ;;
                                                 *)
                                                         echo "Please upgrade deno manually to at least $MIN_DENO_VERSION and re-run this script."
-                                                        exit
+                                                        return
                                                         ;;
                                         esac
                                         ;;
@@ -322,7 +322,7 @@ install_deno() {
                                 ln -sf "$deno_path" /usr/local/bin/deno
                         else
                                 echo -e "Installer doesn't have write access to /usr/local/bin to create a symbolic link. Please check permission and try again"
-                                exit 1
+                                return 1
                         fi
                 fi
         fi
@@ -348,9 +348,12 @@ install_deno_vscode_extension() {
 }
 
 feedback_message() {
-        if [ $(command -v $SLACK_CLI_NAME) ]; then
+        if [ $? -eq 0 ] && [ $(command -v $SLACK_CLI_NAME) ]; then
                 echo -e "\n💌 We would love to know how things are going. Really. All of it."
                 echo -e "   Survey your development experience with \`$SLACK_CLI_NAME feedback\`"
+        else
+                echo -e "\n💌 We would love to know how things are going. Really. All of it."
+                echo -e "   Share installation issues: https://github.com/slackapi/slack-cli/issues"
         fi
 }
 
@@ -368,6 +371,8 @@ next_step_message() {
 }
 
 main() {
+        trap 'feedback_message' ERR
+
         set -e
         install_slack_cli "$@"
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -348,12 +348,15 @@ install_deno_vscode_extension() {
 }
 
 feedback_message() {
-        if [ $? -eq 0 ] && [ $(command -v $SLACK_CLI_NAME) ]; then
+        CODE=$?
+        if [ $CODE -eq 0 ] && [ $(command -v $SLACK_CLI_NAME) ]; then
                 echo -e "\n💌 We would love to know how things are going. Really. All of it."
                 echo -e "   Survey your development experience with \`$SLACK_CLI_NAME feedback\`"
         else
-                echo -e "\n💌 We would love to know how things are going. Really. All of it."
+                echo -e "\x1b[0m"
+                echo -e "💌 We would love to know how things are going. Really. All of it."
                 echo -e "   Submit installation issues: https://github.com/slackapi/slack-cli/issues"
+                exit $CODE
         fi
 }
 
@@ -373,7 +376,7 @@ next_step_message() {
 main() {
         trap 'feedback_message' ERR
 
-        set -e
+        set -eE
         install_slack_cli "$@"
 
         sleep 0.1

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -353,7 +353,7 @@ feedback_message() {
                 echo -e "   Survey your development experience with \`$SLACK_CLI_NAME feedback\`"
         else
                 echo -e "\n💌 We would love to know how things are going. Really. All of it."
-                echo -e "   Share installation issues: https://github.com/slackapi/slack-cli/issues"
+                echo -e "   Submit installation issues: https://github.com/slackapi/slack-cli/issues"
         fi
 }
 


### PR DESCRIPTION
> **Changelog**
>
> The installation scripts now make a kind request for feedback in issues if the installation scripts error.

### Summary

This PR outputs a link to the issue tracker if installation scripts fail. Following reported errors of #147.

### Preview

![install](https://github.com/user-attachments/assets/bdc5573a-6e1c-4552-88e6-ef76aefc6aaa)

### Reviewers

With these changes change the environment for testing:

```sh
$ ./scripts/install.sh           # Might error if another "slack" program exists
$ ./scripts/install.sh lack-dev  # Succeeds
$ chmod -w /usr/local/bin        # Remove permissions needed for install
$ ./scripts/install.sh lack-dev  # Errors
$ chmod +w /usr/local/bin        # Revert changes made during this testing
```

### Notes

Before requesting a review I plan to make similar changes on Windows.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).