### PR TITLE
docs: update tools.slack.dev refs to docs.slack.dev/tools

### DIFF
--- a/.github/MAINTAINERS_GUIDE.md
+++ b/.github/MAINTAINERS_GUIDE.md
@@ -123,7 +123,7 @@ You may need to update your `$PATH` environment variable with `$GOPATH/bin`:
     ```bash
     $ vim ~/.zshrc
     ```
-    
+
 2. Add the following:
 
     ```bash
@@ -875,7 +875,7 @@ Steps to merge a pull request:
 When in doubt, find the other maintainers and ask.
 
 [circleci]: ../.circleci/config.yml
-[commands]: https://tools.slack.dev/slack-cli/reference/commands/slack
+[commands]: https://docs.slack.dev/tools/slack-cli/reference/commands/slack/
 [commit]: https://www.conventionalcommits.org/en/v1.0.0/
 [contributing]: ./CONTRIBUTING.md
 [dev-release]: https://github.com/slackapi/slack-cli/releases/tag/dev-build

--- a/.github/cli-sdk-specification.md
+++ b/.github/cli-sdk-specification.md
@@ -50,7 +50,7 @@ Some hooks may return data as part of their functionality. The CLI will use the 
 
 ### ↪️ Discover hook scripts and default configuration with `get-hooks`
 
-In order for the CLI to reliably discover the hooks for the [Deno SDK](https://github.com/slackapi/deno-slack-sdk), [Bolt Frameworks](https://tools.slack.dev), and future community-driven SDKs, the CLI employs a service-discovery-like approach to querying the SDK for what functionality it supports.
+In order for the CLI to reliably discover the hooks for the [Deno SDK](https://github.com/slackapi/deno-slack-sdk), [Bolt Frameworks](https://docs.slack.dev/tools/), and future community-driven SDKs, the CLI employs a service-discovery-like approach to querying the SDK for what functionality it supports.
 
 A project includes a `hooks.json` file in its `.slack` directory which by default contains a single hook (`get-hooks`). The SDK is responsible for implementing this hook and returning to the CLI a JSON object with all hook definitions and their relevant default configuration (one hook to rule them all 💍).
 
@@ -150,7 +150,7 @@ The [app manifest](https://docs.slack.dev/reference/app-manifest) in JSON format
 
 ### 🪝 `build` (optional)
 
-Implementing this hook allows for the CLI to [deploy function code to Slack's managed infrastructure](https://tools.slack.dev/deno-slack-sdk/guides/deploying-to-slack). The work of assembling the application bundle according to Slack's application bundle format is delegated to the SDK via this hook.
+Implementing this hook allows for the CLI to [deploy function code to Slack's managed infrastructure](https://docs.slack.dev/tools/deno-slack-sdk/guides/deploying-to-slack/). The work of assembling the application bundle according to Slack's application bundle format is delegated to the SDK via this hook.
 
 The application bundle format has few restrictions, but the critical ones are:
 - It must have a `manifest.json` at the root of the package
@@ -159,7 +159,7 @@ The application bundle format has few restrictions, but the critical ones are:
 
 The above requirements come from the [deno-slack-runtime](https://github.com/slackapi/deno-slack-runtime) project, which implements the expected Slack deployment bundle format. It contains a hard-coded [reference](https://github.com/slackapi/deno-slack-runtime/blob/main/src/mod.ts#L73) to the above-mentioned `functions/` sub-directory, and combines it with the [specific custom function `callback_id`](https://github.com/slackapi/deno-slack-runtime/blob/main/src/mod.ts#L17-L19) to resolve an import path for userland function source code.
 
-*Note: This hook should only be implemented by official Slack SDKs and is only relevant to apps [deployed to Slack's managed infrastructure](https://tools.slack.dev/deno-slack-sdk/guides/deploying-to-slack).*
+*Note: This hook should only be implemented by official Slack SDKs and is only relevant to apps [deployed to Slack's managed infrastructure](https://docs.slack.dev/tools/deno-slack-sdk/guides/deploying-to-slack/).*
 
 #### Input
 

--- a/cmd/datastore/datastore.go
+++ b/cmd/datastore/datastore.go
@@ -53,7 +53,7 @@ func NewCommand(clients *shared.ClientFactory) *cobra.Command {
 			"This command is supported for apps deployed to Slack managed infrastructure but",
 			"other apps can attempt to run the command with the --force flag.",
 			"",
-			`Discover the datastores: {{LinkText "https://tools.slack.dev/deno-slack-sdk/guides/using-datastores"}}`,
+			`Discover the datastores: {{LinkText "https://docs.slack.dev/tools/deno-slack-sdk/guides/using-datastores"}}`,
 		}, "\n"),
 		Example: style.ExampleCommandsf([]style.ExampleCommand{
 			{

--- a/cmd/env/env.go
+++ b/cmd/env/env.go
@@ -42,7 +42,7 @@ func NewCommand(clients *shared.ClientFactory) *cobra.Command {
 			"This command is supported for apps deployed to Slack managed infrastructure but",
 			"other apps can attempt to run the command with the --force flag.",
 			"",
-			`Explore more: {{LinkText "https://tools.slack.dev/slack-cli/guides/using-environment-variables-with-the-slack-cli"}}`,
+			`Explore more: {{LinkText "https://docs.slack.dev/tools/slack-cli/guides/using-environment-variables-with-the-slack-cli"}}`,
 		}, "\n"),
 		Example: style.ExampleCommandsf([]style.ExampleCommand{
 			{

--- a/cmd/externalauth/externalauth.go
+++ b/cmd/externalauth/externalauth.go
@@ -39,7 +39,7 @@ func NewCommand(clients *shared.ClientFactory) *cobra.Command {
 			"This command is supported for apps deployed to Slack managed infrastructure but",
 			"other apps can attempt to run the command with the --force flag.",
 			"",
-			`Explore providers: {{LinkText "https://tools.slack.dev/deno-slack-sdk/guides/integrating-with-services-requiring-external-authentication"}}`,
+			`Explore providers: {{LinkText "https://docs.slack.dev/tools/deno-slack-sdk/guides/integrating-with-services-requiring-external-authentication"}}`,
 		}, "\n"),
 		Example: style.ExampleCommandsf([]style.ExampleCommand{
 			{

--- a/cmd/function/function.go
+++ b/cmd/function/function.go
@@ -40,7 +40,7 @@ func NewCommand(clients *shared.ClientFactory) *cobra.Command {
 			"Inspect and configure the custom functions included in an app with this command.",
 			"Functions can be added as a step in Workflow Builder and shared among teammates.",
 			"",
-			`Learn more about functions: {{LinkText "https://tools.slack.dev/deno-slack-sdk/guides/creating-functions"}}`,
+			`Learn more about functions: {{LinkText "https://docs.slack.dev/tools/deno-slack-sdk/guides/creating-functions"}}`,
 		}, "\n"),
 		Example: style.ExampleCommandsf([]style.ExampleCommand{
 			{Command: "function distribute", Meaning: "Select a function and choose distribution options"},

--- a/cmd/help/help.go
+++ b/cmd/help/help.go
@@ -107,6 +107,6 @@ const helpTemplate string = `{{.Long}}
   For more information about a specific command, run:
   $ {{.CommandPath}}{{if eq .Name (GetProcessName)}} <command>{{end}} <subcommand> --help
 
