### PR TITLE
build: generate windows dev and latest builds with uploaded releases

### DIFF
--- a/scripts/archive-test.sh
+++ b/scripts/archive-test.sh
@@ -64,6 +64,8 @@ main() {
 
     echo "Checking Windows archives"
     check_exe "$DIST_DIR/slack_cli_${VERSION}_windows_64-bit.zip"
+    check_exe "$DIST_DIR/slack_cli_dev_windows_64-bit.zip"
+    check_exe "$DIST_DIR/slack_cli_latest_windows_64-bit.zip"
 
     echo "Success! Archives exist!"
 }

--- a/scripts/archive.sh
+++ b/scripts/archive.sh
@@ -92,6 +92,20 @@ main() {
     echo "-> Creating Linux production tar.gz file"
     cp "$linux_targz_file_path_version" "$linux_targz_file_path_latest"
     ls -l "$DIST_DIR"/*latest_linux*
+
+    echo "Creating Windows archives"
+
+    windows_zip_file_path_version="$DIST_DIR/slack_cli_${VERSION}_windows_64-bit.zip"
+    windows_zip_file_path_dev="$DIST_DIR/slack_cli_dev_windows_64-bit.zip"
+    windows_zip_file_path_latest="$DIST_DIR/slack_cli_latest_windows_64-bit.zip"
+
+    echo "-> Creating Windows development zip file"
+    cp "$windows_zip_file_path_version" "$windows_zip_file_path_dev"
+    ls -l "$DIST_DIR"/*dev_windows*
+
+    echo "-> Creating Windows production zip file"
+    cp "$windows_zip_file_path_version" "$windows_zip_file_path_latest"
+    ls -l "$DIST_DIR"/*latest_windows*
 }
 
 # Repackage tarballs with the signed zip


### PR DESCRIPTION
> **Changelog**
>
> We added a download for the `latest` version of the Slack CLI for Windows:
>
> - https://downloads.slack-edge.com/slack-cli/slack_cli_latest_windows_64-bit.zip
>
> Manual installations for the latest are now supported at the following links:
>
> - https://downloads.slack-edge.com/slack-cli/slack_cli_latest_linux_64-bit.tar.gz
> - https://downloads.slack-edge.com/slack-cli/slack_cli_latest_macOS_arm64.tar.gz
> - https://downloads.slack-edge.com/slack-cli/slack_cli_latest_macOS_amd64.tar.gz
> - https://downloads.slack-edge.com/slack-cli/slack_cli_latest_macOS_64-bit.tar.gz
> - https://downloads.slack-edge.com/slack-cli/slack_cli_latest_windows_64-bit.zip

### Summary

This PR adds a `dev` and `latest` build for Windows to uploaded releases both on GitHub and for manual installation.

We might now recommend using this link in unversioned installation steps! 📚

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).