### PR TITLE
fix: hide version checks at the end of windows install script

### DIFF
--- a/scripts/install-windows-dev.ps1
+++ b/scripts/install-windows-dev.ps1
@@ -326,11 +326,11 @@ function terms_of_service {
     [Parameter(HelpMessage = "Alias of Slack CLI")]
     [string]$Alias
   )
-  $confirmed_alias = check_slack_binary_exist $Alias $Version $false
-  if (Get-Command $confirmed_alias) {
-    Write-Host "`nUse of the Slack CLI should comply with the Slack API Terms of Service:"
-    Write-Host "   https://slack.com/terms-of-service/api"
-  }
+  # $confirmed_alias = check_slack_binary_exist $Alias $Version $false
+  # if (Get-Command $confirmed_alias) {
+  Write-Host "`nUse of the Slack CLI should comply with the Slack API Terms of Service:"
+  Write-Host "   https://slack.com/terms-of-service/api"
+  # }
 }
 
 function next_step_message {
@@ -368,6 +368,6 @@ Write-Host "`nAdding developer tooling for an enhanced experience..."
 install_git $SkipGit
 install_deno_vscode_extension $SkipDeno
 Write-Host "Sweet! You're all set to start developing!"
-feedback_message $Alias
+# feedback_message $Alias
 terms_of_service $Alias
-next_step_message $Alias
+# next_step_message $Alias


### PR DESCRIPTION
### Summary

This PR hides the `check_slack_binary_exist` checks at the end of the Windows installation script in a debugging attempt of multiple processes in CI :bug:

### Reviewers

The following commands can be used to test these changes! 🔍 

```txt
irm https://downloads.slack-edge.com/slack-cli/install-windows-dev.ps1 -outfile 'install-windows-dev.ps1'
.\install-windows-dev.ps1 -Version 3.5.2
```

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).