-  For guides and documentation, head over to {{LinkText "https://tools.slack.dev/slack-cli"}}{{end}}
+  For guides and documentation, head over to {{LinkText "https://docs.slack.dev/tools/slack-cli"}}{{end}}
 
 `

--- a/cmd/project/create.go
+++ b/cmd/project/create.go
@@ -198,7 +198,7 @@ func printCreateSuccess(ctx context.Context, clients *shared.ClientFactory, appP
 			Emoji: "compass",
 			Text:  "Explore the documentation to learn more",
 			Secondary: []string{
-				"Read the README.md or peruse the docs over at " + style.Highlight("https://tools.slack.dev/deno-slack-sdk"),
+				"Read the README.md or peruse the docs over at " + style.Highlight("https://docs.slack.dev/tools/deno-slack-sdk"),
 				"Find available commands and usage info with " + style.Commandf("help", false),
 			},
 		}))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -99,7 +99,7 @@ func NewRootCommand(clients *shared.ClientFactory, updateNotification *update.Up
 		Long: strings.Join([]string{
 			`{{Emoji "sparkles"}}CLI to create, run, and deploy Slack apps`,
 			"",
-			`{{Emoji "books"}}Get started by reading the docs: {{LinkText "https://tools.slack.dev/slack-cli"}}`,
+			`{{Emoji "books"}}Get started by reading the docs: {{LinkText "https://docs.slack.dev/tools/slack-cli"}}`,
 		}, "\n"),
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()

--- a/cmd/triggers/generate.go
+++ b/cmd/triggers/generate.go
@@ -195,7 +195,7 @@ func getFullyQualifiedTriggerFilePaths(ctx context.Context, clients *shared.Clie
 
 	if len(triggerFilePaths) <= 0 {
 		clients.IO.PrintInfo(ctx, false, style.SectionSecondaryf(
-			"No trigger definition files found\nLearn more about triggers:\nhttps://tools.slack.dev/deno-slack-sdk/guides/creating-link-triggers",
+			"No trigger definition files found\nLearn more about triggers:\nhttps://docs.slack.dev/tools/deno-slack-sdk/guides/creating-link-triggers",
 		))
 		return nil, nil
 	} else {

--- a/docs/reference/commands/slack.md
+++ b/docs/reference/commands/slack.md
@@ -6,7 +6,7 @@ Slack command-line tool
 
 CLI to create, run, and deploy Slack apps
 
-Get started by reading the docs: [https://tools.slack.dev/slack-cli](https://tools.slack.dev/slack-cli)
+Get started by reading the docs: [https://docs.slack.dev/tools/slack-cli](https://docs.slack.dev/tools/slack-cli/)
 
 ```
 slack <command> <subcommand> [flags]

