### PR TITLE
refactor: join the app selector and team selector logic

### DIFF
--- a/cmd/app/add.go
+++ b/cmd/app/add.go
@@ -36,7 +36,7 @@ import (
 var runAddCommandFunc = RunAddCommand
 var appInstallProdAppFunc = apps.Add
 var appInstallDevAppFunc = apps.InstallLocalApp
-var teamAppSelectPromptFunc = prompts.TeamAppSelectPrompt
+var appSelectPromptFunc = prompts.AppSelectPrompt
 
 // Flags
 
@@ -111,7 +111,7 @@ func preRunAddCommand(ctx context.Context, clients *shared.ClientFactory) error 
 // RunAddCommand executes the workspace install command, prints output, and returns any errors.
 func RunAddCommand(ctx context.Context, clients *shared.ClientFactory, selection *prompts.SelectedApp, orgGrantWorkspaceID string) (context.Context, types.InstallState, types.App, error) {
 	if selection == nil {
-		selected, err := teamAppSelectPromptFunc(ctx, clients, prompts.ShowHostedOnly, prompts.ShowAllApps)
+		selected, err := appSelectPromptFunc(ctx, clients, prompts.ShowHostedOnly, prompts.ShowAllApps)
 		if err != nil {
 			return ctx, "", types.App{}, err
 		}

--- a/cmd/app/add_test.go
+++ b/cmd/app/add_test.go
@@ -140,8 +140,8 @@ func TestAppAddCommand(t *testing.T) {
 
 				// Mock TeamSelector prompt to return "team1"
 				appSelectMock := prompts.NewAppSelectMock()
-				teamAppSelectPromptFunc = appSelectMock.TeamAppSelectPrompt
-				appSelectMock.On("TeamAppSelectPrompt").Return(prompts.SelectedApp{Auth: mockAuthTeam1}, nil)
+				appSelectPromptFunc = appSelectMock.AppSelectPrompt
+				appSelectMock.On("AppSelectPrompt", mock.Anything, mock.Anything, prompts.ShowHostedOnly, prompts.ShowAllApps).Return(prompts.SelectedApp{Auth: mockAuthTeam1}, nil)
 
 				// Mock valid session for team1
 				cm.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{
@@ -212,8 +212,8 @@ func TestAppAddCommand(t *testing.T) {
 
 				// Mock TeamSelector prompt to return "team1"
 				appSelectMock := prompts.NewAppSelectMock()
-				teamAppSelectPromptFunc = appSelectMock.TeamAppSelectPrompt
-				appSelectMock.On("TeamAppSelectPrompt").Return(prompts.SelectedApp{App: mockAppTeam1, Auth: mockAuthTeam1}, nil)
+				appSelectPromptFunc = appSelectMock.AppSelectPrompt
+				appSelectMock.On("AppSelectPrompt", mock.Anything, mock.Anything, prompts.ShowHostedOnly, prompts.ShowAllApps).Return(prompts.SelectedApp{App: mockAppTeam1, Auth: mockAuthTeam1}, nil)
 
 				// Mock valid session for team1
 				cm.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{
@@ -292,8 +292,8 @@ func TestAppAddCommand(t *testing.T) {
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
 				prepareAddMocks(t, cf, cm)
 				appSelectMock := prompts.NewAppSelectMock()
-				teamAppSelectPromptFunc = appSelectMock.TeamAppSelectPrompt
-				appSelectMock.On("TeamAppSelectPrompt").Return(prompts.SelectedApp{App: mockAppTeam1}, nil)
+				appSelectPromptFunc = appSelectMock.AppSelectPrompt
+				appSelectMock.On("AppSelectPrompt", mock.Anything, mock.Anything, prompts.ShowHostedOnly, prompts.ShowAllApps).Return(prompts.SelectedApp{App: mockAppTeam1}, nil)
 			},
 		},
 		"adds a new deployed app to an org with a workspace grant": {
@@ -303,8 +303,8 @@ func TestAppAddCommand(t *testing.T) {
 				prepareAddMocks(t, cf, cm)
 				// Select workspace
 				appSelectMock := prompts.NewAppSelectMock()
-				teamAppSelectPromptFunc = appSelectMock.TeamAppSelectPrompt
-				appSelectMock.On("TeamAppSelectPrompt").Return(prompts.SelectedApp{App: types.NewApp(), Auth: mockOrgAuth}, nil)
+				appSelectPromptFunc = appSelectMock.AppSelectPrompt
+				appSelectMock.On("AppSelectPrompt", mock.Anything, mock.Anything, prompts.ShowHostedOnly, prompts.ShowAllApps).Return(prompts.SelectedApp{App: types.NewApp(), Auth: mockOrgAuth}, nil)
 				// Mock calls
 				cm.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{
 					UserID:   &mockOrgAuth.UserID,
@@ -363,8 +363,8 @@ func TestAppAddCommand(t *testing.T) {
 				prepareAddMocks(t, cf, cm)
 				// Select workspace
 				appSelectMock := prompts.NewAppSelectMock()
-				teamAppSelectPromptFunc = appSelectMock.TeamAppSelectPrompt
-				appSelectMock.On("TeamAppSelectPrompt").Return(prompts.SelectedApp{App: types.NewApp(), Auth: mockOrgAuth}, nil)
+				appSelectPromptFunc = appSelectMock.AppSelectPrompt
+				appSelectMock.On("AppSelectPrompt", mock.Anything, mock.Anything, prompts.ShowHostedOnly, prompts.ShowAllApps).Return(prompts.SelectedApp{App: types.NewApp(), Auth: mockOrgAuth}, nil)
 				// Mock calls
 				cm.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{
 					UserID:   &mockOrgAuth.UserID,
@@ -419,8 +419,8 @@ func TestAppAddCommand(t *testing.T) {
 				prepareAddMocks(t, cf, cm)
 				// Select workspace
 				appSelectMock := prompts.NewAppSelectMock()
-				teamAppSelectPromptFunc = appSelectMock.TeamAppSelectPrompt
-				appSelectMock.On("TeamAppSelectPrompt").Return(prompts.SelectedApp{App: types.NewApp(), Auth: mockOrgAuth}, nil)
+				appSelectPromptFunc = appSelectMock.AppSelectPrompt
+				appSelectMock.On("AppSelectPrompt", mock.Anything, mock.Anything, prompts.ShowHostedOnly, prompts.ShowAllApps).Return(prompts.SelectedApp{App: types.NewApp(), Auth: mockOrgAuth}, nil)
 				// Mock calls
 				cm.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{
 					UserID:   &mockOrgAuth.UserID,

--- a/cmd/app/delete.go
+++ b/cmd/app/delete.go
@@ -71,7 +71,7 @@ func RunDeleteCommand(ctx context.Context, clients *shared.ClientFactory, cmd *c
 	}
 
 	// Get the app auth selection from the flag or prompt
-	selection, err := deleteAppSelectPromptFunc(ctx, clients, prompts.ShowInstalledAndUninstalledApps)
+	selection, err := deleteAppSelectPromptFunc(ctx, clients, prompts.ShowAllEnvironments, prompts.ShowInstalledAndUninstalledApps)
 	if err != nil {
 		if slackerror.ToSlackError(err).Code == slackerror.ErrInstallationRequired {
 			return types.App{}, nil

--- a/cmd/app/delete_test.go
+++ b/cmd/app/delete_test.go
@@ -55,7 +55,7 @@ func TestAppsDeleteCommand(t *testing.T) {
 				// Mock App Selection
 				appSelectMock := prompts.NewAppSelectMock()
 				deleteAppSelectPromptFunc = appSelectMock.AppSelectPrompt
-				appSelectMock.On("AppSelectPrompt").Return(prompts.SelectedApp{
+				appSelectMock.On("AppSelectPrompt", mock.Anything, mock.Anything, prompts.ShowAllEnvironments, prompts.ShowInstalledAndUninstalledApps).Return(prompts.SelectedApp{
 					Auth: types.SlackAuth{TeamDomain: fakeDeployedApp.TeamDomain},
 					App:  fakeDeployedApp,
 				}, nil)
@@ -89,7 +89,7 @@ func TestAppsDeleteCommand(t *testing.T) {
 				// Mock App Selection
 				appSelectMock := prompts.NewAppSelectMock()
 				deleteAppSelectPromptFunc = appSelectMock.AppSelectPrompt
-				appSelectMock.On("AppSelectPrompt").Return(prompts.SelectedApp{
+				appSelectMock.On("AppSelectPrompt", mock.Anything, mock.Anything, prompts.ShowAllEnvironments, prompts.ShowInstalledAndUninstalledApps).Return(prompts.SelectedApp{
 					Auth: types.SlackAuth{TeamDomain: fakeLocalApp.TeamDomain},
 					App:  fakeLocalApp,
 				}, nil)
@@ -122,7 +122,7 @@ func TestAppsDeleteCommand(t *testing.T) {
 				// Mock App Selection
 				appSelectMock := prompts.NewAppSelectMock()
 				deleteAppSelectPromptFunc = appSelectMock.AppSelectPrompt
-				appSelectMock.On("AppSelectPrompt").Return(prompts.SelectedApp{
+				appSelectMock.On("AppSelectPrompt", mock.Anything, mock.Anything, prompts.ShowAllEnvironments, prompts.ShowInstalledAndUninstalledApps).Return(prompts.SelectedApp{
 					Auth: types.SlackAuth{TeamDomain: fakeDeployedApp.TeamDomain},
 					App:  fakeDeployedApp,
 				}, nil)
@@ -149,7 +149,7 @@ func TestAppsDeleteCommand(t *testing.T) {
 				cm.API.On("ValidateSession", mock.Anything, mock.Anything).Return(api.AuthSession{}, nil)
 				appSelectMock := prompts.NewAppSelectMock()
 				deleteAppSelectPromptFunc = appSelectMock.AppSelectPrompt
-				appSelectMock.On("AppSelectPrompt").Return(prompts.SelectedApp{App: fakeDeployedApp}, nil)
+				appSelectMock.On("AppSelectPrompt", mock.Anything, mock.Anything, prompts.ShowAllEnvironments, prompts.ShowInstalledAndUninstalledApps).Return(prompts.SelectedApp{App: fakeDeployedApp}, nil)
 			},
 		},
 	}, func(cf *shared.ClientFactory) *cobra.Command {

--- a/cmd/app/settings.go
+++ b/cmd/app/settings.go
@@ -96,7 +96,7 @@ func appSettingsCommandRunE(clients *shared.ClientFactory, cmd *cobra.Command, a
 	ctx := cmd.Context()
 	clients.IO.PrintTrace(ctx, slacktrace.AppSettingsStart)
 
-	app, err := settingsAppSelectPromptFunc(ctx, clients, prompts.ShowInstalledAndUninstalledApps)
+	app, err := settingsAppSelectPromptFunc(ctx, clients, prompts.ShowAllEnvironments, prompts.ShowInstalledAndUninstalledApps)
 	if err != nil {
 		return err
 	}

--- a/cmd/app/settings_test.go
+++ b/cmd/app/settings_test.go
@@ -96,6 +96,10 @@ func Test_App_SettingsCommand(t *testing.T) {
 				appSelectMock := prompts.NewAppSelectMock()
 				appSelectMock.On(
 					"AppSelectPrompt",
+					mock.Anything,
+					mock.Anything,
+					prompts.ShowAllEnvironments,
+					prompts.ShowInstalledAndUninstalledApps,
 				).Return(
 					prompts.SelectedApp{App: types.App{AppID: "A0101010101"}},
 					nil,
@@ -124,6 +128,10 @@ func Test_App_SettingsCommand(t *testing.T) {
 				appSelectMock := prompts.NewAppSelectMock()
 				appSelectMock.On(
 					"AppSelectPrompt",
+					mock.Anything,
+					mock.Anything,
+					prompts.ShowAllEnvironments,
+					prompts.ShowInstalledAndUninstalledApps,
 				).Return(
 					prompts.SelectedApp{},
 					slackerror.New(slackerror.ErrInstallationRequired),
@@ -147,6 +155,10 @@ func Test_App_SettingsCommand(t *testing.T) {
 				appSelectMock := prompts.NewAppSelectMock()
 				appSelectMock.On(
 					"AppSelectPrompt",
+					mock.Anything,
+					mock.Anything,
+					prompts.ShowAllEnvironments,
+					prompts.ShowInstalledAndUninstalledApps,
 				).Return(
 					prompts.SelectedApp{App: types.App{AppID: "A0123456789"}},
 					nil,
@@ -176,6 +188,10 @@ func Test_App_SettingsCommand(t *testing.T) {
 				appSelectMock := prompts.NewAppSelectMock()
 				appSelectMock.On(
 					"AppSelectPrompt",
+					mock.Anything,
+					mock.Anything,
+					prompts.ShowAllEnvironments,
+					prompts.ShowInstalledAndUninstalledApps,
 				).Return(
 					prompts.SelectedApp{
 						App:  types.App{AppID: "A0123456789"},

--- a/cmd/app/uninstall.go
+++ b/cmd/app/uninstall.go
@@ -66,7 +66,7 @@ func RunUninstallCommand(ctx context.Context, clients *shared.ClientFactory, cmd
 	}
 
 	// Get the workspace from the flag or prompt
-	selection, err := uninstallAppSelectPromptFunc(ctx, clients, prompts.ShowInstalledAppsOnly)
+	selection, err := uninstallAppSelectPromptFunc(ctx, clients, prompts.ShowAllEnvironments, prompts.ShowInstalledAppsOnly)
 	if err != nil {
 		if slackerror.ToSlackError(err).Code == slackerror.ErrInstallationRequired {
 			return types.App{}, nil

--- a/cmd/app/uninstall_test.go
+++ b/cmd/app/uninstall_test.go
@@ -84,7 +84,7 @@ func TestAppsUninstall(t *testing.T) {
 				prepareCommonUninstallMocks(ctx, cf, cm)
 				appSelectMock := prompts.NewAppSelectMock()
 				uninstallAppSelectPromptFunc = appSelectMock.AppSelectPrompt
-				appSelectMock.On("AppSelectPrompt").Return(prompts.SelectedApp{App: fakeApp}, nil)
+				appSelectMock.On("AppSelectPrompt", mock.Anything, mock.Anything, prompts.ShowAllEnvironments, prompts.ShowInstalledAppsOnly).Return(prompts.SelectedApp{App: fakeApp}, nil)
 			},
 		},
 	}, func(clients *shared.ClientFactory) *cobra.Command {
@@ -99,7 +99,7 @@ func prepareCommonUninstallMocks(ctx context.Context, clients *shared.ClientFact
 	// Mock App Selection
 	appSelectMock := prompts.NewAppSelectMock()
 	uninstallAppSelectPromptFunc = appSelectMock.AppSelectPrompt
-	appSelectMock.On("AppSelectPrompt").Return(selectedProdApp, nil)
+	appSelectMock.On("AppSelectPrompt", mock.Anything, mock.Anything, prompts.ShowAllEnvironments, prompts.ShowInstalledAppsOnly).Return(selectedProdApp, nil)
 
 	// Mock API calls
 	clientsMock.Auth.On("ResolveAPIHost", mock.Anything, mock.Anything, mock.Anything).

--- a/cmd/collaborators/add.go
+++ b/cmd/collaborators/add.go
@@ -74,7 +74,7 @@ func runAddCommandFunc(ctx context.Context, clients *shared.ClientFactory, cmd *
 	defer span.Finish()
 
 	// Get the app auth selection from the flag or prompt
-	selection, err := teamAppSelectPromptFunc(ctx, clients, prompts.ShowHostedOnly, prompts.ShowInstalledAndUninstalledApps)
+	selection, err := appSelectPromptFunc(ctx, clients, prompts.ShowHostedOnly, prompts.ShowInstalledAndUninstalledApps)
 	if err != nil {
 		return err
 	}

--- a/cmd/collaborators/add_test.go
+++ b/cmd/collaborators/add_test.go
@@ -35,8 +35,8 @@ func TestAddCommand(t *testing.T) {
 				cm.AddDefaultMocks()
 				// Mock App Selection
 				appSelectMock := prompts.NewAppSelectMock()
-				teamAppSelectPromptFunc = appSelectMock.TeamAppSelectPrompt
-				appSelectMock.On("TeamAppSelectPrompt").Return(prompts.SelectedApp{App: types.App{AppID: "A123"}, Auth: types.SlackAuth{}}, nil)
+				appSelectPromptFunc = appSelectMock.AppSelectPrompt
+				appSelectMock.On("AppSelectPrompt", mock.Anything, mock.Anything, prompts.ShowHostedOnly, prompts.ShowInstalledAndUninstalledApps).Return(prompts.SelectedApp{App: types.App{AppID: "A123"}, Auth: types.SlackAuth{}}, nil)
 				// Set experiment flag
 				cm.Config.ExperimentsFlag = append(cm.Config.ExperimentsFlag, "read-only-collaborators")
 				cm.Config.LoadExperiments(ctx, cm.IO.PrintDebug)
@@ -59,8 +59,8 @@ func TestAddCommand(t *testing.T) {
 				cm.AddDefaultMocks()
 				// Mock App Selection
 				appSelectMock := prompts.NewAppSelectMock()
-				teamAppSelectPromptFunc = appSelectMock.TeamAppSelectPrompt
-				appSelectMock.On("TeamAppSelectPrompt").Return(prompts.SelectedApp{App: types.App{AppID: "A123"}, Auth: types.SlackAuth{}}, nil)
+				appSelectPromptFunc = appSelectMock.AppSelectPrompt
+				appSelectMock.On("AppSelectPrompt", mock.Anything, mock.Anything, prompts.ShowHostedOnly, prompts.ShowInstalledAndUninstalledApps).Return(prompts.SelectedApp{App: types.App{AppID: "A123"}, Auth: types.SlackAuth{}}, nil)
 				// Set experiment flag
 				cm.Config.ExperimentsFlag = append(cm.Config.ExperimentsFlag, "read-only-collaborators")
 				cm.Config.LoadExperiments(ctx, cm.IO.PrintDebug)
@@ -84,8 +84,8 @@ func TestAddCommand(t *testing.T) {
 				cm.AddDefaultMocks()
 				// Mock App Selection
 				appSelectMock := prompts.NewAppSelectMock()
-				teamAppSelectPromptFunc = appSelectMock.TeamAppSelectPrompt
-				appSelectMock.On("TeamAppSelectPrompt").Return(prompts.SelectedApp{App: types.App{AppID: "A123"}, Auth: types.SlackAuth{}}, nil)
+				appSelectPromptFunc = appSelectMock.AppSelectPrompt
+				appSelectMock.On("AppSelectPrompt", mock.Anything, mock.Anything, prompts.ShowHostedOnly, prompts.ShowInstalledAndUninstalledApps).Return(prompts.SelectedApp{App: types.App{AppID: "A123"}, Auth: types.SlackAuth{}}, nil)
 				// Mock API call
 				cm.API.On("AddCollaborator", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(nil)

--- a/cmd/collaborators/collaborators.go
+++ b/cmd/collaborators/collaborators.go
@@ -26,8 +26,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// teamAppSelectPromptFunc is a handle to the TeamAppSelectPrompt that can be mocked in tests
-var teamAppSelectPromptFunc = prompts.TeamAppSelectPrompt
+// appSelectPromptFunc is a handle to the AppSelectPrompt that can be mocked in tests
+var appSelectPromptFunc = prompts.AppSelectPrompt
 
 func NewCommand(clients *shared.ClientFactory) *cobra.Command {
 	cmd := &cobra.Command{

--- a/cmd/collaborators/collaborators_test.go
+++ b/cmd/collaborators/collaborators_test.go
@@ -102,8 +102,8 @@ func TestCollaboratorsCommand(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx := slackcontext.MockContext(t.Context())
 			appSelectMock := prompts.NewAppSelectMock()
-			teamAppSelectPromptFunc = appSelectMock.TeamAppSelectPrompt
-			appSelectMock.On("TeamAppSelectPrompt").Return(prompts.SelectedApp{App: tt.app, Auth: types.SlackAuth{}}, nil)
+			appSelectPromptFunc = appSelectMock.AppSelectPrompt
+			appSelectMock.On("AppSelectPrompt", mock.Anything, mock.Anything, prompts.ShowHostedOnly, prompts.ShowInstalledAndUninstalledApps).Return(prompts.SelectedApp{App: tt.app, Auth: types.SlackAuth{}}, nil)
 			clientsMock := shared.NewClientsMock()
 			clientsMock.AddDefaultMocks()
 			clientsMock.API.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).

--- a/cmd/collaborators/list.go
+++ b/cmd/collaborators/list.go
@@ -58,7 +58,7 @@ func runListCommand(cmd *cobra.Command, clients *shared.ClientFactory) error {
 	defer span.Finish()
 
 	// Get the app auth selection from the flag or prompt
-	selection, err := teamAppSelectPromptFunc(ctx, clients, prompts.ShowHostedOnly, prompts.ShowInstalledAndUninstalledApps)
+	selection, err := appSelectPromptFunc(ctx, clients, prompts.ShowHostedOnly, prompts.ShowInstalledAndUninstalledApps)
 	if err != nil {
 		return err
 	}

--- a/cmd/collaborators/list_test.go
+++ b/cmd/collaborators/list_test.go
@@ -102,8 +102,8 @@ func TestListCommand(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx := slackcontext.MockContext(t.Context())
 			appSelectMock := prompts.NewAppSelectMock()
-			teamAppSelectPromptFunc = appSelectMock.TeamAppSelectPrompt
-			appSelectMock.On("TeamAppSelectPrompt").Return(prompts.SelectedApp{App: tt.app, Auth: types.SlackAuth{}}, nil)
+			appSelectPromptFunc = appSelectMock.AppSelectPrompt
+			appSelectMock.On("AppSelectPrompt", mock.Anything, mock.Anything, prompts.ShowHostedOnly, prompts.ShowInstalledAndUninstalledApps).Return(prompts.SelectedApp{App: tt.app, Auth: types.SlackAuth{}}, nil)
 			clientsMock := shared.NewClientsMock()
 			clientsMock.AddDefaultMocks()
 			clientsMock.API.On("ListCollaborators", mock.Anything, mock.Anything, mock.Anything).

--- a/cmd/collaborators/remove.go
+++ b/cmd/collaborators/remove.go
@@ -59,7 +59,7 @@ func runRemoveCommandFunc(ctx context.Context, clients *shared.ClientFactory, cm
 	var span opentracing.Span
 	span, ctx = opentracing.StartSpanFromContext(ctx, "cmd.Collaborators.Remove")
 	defer span.Finish()
-	selection, err := teamAppSelectPromptFunc(ctx, clients, prompts.ShowHostedOnly, prompts.ShowInstalledAndUninstalledApps)
+	selection, err := appSelectPromptFunc(ctx, clients, prompts.ShowHostedOnly, prompts.ShowInstalledAndUninstalledApps)
 	if err != nil {
 		return err
 	}

--- a/cmd/collaborators/remove_test.go
+++ b/cmd/collaborators/remove_test.go
@@ -53,8 +53,8 @@ func TestRemoveCommand(t *testing.T) {
 			CmdArgs: []string{"USLACKBOT"},
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
 				appSelectMock := prompts.NewAppSelectMock()
-				teamAppSelectPromptFunc = appSelectMock.TeamAppSelectPrompt
-				appSelectMock.On("TeamAppSelectPrompt").
+				appSelectPromptFunc = appSelectMock.AppSelectPrompt
+				appSelectMock.On("AppSelectPrompt", mock.Anything, mock.Anything, prompts.ShowHostedOnly, prompts.ShowInstalledAndUninstalledApps).
 					Return(mockSelection, nil)
 				cm.API.On("RemoveCollaborator", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(nil)
@@ -72,8 +72,8 @@ func TestRemoveCommand(t *testing.T) {
 			CmdArgs: []string{},
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
 				appSelectMock := prompts.NewAppSelectMock()
-				teamAppSelectPromptFunc = appSelectMock.TeamAppSelectPrompt
-				appSelectMock.On("TeamAppSelectPrompt").
+				appSelectPromptFunc = appSelectMock.AppSelectPrompt
+				appSelectMock.On("AppSelectPrompt", mock.Anything, mock.Anything, prompts.ShowHostedOnly, prompts.ShowInstalledAndUninstalledApps).
 					Return(mockSelection, nil)
 				cm.API.On("RemoveCollaborator", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(nil)
@@ -93,8 +93,8 @@ func TestRemoveCommand(t *testing.T) {
 			CmdArgs: []string{},
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
 				appSelectMock := prompts.NewAppSelectMock()
-				teamAppSelectPromptFunc = appSelectMock.TeamAppSelectPrompt
-				appSelectMock.On("TeamAppSelectPrompt").
+				appSelectPromptFunc = appSelectMock.AppSelectPrompt
+				appSelectMock.On("AppSelectPrompt", mock.Anything, mock.Anything, prompts.ShowHostedOnly, prompts.ShowInstalledAndUninstalledApps).
 					Return(mockSelection, nil)
 				cm.API.On("RemoveCollaborator", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 					Return(nil)

--- a/cmd/collaborators/update.go
+++ b/cmd/collaborators/update.go
@@ -97,7 +97,7 @@ func runUpdateCommand(cmd *cobra.Command, clients *shared.ClientFactory, args []
 	}
 
 	// Get the app auth selection from the flag or prompt
-	selection, err := teamAppSelectPromptFunc(ctx, clients, prompts.ShowHostedOnly, prompts.ShowInstalledAndUninstalledApps)
+	selection, err := appSelectPromptFunc(ctx, clients, prompts.ShowHostedOnly, prompts.ShowInstalledAndUninstalledApps)
 	if err != nil {
 		return err
 	}

--- a/cmd/collaborators/update_test.go
+++ b/cmd/collaborators/update_test.go
@@ -35,8 +35,8 @@ func TestUpdateCommand(t *testing.T) {
 				clientsMock.AddDefaultMocks()
 				// Mock App Selection
 				appSelectMock := prompts.NewAppSelectMock()
-				teamAppSelectPromptFunc = appSelectMock.TeamAppSelectPrompt
-				appSelectMock.On("TeamAppSelectPrompt").Return(prompts.SelectedApp{App: types.App{AppID: "A123"}, Auth: types.SlackAuth{}}, nil)
+				appSelectPromptFunc = appSelectMock.AppSelectPrompt
+				appSelectMock.On("AppSelectPrompt", mock.Anything, mock.Anything, prompts.ShowHostedOnly, prompts.ShowInstalledAndUninstalledApps).Return(prompts.SelectedApp{App: types.App{AppID: "A123"}, Auth: types.SlackAuth{}}, nil)
 				// Set experiment flag
 				clientsMock.Config.ExperimentsFlag = append(clientsMock.Config.ExperimentsFlag, "read-only-collaborators")
 				clientsMock.Config.LoadExperiments(ctx, clientsMock.IO.PrintDebug)
@@ -53,8 +53,8 @@ func TestUpdateCommand(t *testing.T) {
 				clientsMock.AddDefaultMocks()
 				// Mock App Selection
 				appSelectMock := prompts.NewAppSelectMock()
-				teamAppSelectPromptFunc = appSelectMock.TeamAppSelectPrompt
-				appSelectMock.On("TeamAppSelectPrompt").Return(prompts.SelectedApp{App: types.App{AppID: "A123"}, Auth: types.SlackAuth{}}, nil)
+				appSelectPromptFunc = appSelectMock.AppSelectPrompt
+				appSelectMock.On("AppSelectPrompt", mock.Anything, mock.Anything, prompts.ShowHostedOnly, prompts.ShowInstalledAndUninstalledApps).Return(prompts.SelectedApp{App: types.App{AppID: "A123"}, Auth: types.SlackAuth{}}, nil)
 				// Set experiment flag
 				clientsMock.Config.ExperimentsFlag = append(clientsMock.Config.ExperimentsFlag, "read-only-collaborators")
 				clientsMock.Config.LoadExperiments(ctx, clientsMock.IO.PrintDebug)

--- a/cmd/datastore/bulk_delete.go
+++ b/cmd/datastore/bulk_delete.go
@@ -73,7 +73,7 @@ func NewBulkDeleteCommand(clients *shared.ClientFactory) *cobra.Command {
 			}
 
 			// Get the app auth selection from the flag or prompt
-			selection, err := appSelectPromptFunc(ctx, clients, prompts.ShowInstalledAppsOnly)
+			selection, err := appSelectPromptFunc(ctx, clients, prompts.ShowAllEnvironments, prompts.ShowInstalledAppsOnly)
 			if err != nil {
 				return err
 			}

--- a/cmd/datastore/bulk_get.go
+++ b/cmd/datastore/bulk_get.go
@@ -75,7 +75,7 @@ func NewBulkGetCommand(clients *shared.ClientFactory) *cobra.Command {
 			}
 
 			// Get the app auth selection from the flag or prompt
-			selection, err := appSelectPromptFunc(ctx, clients, prompts.ShowInstalledAppsOnly)
+			selection, err := appSelectPromptFunc(ctx, clients, prompts.ShowAllEnvironments, prompts.ShowInstalledAppsOnly)
 			if err != nil {
 				return err
 			}

--- a/cmd/datastore/bulk_put.go
+++ b/cmd/datastore/bulk_put.go
@@ -88,7 +88,7 @@ func NewBulkPutCommand(clients *shared.ClientFactory) *cobra.Command {
 			}
 
 			// Get the selection from the flag or prompt
-			selection, err := appSelectPromptFunc(ctx, clients, prompts.ShowInstalledAppsOnly)
+			selection, err := appSelectPromptFunc(ctx, clients, prompts.ShowAllEnvironments, prompts.ShowInstalledAppsOnly)
 			if err != nil {
 				return err
 			}

--- a/cmd/datastore/count.go
+++ b/cmd/datastore/count.go
@@ -113,7 +113,7 @@ func runCountCommandFunc(
 	}
 
 	// Get the app from the flag or prompt
-	selection, err := appSelectPromptFunc(ctx, clients, prompts.ShowInstalledAppsOnly)
+	selection, err := appSelectPromptFunc(ctx, clients, prompts.ShowAllEnvironments, prompts.ShowInstalledAppsOnly)
 	if err != nil {
 		return err
 	}

--- a/cmd/datastore/count_test.go
+++ b/cmd/datastore/count_test.go
@@ -348,7 +348,7 @@ func TestCountCommand(t *testing.T) {
 		}
 		appSelectMock := prompts.NewAppSelectMock()
 		appSelectPromptFunc = appSelectMock.AppSelectPrompt
-		appSelectMock.On("AppSelectPrompt").
+		appSelectMock.On("AppSelectPrompt", mock.Anything, mock.Anything, prompts.ShowAllEnvironments, prompts.ShowInstalledAppsOnly).
 			Return(prompts.SelectedApp{App: types.App{AppID: "A001"}}, nil)
 		return cmd
 	})

--- a/cmd/datastore/datastore_test.go
+++ b/cmd/datastore/datastore_test.go
@@ -59,7 +59,7 @@ func setupDatastoreMocks() *shared.ClientsMock {
 	// Select the same example app each time
 	appSelectMock := prompts.NewAppSelectMock()
 	appSelectPromptFunc = appSelectMock.AppSelectPrompt
-	appSelectMock.On("AppSelectPrompt").Return(prompts.SelectedApp{
+	appSelectMock.On("AppSelectPrompt", mock.Anything, mock.Anything, prompts.ShowAllEnvironments, prompts.ShowInstalledAppsOnly).Return(prompts.SelectedApp{
 		App: types.App{AppID: mockAppID},
 	}, nil)
 

--- a/cmd/datastore/delete.go
+++ b/cmd/datastore/delete.go
@@ -75,7 +75,7 @@ func NewDeleteCommand(clients *shared.ClientFactory) *cobra.Command {
 			}
 
 			// Get the app auth selection from the flag or prompt
-			selection, err := appSelectPromptFunc(ctx, clients, prompts.ShowInstalledAppsOnly)
+			selection, err := appSelectPromptFunc(ctx, clients, prompts.ShowAllEnvironments, prompts.ShowInstalledAppsOnly)
 			if err != nil {
 				return err
 			}

--- a/cmd/datastore/get.go
+++ b/cmd/datastore/get.go
@@ -77,7 +77,7 @@ func NewGetCommand(clients *shared.ClientFactory) *cobra.Command {
 			}
 
 			// Get the app auth selection from the flag or prompt
-			selection, err := appSelectPromptFunc(ctx, clients, prompts.ShowInstalledAppsOnly)
+			selection, err := appSelectPromptFunc(ctx, clients, prompts.ShowAllEnvironments, prompts.ShowInstalledAppsOnly)
 			if err != nil {
 				return err
 			}

--- a/cmd/datastore/put.go
+++ b/cmd/datastore/put.go
@@ -76,7 +76,7 @@ func NewPutCommand(clients *shared.ClientFactory) *cobra.Command {
 			}
 
 			// Get the selection from the flag or prompt
-			selection, err := appSelectPromptFunc(ctx, clients, prompts.ShowInstalledAppsOnly)
+			selection, err := appSelectPromptFunc(ctx, clients, prompts.ShowAllEnvironments, prompts.ShowInstalledAppsOnly)
 			if err != nil {
 				return err
 			}

--- a/cmd/datastore/query.go
+++ b/cmd/datastore/query.go
@@ -99,7 +99,7 @@ func NewQueryCommand(clients *shared.ClientFactory) *cobra.Command {
 			}
 
 			// Get the selection from the flag or prompt
-			selection, err := appSelectPromptFunc(ctx, clients, prompts.ShowInstalledAppsOnly)
+			selection, err := appSelectPromptFunc(ctx, clients, prompts.ShowAllEnvironments, prompts.ShowInstalledAppsOnly)
 			if err != nil {
 				return err
 			}

--- a/cmd/datastore/update.go
+++ b/cmd/datastore/update.go
@@ -76,7 +76,7 @@ func NewUpdateCommand(clients *shared.ClientFactory) *cobra.Command {
 			}
 
 			// Get the selection and auth selection from the flag or prompt
-			selection, err := appSelectPromptFunc(ctx, clients, prompts.ShowInstalledAppsOnly)
+			selection, err := appSelectPromptFunc(ctx, clients, prompts.ShowAllEnvironments, prompts.ShowInstalledAppsOnly)
 			if err != nil {
 				return err
 			}

--- a/cmd/env/add.go
+++ b/cmd/env/add.go
@@ -88,7 +88,7 @@ func runEnvAddCommandFunc(clients *shared.ClientFactory, cmd *cobra.Command, arg
 	ctx := cmd.Context()
 
 	// Get the workspace from the flag or prompt
-	selection, err := teamAppSelectPromptFunc(ctx, clients, prompts.ShowHostedOnly, prompts.ShowInstalledAppsOnly)
+	selection, err := appSelectPromptFunc(ctx, clients, prompts.ShowHostedOnly, prompts.ShowInstalledAppsOnly)
 	if err != nil {
 		return err
 	}

--- a/cmd/env/add_test.go
+++ b/cmd/env/add_test.go
@@ -283,8 +283,8 @@ func setupEnvAddCommandMocks(ctx context.Context, cm *shared.ClientsMock, cf *sh
 	_ = cf.AppClient().SaveDeployed(ctx, mockApp)
 
 	appSelectMock := prompts.NewAppSelectMock()
-	teamAppSelectPromptFunc = appSelectMock.TeamAppSelectPrompt
-	appSelectMock.On("TeamAppSelectPrompt").Return(prompts.SelectedApp{Auth: mockAuth, App: mockApp}, nil)
+	appSelectPromptFunc = appSelectMock.AppSelectPrompt
+	appSelectMock.On("AppSelectPrompt", mock.Anything, mock.Anything, prompts.ShowHostedOnly, prompts.ShowInstalledAppsOnly).Return(prompts.SelectedApp{Auth: mockAuth, App: mockApp}, nil)
 
 	cm.Config.Flags.String("value", "", "mock value flag")
 

--- a/cmd/env/env.go
+++ b/cmd/env/env.go
@@ -27,8 +27,8 @@ import (
 var variableNameFlag string
 var variableValueFlag string
 
-// teamAppSelectPromptFunc is a handle to the TeamAppSelectPrompt that can be mocked in tests
-var teamAppSelectPromptFunc = prompts.TeamAppSelectPrompt
+// appSelectPromptFunc is a handle to the AppSelectPrompt that can be mocked in tests
+var appSelectPromptFunc = prompts.AppSelectPrompt
 
 func NewCommand(clients *shared.ClientFactory) *cobra.Command {
 	cmd := &cobra.Command{

--- a/cmd/env/list.go
+++ b/cmd/env/list.go
@@ -78,7 +78,7 @@ func runEnvListCommandFunc(
 ) error {
 	ctx := cmd.Context()
 
-	selection, err := teamAppSelectPromptFunc(
+	selection, err := appSelectPromptFunc(
 		ctx,
 		clients,
 		prompts.ShowHostedOnly,

--- a/cmd/env/list_test.go
+++ b/cmd/env/list_test.go
@@ -146,8 +146,8 @@ func Test_Env_ListCommand(t *testing.T) {
 					nil,
 				)
 				appSelectMock := prompts.NewAppSelectMock()
-				teamAppSelectPromptFunc = appSelectMock.TeamAppSelectPrompt
-				appSelectMock.On("TeamAppSelectPrompt").Return(prompts.SelectedApp{}, nil)
+				appSelectPromptFunc = appSelectMock.AppSelectPrompt
+				appSelectMock.On("AppSelectPrompt", mock.Anything, mock.Anything, prompts.ShowHostedOnly, prompts.ShowInstalledAppsOnly).Return(prompts.SelectedApp{}, nil)
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
 				cm.API.AssertCalled(

--- a/cmd/env/remove.go
+++ b/cmd/env/remove.go
@@ -85,7 +85,7 @@ func runEnvRemoveCommandFunc(clients *shared.ClientFactory, cmd *cobra.Command, 
 	var ctx = cmd.Context()
 
 	// Get the workspace from the flag or prompt
-	selection, err := teamAppSelectPromptFunc(ctx, clients, prompts.ShowHostedOnly, prompts.ShowInstalledAppsOnly)
+	selection, err := appSelectPromptFunc(ctx, clients, prompts.ShowHostedOnly, prompts.ShowInstalledAppsOnly)
 	if err != nil {
 		return err
 	}

--- a/cmd/env/remove_test.go
+++ b/cmd/env/remove_test.go
@@ -153,8 +153,8 @@ func Test_Env_RemoveCommand(t *testing.T) {
 					nil,
 				)
 				appSelectMock := prompts.NewAppSelectMock()
-				teamAppSelectPromptFunc = appSelectMock.TeamAppSelectPrompt
-				appSelectMock.On("TeamAppSelectPrompt").Return(prompts.SelectedApp{}, nil)
+				appSelectPromptFunc = appSelectMock.AppSelectPrompt
+				appSelectMock.On("AppSelectPrompt", mock.Anything, mock.Anything, prompts.ShowHostedOnly, prompts.ShowInstalledAppsOnly).Return(prompts.SelectedApp{}, nil)
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
 				cm.API.AssertCalled(
@@ -212,8 +212,8 @@ func Test_Env_RemoveCommand(t *testing.T) {
 					nil,
 				)
 				appSelectMock := prompts.NewAppSelectMock()
-				teamAppSelectPromptFunc = appSelectMock.TeamAppSelectPrompt
-				appSelectMock.On("TeamAppSelectPrompt").Return(prompts.SelectedApp{}, nil)
+				appSelectPromptFunc = appSelectMock.AppSelectPrompt
+				appSelectMock.On("AppSelectPrompt", mock.Anything, mock.Anything, prompts.ShowHostedOnly, prompts.ShowInstalledAppsOnly).Return(prompts.SelectedApp{}, nil)
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
 				cm.API.AssertCalled(
@@ -246,8 +246,8 @@ func Test_Env_RemoveCommand(t *testing.T) {
 					nil,
 				)
 				appSelectMock := prompts.NewAppSelectMock()
-				teamAppSelectPromptFunc = appSelectMock.TeamAppSelectPrompt
-				appSelectMock.On("TeamAppSelectPrompt").Return(prompts.SelectedApp{}, nil)
+				appSelectPromptFunc = appSelectMock.AppSelectPrompt
+				appSelectMock.On("AppSelectPrompt", mock.Anything, mock.Anything, prompts.ShowHostedOnly, prompts.ShowInstalledAppsOnly).Return(prompts.SelectedApp{}, nil)
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
 				cm.API.AssertCalled(

--- a/cmd/externalauth/add.go
+++ b/cmd/externalauth/add.go
@@ -83,7 +83,7 @@ func runAddCommand(clients *shared.ClientFactory, cmd *cobra.Command) error {
 	// Get the app selection and accompanying auth from the prompt
 	// Note: Only installed apps will be shown in the prompt as installation is required for this command.
 	//       This is consistent with the experience for other commands that require installation.
-	selection, err := appSelectPromptFunc(ctx, clients, prompts.ShowInstalledAppsOnly)
+	selection, err := appSelectPromptFunc(ctx, clients, prompts.ShowAllEnvironments, prompts.ShowInstalledAppsOnly)
 	if err != nil {
 		return err
 	}

--- a/cmd/externalauth/add_secret.go
+++ b/cmd/externalauth/add_secret.go
@@ -86,7 +86,7 @@ func runAddClientSecretCommand(clients *shared.ClientFactory, cmd *cobra.Command
 	ctx := cmd.Context()
 
 	// Get the app selection and accompanying auth from the prompt
-	selection, err := appSelectPromptFunc(ctx, clients, prompts.ShowInstalledAppsOnly)
+	selection, err := appSelectPromptFunc(ctx, clients, prompts.ShowAllEnvironments, prompts.ShowInstalledAppsOnly)
 	if err != nil {
 		return err
 	}

--- a/cmd/externalauth/helpers_test.go
+++ b/cmd/externalauth/helpers_test.go
@@ -17,6 +17,7 @@ package externalauth
 import (
 	"github.com/slackapi/slack-cli/internal/prompts"
 	"github.com/slackapi/slack-cli/internal/shared/types"
+	"github.com/stretchr/testify/mock"
 )
 
 var fakeAppID = "A1234"
@@ -38,7 +39,7 @@ func setupMockAppSelection(selectedApp prompts.SelectedApp) func() {
 	appSelectMock := prompts.NewAppSelectMock()
 	var originalPromptFunc = appSelectPromptFunc
 	appSelectPromptFunc = appSelectMock.AppSelectPrompt
-	appSelectMock.On("AppSelectPrompt").Return(selectedApp, nil)
+	appSelectMock.On("AppSelectPrompt", mock.Anything, mock.Anything, prompts.ShowAllEnvironments, prompts.ShowInstalledAppsOnly).Return(selectedApp, nil)
 	return func() {
 		appSelectPromptFunc = originalPromptFunc
 	}

--- a/cmd/externalauth/remove.go
+++ b/cmd/externalauth/remove.go
@@ -95,7 +95,7 @@ func runRemoveCommand(clients *shared.ClientFactory, cmd *cobra.Command) error {
 	ctx := cmd.Context()
 
 	// Get the app selection and accompanying auth from the prompt
-	selection, err := appSelectPromptFunc(ctx, clients, prompts.ShowInstalledAppsOnly)
+	selection, err := appSelectPromptFunc(ctx, clients, prompts.ShowAllEnvironments, prompts.ShowInstalledAppsOnly)
 	if err != nil {
 		return err
 	}

--- a/cmd/externalauth/select_auth.go
+++ b/cmd/externalauth/select_auth.go
@@ -86,7 +86,7 @@ func runSelectAuthCommand(clients *shared.ClientFactory, cmd *cobra.Command) err
 	ctx := cmd.Context()
 
 	// Get the app selection and accompanying auth from the prompt
-	selection, err := appSelectPromptFunc(ctx, clients, prompts.ShowInstalledAppsOnly)
+	selection, err := appSelectPromptFunc(ctx, clients, prompts.ShowAllEnvironments, prompts.ShowInstalledAppsOnly)
 	if err != nil {
 		return err
 	}

--- a/cmd/function/access.go
+++ b/cmd/function/access.go
@@ -91,7 +91,7 @@ func runDistributeCommand(cmd *cobra.Command, clients *shared.ClientFactory) err
 	ctx := cmd.Context()
 
 	// Get the app selection and accompanying auth from the prompt
-	selectedApp, err := appSelectPromptFunc(ctx, clients, prompts.ShowInstalledAppsOnly)
+	selectedApp, err := appSelectPromptFunc(ctx, clients, prompts.ShowAllEnvironments, prompts.ShowInstalledAppsOnly)
 	if err != nil {
 		return err
 	}

--- a/cmd/function/helpers_test.go
+++ b/cmd/function/helpers_test.go
@@ -17,6 +17,7 @@ package function
 import (
 	"github.com/slackapi/slack-cli/internal/prompts"
 	"github.com/slackapi/slack-cli/internal/shared/types"
+	"github.com/stretchr/testify/mock"
 )
 
 var (
@@ -37,7 +38,7 @@ func setupMockAppSelection(selectedApp prompts.SelectedApp) func() {
 	appSelectMock := prompts.NewAppSelectMock()
 	var originalPromptFunc = appSelectPromptFunc
 	appSelectPromptFunc = appSelectMock.AppSelectPrompt
-	appSelectMock.On("AppSelectPrompt").Return(selectedApp, nil)
+	appSelectMock.On("AppSelectPrompt", mock.Anything, mock.Anything, prompts.ShowAllEnvironments, prompts.ShowInstalledAppsOnly).Return(selectedApp, nil)
 	return func() {
 		appSelectPromptFunc = originalPromptFunc
 	}

--- a/cmd/manifest/info.go
+++ b/cmd/manifest/info.go
@@ -129,7 +129,7 @@ func getManifestInfoProject(ctx context.Context, clients *shared.ClientFactory) 
 
 // getManifestInfoRemote gathers app manifest information from app settings
 func getManifestInfoRemote(ctx context.Context, clients *shared.ClientFactory) (types.AppManifest, error) {
-	selection, err := appSelectPromptFunc(ctx, clients, prompts.ShowInstalledAndUninstalledApps)
+	selection, err := appSelectPromptFunc(ctx, clients, prompts.ShowAllEnvironments, prompts.ShowInstalledAndUninstalledApps)
 	if err != nil {
 		return types.AppManifest{}, err
 	}

--- a/cmd/manifest/info_test.go
+++ b/cmd/manifest/info_test.go
@@ -82,7 +82,7 @@ func TestInfoCommand(t *testing.T) {
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
 				appSelectMock := prompts.NewAppSelectMock()
 				appSelectPromptFunc = appSelectMock.AppSelectPrompt
-				appSelectMock.On("AppSelectPrompt").Return(
+				appSelectMock.On("AppSelectPrompt", mock.Anything, mock.Anything, prompts.ShowAllEnvironments, prompts.ShowInstalledAndUninstalledApps).Return(
 					prompts.SelectedApp{
 						App:  types.App{AppID: "A001"},
 						Auth: types.SlackAuth{Token: "xapp"}}, nil)
@@ -112,7 +112,7 @@ func TestInfoCommand(t *testing.T) {
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
 				appSelectMock := prompts.NewAppSelectMock()
 				appSelectPromptFunc = appSelectMock.AppSelectPrompt
-				appSelectMock.On("AppSelectPrompt").Return(
+				appSelectMock.On("AppSelectPrompt", mock.Anything, mock.Anything, prompts.ShowAllEnvironments, prompts.ShowInstalledAndUninstalledApps).Return(
 					prompts.SelectedApp{
 						App:  types.App{AppID: "A004"},
 						Auth: types.SlackAuth{Token: "xapp"}}, nil)
@@ -163,7 +163,7 @@ func TestInfoCommand(t *testing.T) {
 				cf.AppClient().Manifest = manifestMock
 				appSelectMock := prompts.NewAppSelectMock()
 				appSelectPromptFunc = appSelectMock.AppSelectPrompt
-				appSelectMock.On("AppSelectPrompt").Return(prompts.SelectedApp{
+				appSelectMock.On("AppSelectPrompt", mock.Anything, mock.Anything, prompts.ShowAllEnvironments, prompts.ShowInstalledAndUninstalledApps).Return(prompts.SelectedApp{
 					App:  types.App{AppID: "A005"},
 					Auth: types.SlackAuth{Token: "xapp-example-005"},
 				}, nil)

--- a/cmd/manifest/manifest_test.go
+++ b/cmd/manifest/manifest_test.go
@@ -38,7 +38,7 @@ func TestManifestCommand(t *testing.T) {
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
 				appSelectMock := prompts.NewAppSelectMock()
 				appSelectPromptFunc = appSelectMock.AppSelectPrompt
-				appSelectMock.On("AppSelectPrompt").Return(
+				appSelectMock.On("AppSelectPrompt", mock.Anything, mock.Anything, prompts.ShowAllEnvironments, prompts.ShowInstalledAndUninstalledApps).Return(
 					prompts.SelectedApp{
 						App:  types.App{AppID: "A001"},
 						Auth: types.SlackAuth{Token: "xapp"},

--- a/cmd/manifest/validate.go
+++ b/cmd/manifest/validate.go
@@ -62,7 +62,7 @@ func NewValidateCommand(clients *shared.ClientFactory) *cobra.Command {
 			// Get the app selection and accompanying auth of an installed app or gather
 			// some other authentication token
 			var token string
-			selection, err := appSelectPromptFunc(ctx, clients, prompts.ShowInstalledAppsOnly)
+			selection, err := appSelectPromptFunc(ctx, clients, prompts.ShowAllEnvironments, prompts.ShowInstalledAppsOnly)
 			if err != nil {
 				if slackerror.ToSlackError(err).Code != slackerror.ErrInstallationRequired {
 					return err

--- a/cmd/manifest/validate_test.go
+++ b/cmd/manifest/validate_test.go
@@ -58,7 +58,7 @@ func TestManifestValidateCommand(t *testing.T) {
 
 	appSelectMock := prompts.NewAppSelectMock()
 	appSelectPromptFunc = appSelectMock.AppSelectPrompt
-	appSelectMock.On("AppSelectPrompt").Return(prompts.SelectedApp{}, nil)
+	appSelectMock.On("AppSelectPrompt", mock.Anything, mock.Anything, prompts.ShowAllEnvironments, prompts.ShowInstalledAppsOnly).Return(prompts.SelectedApp{}, nil)
 
 	manifestValidatePkgMock := new(ManifestValidatePkgMock)
 	manifestValidateFunc = manifestValidatePkgMock.ManifestValidate
@@ -89,7 +89,7 @@ func TestManifestValidateCommand_HandleMissingAppInstallError_ZeroUserAuth(t *te
 	// Mock a failed AppSelectPrompt
 	appSelectMock := prompts.NewAppSelectMock()
 	appSelectPromptFunc = appSelectMock.AppSelectPrompt
-	appSelectMock.On("AppSelectPrompt").Return(prompts.SelectedApp{}, slackerror.New(slackerror.ErrInstallationRequired))
+	appSelectMock.On("AppSelectPrompt", mock.Anything, mock.Anything, prompts.ShowAllEnvironments, prompts.ShowInstalledAppsOnly).Return(prompts.SelectedApp{}, slackerror.New(slackerror.ErrInstallationRequired))
 
 	// Mock zero user auths
 	mockAuths := []types.SlackAuth{}
@@ -133,7 +133,7 @@ func TestManifestValidateCommand_HandleMissingAppInstallError_OneUserAuth(t *tes
 	// Mock a failed AppSelectPrompt
 	appSelectMock := prompts.NewAppSelectMock()
 	appSelectPromptFunc = appSelectMock.AppSelectPrompt
-	appSelectMock.On("AppSelectPrompt").Return(prompts.SelectedApp{}, slackerror.New(slackerror.ErrInstallationRequired))
+	appSelectMock.On("AppSelectPrompt", mock.Anything, mock.Anything, prompts.ShowAllEnvironments, prompts.ShowInstalledAppsOnly).Return(prompts.SelectedApp{}, slackerror.New(slackerror.ErrInstallationRequired))
 
 	// Mock the manifest validate package
 	manifestValidatePkgMock := new(ManifestValidatePkgMock)
@@ -163,7 +163,7 @@ func TestManifestValidateCommand_HandleMissingAppInstallError_MoreThanOneUserAut
 	// Mock a failed AppSelectPrompt
 	appSelectMock := prompts.NewAppSelectMock()
 	appSelectPromptFunc = appSelectMock.AppSelectPrompt
-	appSelectMock.On("AppSelectPrompt").Return(prompts.SelectedApp{}, slackerror.New(slackerror.ErrInstallationRequired))
+	appSelectMock.On("AppSelectPrompt", mock.Anything, mock.Anything, prompts.ShowAllEnvironments, prompts.ShowInstalledAppsOnly).Return(prompts.SelectedApp{}, slackerror.New(slackerror.ErrInstallationRequired))
 	clientsMock.IO.On("SelectPrompt", mock.Anything, prompts.SelectTeamPrompt, mock.Anything, iostreams.MatchPromptConfig(iostreams.SelectPromptConfig{
 		Flag: clients.Config.Flags.Lookup("team"),
 	})).Return(iostreams.SelectPromptResponse{
@@ -227,7 +227,7 @@ func TestManifestValidateCommand_HandleOtherErrors(t *testing.T) {
 	appSelectMock := prompts.NewAppSelectMock()
 	appSelectPromptFunc = appSelectMock.AppSelectPrompt
 	errMsg := "Unrelated error"
-	appSelectMock.On("AppSelectPrompt").Return(prompts.SelectedApp{}, slackerror.New(errMsg))
+	appSelectMock.On("AppSelectPrompt", mock.Anything, mock.Anything, prompts.ShowAllEnvironments, prompts.ShowInstalledAppsOnly).Return(prompts.SelectedApp{}, slackerror.New(errMsg))
 
 	err := cmd.ExecuteContext(ctx)
 	require.ErrorContains(t, err, errMsg)

--- a/cmd/openformresponse/export.go
+++ b/cmd/openformresponse/export.go
@@ -68,7 +68,7 @@ func runExportCommand(clients *shared.ClientFactory, cmd *cobra.Command) error {
 	var span, _ = opentracing.StartSpanFromContext(ctx, "cmd.open-form-response.export")
 	defer span.Finish()
 
-	selection, err := exportAppSelectPromptFunc(ctx, clients, prompts.ShowInstalledAppsOnly)
+	selection, err := exportAppSelectPromptFunc(ctx, clients, prompts.ShowAllEnvironments, prompts.ShowInstalledAppsOnly)
 	if err != nil {
 		return err
 	}

--- a/cmd/openformresponse/export_test.go
+++ b/cmd/openformresponse/export_test.go
@@ -83,7 +83,7 @@ func setupMockCreateAppSelection(selectedApp prompts.SelectedApp) func() {
 	appSelectMock := prompts.NewAppSelectMock()
 	var originalPromptFunc = exportAppSelectPromptFunc
 	exportAppSelectPromptFunc = appSelectMock.AppSelectPrompt
-	appSelectMock.On("AppSelectPrompt").Return(selectedApp, nil)
+	appSelectMock.On("AppSelectPrompt", mock.Anything, mock.Anything, prompts.ShowAllEnvironments, prompts.ShowInstalledAppsOnly).Return(selectedApp, nil)
 	return func() {
 		exportAppSelectPromptFunc = originalPromptFunc
 	}

--- a/cmd/platform/activity.go
+++ b/cmd/platform/activity.go
@@ -105,7 +105,7 @@ func runActivityCommand(clients *shared.ClientFactory, cmd *cobra.Command, args 
 	}
 
 	// Prompt for an installed app
-	selection, err := appSelectPromptFunc(ctx, clients, prompts.ShowInstalledAppsOnly)
+	selection, err := appSelectPromptFunc(ctx, clients, prompts.ShowAllEnvironments, prompts.ShowInstalledAppsOnly)
 	if err != nil {
 		return err
 	}

--- a/cmd/platform/activity_test.go
+++ b/cmd/platform/activity_test.go
@@ -65,7 +65,7 @@ func TestActivity_Command(t *testing.T) {
 
 	appSelectMock := prompts.NewAppSelectMock()
 	appSelectPromptFunc = appSelectMock.AppSelectPrompt
-	appSelectMock.On("AppSelectPrompt").Return(prompts.SelectedApp{}, nil)
+	appSelectMock.On("AppSelectPrompt", mock.Anything, mock.Anything, prompts.ShowAllEnvironments, prompts.ShowInstalledAppsOnly).Return(prompts.SelectedApp{}, nil)
 
 	err := cmd.ExecuteContext(ctx)
 	if err != nil {

--- a/cmd/platform/deploy.go
+++ b/cmd/platform/deploy.go
@@ -41,7 +41,6 @@ import (
 // Create handle to Deploy function for testing
 // TODO - Stopgap until we learn the correct way to structure our code for testing.
 var deployFunc = platform.Deploy
-var teamAppSelectPromptFunc = prompts.TeamAppSelectPrompt
 
 // TODO - Same as above, but probably even worse
 var runAddCommandFunc = app.RunAddCommand
@@ -79,7 +78,7 @@ func NewDeployCommand(clients *shared.ClientFactory) *cobra.Command {
 				deploySpinner.Stop()
 			}()
 
-			selection, err := teamAppSelectPromptFunc(ctx, clients, prompts.ShowHostedOnly, prompts.ShowAllApps)
+			selection, err := appSelectPromptFunc(ctx, clients, prompts.ShowHostedOnly, prompts.ShowAllApps)
 			if err != nil {
 				return err
 			}

--- a/cmd/platform/deploy_test.go
+++ b/cmd/platform/deploy_test.go
@@ -84,8 +84,8 @@ func TestDeployCommand(t *testing.T) {
 	}, nil)
 
 	appSelectMock := prompts.NewAppSelectMock()
-	appSelectMock.On("TeamAppSelectPrompt").Return(prompts.SelectedApp{}, nil)
-	teamAppSelectPromptFunc = appSelectMock.TeamAppSelectPrompt
+	appSelectMock.On("AppSelectPrompt", mock.Anything, mock.Anything, prompts.ShowHostedOnly, prompts.ShowAllApps).Return(prompts.SelectedApp{}, nil)
+	appSelectPromptFunc = appSelectMock.AppSelectPrompt
 
 	manifestMock := &app.ManifestMockObject{}
 	manifestMock.On("GetManifestLocal", mock.Anything, mock.Anything, mock.Anything).Return(types.SlackYaml{

--- a/cmd/platform/run.go
+++ b/cmd/platform/run.go
@@ -45,7 +45,7 @@ var runFlags runCmdFlags
 // TODO - Stopgap until we learn the correct way to structure our code for testing.
 var runFunc = platform.Run
 var runRunCommandFunc = RunRunCommand
-var runTeamAppSelectPromptFunc = prompts.TeamAppSelectPrompt
+var runAppSelectPromptFunc = prompts.AppSelectPrompt
 
 func NewRunCommand(clients *shared.ClientFactory) *cobra.Command {
 	cmd := &cobra.Command{
@@ -99,7 +99,7 @@ func RunRunCommand(clients *shared.ClientFactory, cmd *cobra.Command, args []str
 	ctx := cmd.Context()
 
 	// Get the workspace from the flag or prompt
-	selection, err := runTeamAppSelectPromptFunc(ctx, clients, prompts.ShowLocalOnly, prompts.ShowAllApps)
+	selection, err := runAppSelectPromptFunc(ctx, clients, prompts.ShowLocalOnly, prompts.ShowAllApps)
 	if err != nil {
 		switch slackerror.ToSlackError(err).Code {
 		case slackerror.ErrDeployedAppNotSupported:

--- a/cmd/platform/run_test.go
+++ b/cmd/platform/run_test.go
@@ -217,8 +217,8 @@ func TestRunCommand_Flags(t *testing.T) {
 			})
 
 			appSelectMock := prompts.NewAppSelectMock()
-			appSelectMock.On("TeamAppSelectPrompt").Return(tt.selectedAppAuth, tt.selectedAppErr)
-			runTeamAppSelectPromptFunc = appSelectMock.TeamAppSelectPrompt
+			appSelectMock.On("AppSelectPrompt", mock.Anything, mock.Anything, prompts.ShowLocalOnly, prompts.ShowAllApps).Return(tt.selectedAppAuth, tt.selectedAppErr)
+			runAppSelectPromptFunc = appSelectMock.AppSelectPrompt
 
 			runPkgMock := new(RunPkgMock)
 			runFunc = runPkgMock.Run

--- a/cmd/triggers/access.go
+++ b/cmd/triggers/access.go
@@ -102,7 +102,7 @@ func runAccessCommand(cmd *cobra.Command, clients *shared.ClientFactory) error {
 	defer span.Finish()
 
 	// Get the app selection and accompanying auth from the flag or prompt
-	selection, err := accessAppSelectPromptFunc(ctx, clients, prompts.ShowInstalledAppsOnly)
+	selection, err := accessAppSelectPromptFunc(ctx, clients, prompts.ShowAllEnvironments, prompts.ShowInstalledAppsOnly)
 	if err != nil {
 		return err
 	}

--- a/cmd/triggers/access_test.go
+++ b/cmd/triggers/access_test.go
@@ -601,7 +601,7 @@ func setupMockAccessAppSelection(selectedApp prompts.SelectedApp) func() {
 	appSelectMock := prompts.NewAppSelectMock()
 	var originalPromptFunc = accessAppSelectPromptFunc
 	accessAppSelectPromptFunc = appSelectMock.AppSelectPrompt
-	appSelectMock.On("AppSelectPrompt").Return(selectedApp, nil)
+	appSelectMock.On("AppSelectPrompt", mock.Anything, mock.Anything, prompts.ShowAllEnvironments, prompts.ShowInstalledAppsOnly).Return(selectedApp, nil)
 	return func() {
 		accessAppSelectPromptFunc = originalPromptFunc
 	}

--- a/cmd/triggers/create.go
+++ b/cmd/triggers/create.go
@@ -94,7 +94,7 @@ func runCreateCommand(clients *shared.ClientFactory, cmd *cobra.Command) error {
 	defer span.Finish()
 
 	// Get the app selection and accompanying auth from the flag or prompt
-	selection, err := createAppSelectPromptFunc(ctx, clients, prompts.ShowInstalledAndNewApps)
+	selection, err := createAppSelectPromptFunc(ctx, clients, prompts.ShowAllEnvironments, prompts.ShowInstalledAndNewApps)
 	if err != nil {
 		return err
 	}

--- a/cmd/triggers/create_test.go
+++ b/cmd/triggers/create_test.go
@@ -468,7 +468,7 @@ func TestTriggersCreateCommand_AppSelection(t *testing.T) {
 				appSelectMock := prompts.NewAppSelectMock()
 				var originalPromptFunc = createAppSelectPromptFunc
 				createAppSelectPromptFunc = appSelectMock.AppSelectPrompt
-				appSelectMock.On("AppSelectPrompt").Return(prompts.SelectedApp{}, errors.New("selection error"))
+				appSelectMock.On("AppSelectPrompt", mock.Anything, mock.Anything, prompts.ShowAllEnvironments, prompts.ShowInstalledAndNewApps).Return(prompts.SelectedApp{}, errors.New("selection error"))
 				appSelectTeardown = func() {
 					createAppSelectPromptFunc = originalPromptFunc
 				}
@@ -673,7 +673,7 @@ func setupMockCreateAppSelection(selectedApp prompts.SelectedApp) func() {
 	appSelectMock := prompts.NewAppSelectMock()
 	var originalPromptFunc = createAppSelectPromptFunc
 	createAppSelectPromptFunc = appSelectMock.AppSelectPrompt
-	appSelectMock.On("AppSelectPrompt").Return(selectedApp, nil)
+	appSelectMock.On("AppSelectPrompt", mock.Anything, mock.Anything, prompts.ShowAllEnvironments, prompts.ShowInstalledAndNewApps).Return(selectedApp, nil)
 	return func() {
 		createAppSelectPromptFunc = originalPromptFunc
 	}

--- a/cmd/triggers/delete.go
+++ b/cmd/triggers/delete.go
@@ -66,7 +66,7 @@ func runDeleteCommand(clients *shared.ClientFactory, cmd *cobra.Command) error {
 	defer span.Finish()
 
 	// Get the app from the flag or prompt
-	selection, err := deleteAppSelectPromptFunc(ctx, clients, prompts.ShowInstalledAppsOnly)
+	selection, err := deleteAppSelectPromptFunc(ctx, clients, prompts.ShowAllEnvironments, prompts.ShowInstalledAppsOnly)
 	if err != nil {
 		return err
 	}

--- a/cmd/triggers/delete_test.go
+++ b/cmd/triggers/delete_test.go
@@ -117,7 +117,7 @@ func TestTriggersDeleteCommand_AppSelection(t *testing.T) {
 				appSelectTeardown = setupMockDeleteAppSelection(installedProdApp)
 				appSelectMock := prompts.NewAppSelectMock()
 				deleteAppSelectPromptFunc = appSelectMock.AppSelectPrompt
-				appSelectMock.On("AppSelectPrompt").Return(prompts.SelectedApp{}, errors.New("selection error"))
+				appSelectMock.On("AppSelectPrompt", mock.Anything, mock.Anything, prompts.ShowAllEnvironments, prompts.ShowInstalledAppsOnly).Return(prompts.SelectedApp{}, errors.New("selection error"))
 			},
 			Teardown: func() {
 				appSelectTeardown()
@@ -166,7 +166,7 @@ func setupMockDeleteAppSelection(selectedApp prompts.SelectedApp) func() {
 	appSelectMock := prompts.NewAppSelectMock()
 	var originalPromptFunc = deleteAppSelectPromptFunc
 	deleteAppSelectPromptFunc = appSelectMock.AppSelectPrompt
-	appSelectMock.On("AppSelectPrompt").Return(selectedApp, nil)
+	appSelectMock.On("AppSelectPrompt", mock.Anything, mock.Anything, prompts.ShowAllEnvironments, prompts.ShowInstalledAppsOnly).Return(selectedApp, nil)
 	return func() {
 		deleteAppSelectPromptFunc = originalPromptFunc
 	}

--- a/cmd/triggers/info.go
+++ b/cmd/triggers/info.go
@@ -65,7 +65,7 @@ func runInfoCommand(cmd *cobra.Command, clients *shared.ClientFactory) error {
 	defer span.Finish()
 
 	// Get the app from the flag or prompt
-	selection, err := infoAppSelectPromptFunc(ctx, clients, prompts.ShowInstalledAppsOnly)
+	selection, err := infoAppSelectPromptFunc(ctx, clients, prompts.ShowAllEnvironments, prompts.ShowInstalledAppsOnly)
 	if err != nil {
 		return err
 	}

--- a/cmd/triggers/info_test.go
+++ b/cmd/triggers/info_test.go
@@ -181,7 +181,7 @@ func TestTriggersInfoCommand_AppSelection(t *testing.T) {
 				appSelectMock := prompts.NewAppSelectMock()
 				var originalPromptFunc = createAppSelectPromptFunc
 				createAppSelectPromptFunc = appSelectMock.AppSelectPrompt
-				appSelectMock.On("AppSelectPrompt").Return(prompts.SelectedApp{}, errors.New("error"))
+				appSelectMock.On("AppSelectPrompt", mock.Anything, mock.Anything, prompts.ShowAllEnvironments, prompts.ShowInstalledAppsOnly).Return(prompts.SelectedApp{}, errors.New("error"))
 				appSelectTeardown = func() {
 					createAppSelectPromptFunc = originalPromptFunc
 				}
@@ -233,7 +233,7 @@ func setupMockInfoAppSelection(selectedApp prompts.SelectedApp) func() {
 	appSelectMock := prompts.NewAppSelectMock()
 	var originalPromptFunc = infoAppSelectPromptFunc
 	infoAppSelectPromptFunc = appSelectMock.AppSelectPrompt
-	appSelectMock.On("AppSelectPrompt").Return(selectedApp, nil)
+	appSelectMock.On("AppSelectPrompt", mock.Anything, mock.Anything, prompts.ShowAllEnvironments, prompts.ShowInstalledAppsOnly).Return(selectedApp, nil)
 	return func() {
 		infoAppSelectPromptFunc = originalPromptFunc
 	}

--- a/cmd/triggers/list.go
+++ b/cmd/triggers/list.go
@@ -76,7 +76,7 @@ func runListCommand(cmd *cobra.Command, clients *shared.ClientFactory) error {
 	defer span.Finish()
 
 	// Get the app selection and accompanying auth from the flag or prompt
-	selection, err := listAppSelectPromptFunc(ctx, clients, prompts.ShowInstalledAppsOnly)
+	selection, err := listAppSelectPromptFunc(ctx, clients, prompts.ShowAllEnvironments, prompts.ShowInstalledAppsOnly)
 	if err != nil {
 		return err
 	}

--- a/cmd/triggers/list_test.go
+++ b/cmd/triggers/list_test.go
@@ -183,7 +183,7 @@ func setupMockListAppSelection(selectedApp prompts.SelectedApp) func() {
 	appSelectMock := prompts.NewAppSelectMock()
 	var originalPromptFunc = listAppSelectPromptFunc
 	listAppSelectPromptFunc = appSelectMock.AppSelectPrompt
-	appSelectMock.On("AppSelectPrompt").Return(selectedApp, nil)
+	appSelectMock.On("AppSelectPrompt", mock.Anything, mock.Anything, prompts.ShowAllEnvironments, prompts.ShowInstalledAppsOnly).Return(selectedApp, nil)
 	return func() {
 		listAppSelectPromptFunc = originalPromptFunc
 	}

--- a/cmd/triggers/update.go
+++ b/cmd/triggers/update.go
@@ -78,7 +78,7 @@ func runUpdateCommand(clients *shared.ClientFactory, cmd *cobra.Command) error {
 	defer span.Finish()
 
 	// Get the app selection and accompanying auth from the flag or prompt
-	selection, err := updateAppSelectPromptFunc(ctx, clients, prompts.ShowInstalledAppsOnly)
+	selection, err := updateAppSelectPromptFunc(ctx, clients, prompts.ShowAllEnvironments, prompts.ShowInstalledAppsOnly)
 	if err != nil {
 		return err
 	}

--- a/cmd/triggers/update_test.go
+++ b/cmd/triggers/update_test.go
@@ -509,7 +509,7 @@ func setupMockUpdateAppSelection(selectedApp prompts.SelectedApp) func() {
 	appSelectMock := prompts.NewAppSelectMock()
 	var originalPromptFunc = updateAppSelectPromptFunc
 	updateAppSelectPromptFunc = appSelectMock.AppSelectPrompt
-	appSelectMock.On("AppSelectPrompt").Return(selectedApp, nil)
+	appSelectMock.On("AppSelectPrompt", mock.Anything, mock.Anything, prompts.ShowAllEnvironments, prompts.ShowInstalledAppsOnly).Return(selectedApp, nil)
 	return func() {
 		updateAppSelectPromptFunc = originalPromptFunc
 	}

--- a/internal/app/app_client.go
+++ b/internal/app/app_client.go
@@ -458,7 +458,7 @@ func (ac *AppClient) migrateToAppByTeamIDLocal() error {
 // as team domain is not guaranteed to be unique
 func (ac *AppClient) getDeployedAppTeamDomain(ctx context.Context) string {
 	// Find the app team using the priority:
-	// 1. Team Flag (set by the user or prompts.TeamAppSelectPrompt)
+	// 1. Team Flag (set by the user)
 	if ac.config.TeamFlag != "" {
 		return ac.config.TeamFlag
 	}

--- a/internal/prompts/app_select_mock.go
+++ b/internal/prompts/app_select_mock.go
@@ -31,14 +31,8 @@ func NewAppSelectMock() *AppSelectMock {
 	return &AppSelectMock{}
 }
 
-// TeamAppSelectPrompt mocks the workspace selection prompt
-func (m *AppSelectMock) TeamAppSelectPrompt(ctx context.Context, clients *shared.ClientFactory, runEnv AppEnvironmentType, status AppInstallStatus) (SelectedApp, error) {
-	args := m.Called()
-	return args.Get(0).(SelectedApp), args.Error(1)
-}
-
 // AppSelectPrompt mocks the app selection prompt
-func (m *AppSelectMock) AppSelectPrompt(ctx context.Context, clients *shared.ClientFactory, status AppInstallStatus) (SelectedApp, error) {
-	args := m.Called()
+func (m *AppSelectMock) AppSelectPrompt(ctx context.Context, clients *shared.ClientFactory, env AppEnvironmentType, status AppInstallStatus) (SelectedApp, error) {
+	args := m.Called(ctx, clients, env, status)
 	return args.Get(0).(SelectedApp), args.Error(1)
 }


### PR DESCRIPTION
### Summary

This PR combines the `AppSelectPrompt` and `TeamSelectPrompt` into the `AppSelectPrompt` following #158.

Also included are improvements to the app selector mocks to expect a particular app environment and installation status 👾 

No change to functionalities!

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).