### PR TITLE
Mwbrooks setup update

### DIFF
--- a/.github/MAINTAINERS_GUIDE.md
+++ b/.github/MAINTAINERS_GUIDE.md
@@ -118,7 +118,12 @@ command not found: golangci-lint
 ```
 
 You may need to update your `$PATH` environment variable with `$GOPATH/bin`:
-1. Open your terminal's configuration file (e.g. `~/.zshrc`)
+1. Open your terminal's configuration file (e.g. `~/.zshrc`):
+
+    ```bash
+    $ vim ~/.zshrc
+    ```
+    
 2. Add the following:
 
     ```bash

--- a/.github/MAINTAINERS_GUIDE.md
+++ b/.github/MAINTAINERS_GUIDE.md
@@ -105,6 +105,33 @@ Confirm the installation worked right with:
 golangci-lint --version
 ```
 
+<details>
+<summary>Troubleshooting</summary>
+
+#### Error: command not found: golangci-lint
+
+If you receive the following error:
+
+```bash
+$ golangci-lint --version
+command not found: golangci-lint
+```
+
+You may need to update your `$PATH` environment variable with `$GOPATH/bin`:
+1. Open your terminal's configuration file (e.g. `~/.zshrc`)
+2. Add the following:
+
+    ```bash
+    export PATH=$PATH:$(go env GOPATH)/bin
+    ```
+3. Open a new terminal session (tab) or source your configuration file (`source ~/.zshrc`).
+4. Run the following command:
+
+    ```bash
+    $ golangci-lint --version
+    ```
+</details>
+
 #### VSCode
 
 Settings are already defined in this project for using the VSCode editor with


### PR DESCRIPTION
### Summary

This pull request updates the `MAINTAINERS_GUIDE.md` with a troubleshooting step to add the `$GOPATH/bin` to your `$PATH`.

→ [Preview MAINTAINERS_GUDIE.md](https://github.com/slackapi/slack-cli/blob/ee0122fa8f9797a7f483409a0b8f12746a8de2ab/.github/MAINTAINERS_GUIDE.md#error-command-not-found-golangci-lint)

Honestly, I'm not sure what the best practice is here. The [golangci-lint Installation Guide](https://golangci-lint.run/welcome/install/#binaries) asks you to run a curl command that installs `golangci-lint` to your `$(go env GOPATH)/bin`. However, the default installation of Golang using the `.pkg` doesn't configure this path. I imagine this varies depending how Golang was installed, so I've decided to add this as a troubleshooting step.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).