--- a/docs/reference/commands/slack_datastore.md
+++ b/docs/reference/commands/slack_datastore.md
@@ -9,7 +9,7 @@ Interact with the items stored in an app's datastore.
 This command is supported for apps deployed to Slack managed infrastructure but
 other apps can attempt to run the command with the --force flag.
 
-Discover the datastores: [https://tools.slack.dev/deno-slack-sdk/guides/using-datastores](https://tools.slack.dev/deno-slack-sdk/guides/using-datastores)
+Discover the datastores: [https://docs.slack.dev/tools/deno-slack-sdk/guides/using-datastores](https://docs.slack.dev/tools/deno-slack-sdk/guides/using-datastores/)
 
 ```
 slack datastore <subcommand> <expression> [flags]

--- a/docs/reference/commands/slack_env.md
+++ b/docs/reference/commands/slack_env.md
@@ -10,7 +10,7 @@ infrastructure.
 This command is supported for apps deployed to Slack managed infrastructure but
 other apps can attempt to run the command with the --force flag.
 
-Explore more: [https://tools.slack.dev/slack-cli/guides/using-environment-variables-with-the-slack-cli](https://tools.slack.dev/slack-cli/guides/using-environment-variables-with-the-slack-cli)
+Explore more: [https://docs.slack.dev/tools/slack-cli/guides/using-environment-variables-with-the-slack-cli](https://docs.slack.dev/tools/slack-cli/guides/using-environment-variables-with-the-slack-cli/)
 
 ```
 slack env <subcommand> [flags]

--- a/docs/reference/commands/slack_external-auth.md
+++ b/docs/reference/commands/slack_external-auth.md
@@ -9,7 +9,7 @@ Adjust external authorization and authentication providers of a workflow app.
 This command is supported for apps deployed to Slack managed infrastructure but
 other apps can attempt to run the command with the --force flag.
 
-Explore providers: [https://tools.slack.dev/deno-slack-sdk/guides/integrating-with-services-requiring-external-authentication](https://tools.slack.dev/deno-slack-sdk/guides/integrating-with-services-requiring-external-authentication)
+Explore providers: [https://docs.slack.dev/tools/deno-slack-sdk/guides/integrating-with-services-requiring-external-authentication/](https://docs.slack.dev/tools/deno-slack-sdk/guides/integrating-with-services-requiring-external-authentication/)
 
 ```
 slack external-auth <subcommand> [flags]

--- a/docs/reference/commands/slack_function.md
+++ b/docs/reference/commands/slack_function.md
@@ -10,7 +10,7 @@ Builder. Whatever that puzzle might be.
 Inspect and configure the custom functions included in an app with this command.
 Functions can be added as a step in Workflow Builder and shared among teammates.
 
-Learn more about functions: [https://tools.slack.dev/deno-slack-sdk/guides/creating-functions](https://tools.slack.dev/deno-slack-sdk/guides/creating-functions)
+Learn more about functions: [https://docs.slack.dev/tools/deno-slack-sdk/guides/creating-functions](https://docs.slack.dev/tools/deno-slack-sdk/guides/creating-functions/)
 
 ```
 slack function <subcommand> [flags]

--- a/internal/slackerror/errors.go
+++ b/internal/slackerror/errors.go
@@ -346,7 +346,7 @@ var ErrorCodeMap = map[string]Error{
 		},
 		Remediation: fmt.Sprintf(`Learn about building apps with the Deno Slack SDK:
 
-https://tools.slack.dev/deno-slack-sdk
+https://docs.slack.dev/tools/deno-slack-sdk
 
 If you are using a Bolt framework, add a deploy hook then run: %s
 
@@ -561,7 +561,7 @@ Otherwise start your app for local development with: %s`,
 	ErrCLIAutoUpdate: {
 		Code:        ErrCLIAutoUpdate,
 		Message:     "Couldn't auto-update this command-line tool",
-		Remediation: "You can manually install the latest version from:\nhttps://tools.slack.dev/slack-cli",
+		Remediation: "You can manually install the latest version from:\nhttps://docs.slack.dev/tools/slack-cli",
 	},
 
 	ErrCLIConfigLocationError: {

--- a/internal/update/cli.go
+++ b/internal/update/cli.go
@@ -90,7 +90,7 @@ func (c *CLIDependency) PrintUpdateNotification(cmd *cobra.Command) (bool, error
 	} else {
 		cmd.Printf(
 			"\n   To manually update, visit the download page:\n   %s\n\n",
-			style.CommandText("https://tools.slack.dev/slack-cli"),
+			style.CommandText("https://docs.slack.dev/tools/slack-cli"),
 		)
 		selfUpdatePrompt := fmt.Sprintf("%sDo you want to auto-update to the latest version now?", style.Emoji("rocket"))
 		return c.clients.IO.ConfirmPrompt(ctx, selfUpdatePrompt, false)

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -139,7 +139,7 @@ install_slack_cli() {
         else
                 echo "🛑 Error: This installer is only supported on Linux and macOS"
                 echo "🔖 Try using a different installation method:"
-                echo "🔗 https://tools.slack.dev/slack-cli"
+                echo "🔗 https://docs.slack.dev/tools/slack-cli"
                 return 1
         fi
 

--- a/scripts/install-windows-dev.ps1
+++ b/scripts/install-windows-dev.ps1
@@ -347,7 +347,7 @@ function next_step_message {
     }
     catch {
       Write-Error "Slack CLI was not installed."
-      Write-Host "`nFind help troubleshooting: https://tools.slack.dev/slack-cli"
+      Write-Host "`nFind help troubleshooting: https://docs.slack.dev/tools/slack-cli"
       throw
     }
   }

--- a/scripts/install-windows.ps1
+++ b/scripts/install-windows.ps1
@@ -338,7 +338,7 @@ function next_step_message {
     }
     catch {
       Write-Error "Slack CLI was not installed."
-      Write-Host "`nFind help troubleshooting: https://tools.slack.dev/slack-cli"
+      Write-Host "`nFind help troubleshooting: https://docs.slack.dev/tools/slack-cli"
       throw
     }
   }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -141,7 +141,7 @@ install_slack_cli() {
         else
                 echo "🛑 Error: This installer is only supported on Linux and macOS"
                 echo "🔖 Try using a different installation method:"
-                echo "🔗 https://tools.slack.dev/slack-cli"
+                echo "🔗 https://docs.slack.dev/tools/slack-cli"
                 return 1
         fi
 


### PR DESCRIPTION
### CHANGELOG

Update the Slack CLI output to use the new https://docs.slack.dev/tools URL instead of the previous https://tools.slack.dev URL.

### Summary

This pull request updates some Slack CLI output that references https://tools.slack.dev/ to now be https://docs.slack.dev/tools/.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).