### PR TITLE
fix: URL checker uses HEAD instead of GET

### DIFF
--- a/internal/deputil/url.go
+++ b/internal/deputil/url.go
@@ -22,7 +22,7 @@ import (
 
 // URLChecker returns url if its status code is 200, otherwise returns empty string
 func URLChecker(httpClient slackhttp.HTTPClient, url string) string {
-	resp, err := httpClient.Get(url)
+	resp, err := httpClient.Head(url)
 	if err != nil {
 		return ""
 	}

--- a/internal/deputil/url_test.go
+++ b/internal/deputil/url_test.go
@@ -35,7 +35,7 @@ func Test_URLChecker(t *testing.T) {
 			expectedURL: "https://github.com/slack-samples/deno-starter-template",
 			setupHTTPClientMock: func(httpClientMock *slackhttp.HTTPClientMock) {
 				resOK := slackhttp.MockHTTPResponse(http.StatusOK, "OK")
-				httpClientMock.On("Get", mock.Anything).Return(resOK, nil)
+				httpClientMock.On("Head", mock.Anything).Return(resOK, nil)
 			},
 		},
 		"Returns an empty string when the HTTP status code is not 200": {
@@ -43,14 +43,14 @@ func Test_URLChecker(t *testing.T) {
 			expectedURL: "",
 			setupHTTPClientMock: func(httpClientMock *slackhttp.HTTPClientMock) {
 				resNotFound := slackhttp.MockHTTPResponse(http.StatusNotFound, "Not Found")
-				httpClientMock.On("Get", mock.Anything).Return(resNotFound, nil)
+				httpClientMock.On("Head", mock.Anything).Return(resNotFound, nil)
 			},
 		},
 		"Returns an empty string when the HTTPClient has an error": {
 			url:         "invalid_url",
 			expectedURL: "",
 			setupHTTPClientMock: func(httpClientMock *slackhttp.HTTPClientMock) {
-				httpClientMock.On("Get", mock.Anything).Return(nil, fmt.Errorf("HTTPClient error"))
+				httpClientMock.On("Head", mock.Anything).Return(nil, fmt.Errorf("HTTPClient error"))
 			},
 		},
 	}

--- a/internal/pkg/create/create_test.go
+++ b/internal/pkg/create/create_test.go
@@ -89,7 +89,7 @@ func Test_generateGitZipFileURL(t *testing.T) {
 			expectedURL: "https://github.com/slack-samples/deno-starter-template/archive/refs/heads/main.zip",
 			setupHTTPClientMock: func(httpClientMock *slackhttp.HTTPClientMock) {
 				res := slackhttp.MockHTTPResponse(http.StatusOK, "OK")
-				httpClientMock.On("Get", mock.Anything).Return(res, nil)
+				httpClientMock.On("Head", mock.Anything).Return(res, nil)
 			},
 		},
 		"Returns the zip URL using the master branch when no branch is provided and main branch doesn't exist": {
@@ -98,8 +98,8 @@ func Test_generateGitZipFileURL(t *testing.T) {
 			expectedURL: "https://github.com/slack-samples/deno-starter-template/archive/refs/heads/master.zip",
 			setupHTTPClientMock: func(httpClientMock *slackhttp.HTTPClientMock) {
 				res := slackhttp.MockHTTPResponse(http.StatusOK, "OK")
-				httpClientMock.On("Get", "https://github.com/slack-samples/deno-starter-template/archive/refs/heads/main.zip").Return(nil, fmt.Errorf("HttpClient error"))
-				httpClientMock.On("Get", "https://github.com/slack-samples/deno-starter-template/archive/refs/heads/master.zip").Return(res, nil)
+				httpClientMock.On("Head", "https://github.com/slack-samples/deno-starter-template/archive/refs/heads/main.zip").Return(nil, fmt.Errorf("HttpClient error"))
+				httpClientMock.On("Head", "https://github.com/slack-samples/deno-starter-template/archive/refs/heads/master.zip").Return(res, nil)
 			},
 		},
 		"Returns the zip URL using the specified branch when a branch is provided": {
@@ -108,7 +108,7 @@ func Test_generateGitZipFileURL(t *testing.T) {
 			expectedURL: "https://github.com/slack-samples/deno-starter-template/archive/refs/heads/pre-release-0316.zip",
 			setupHTTPClientMock: func(httpClientMock *slackhttp.HTTPClientMock) {
 				res := slackhttp.MockHTTPResponse(http.StatusOK, "OK")
-				httpClientMock.On("Get", mock.Anything).Return(res, nil)
+				httpClientMock.On("Head", mock.Anything).Return(res, nil)
 			},
 		},
 		"Returns an empty string when the HTTP status code is not 200": {
@@ -117,7 +117,7 @@ func Test_generateGitZipFileURL(t *testing.T) {
 			expectedURL: "",
 			setupHTTPClientMock: func(httpClientMock *slackhttp.HTTPClientMock) {
 				res := slackhttp.MockHTTPResponse(http.StatusNotFound, "Not Found")
-				httpClientMock.On("Get", mock.Anything).Return(res, nil)
+				httpClientMock.On("Head", mock.Anything).Return(res, nil)
 			},
 		},
 		"Returns an empty string when the HTTPClient has an error": {
@@ -125,7 +125,7 @@ func Test_generateGitZipFileURL(t *testing.T) {
 			gitBranch:   "",
 			expectedURL: "",
 			setupHTTPClientMock: func(httpClientMock *slackhttp.HTTPClientMock) {
-				httpClientMock.On("Get", mock.Anything).Return(nil, fmt.Errorf("HTTPClient error"))
+				httpClientMock.On("Head", mock.Anything).Return(nil, fmt.Errorf("HTTPClient error"))
 			},
 		},
 		"Returns the zip URL with .git suffix removed": {
@@ -134,7 +134,7 @@ func Test_generateGitZipFileURL(t *testing.T) {
 			expectedURL: "https://github.com/slack-samples/deno-starter-template/archive/refs/heads/main.zip",
 			setupHTTPClientMock: func(httpClientMock *slackhttp.HTTPClientMock) {
 				res := slackhttp.MockHTTPResponse(http.StatusOK, "OK")
-				httpClientMock.On("Get", mock.Anything).Return(res, nil)
+				httpClientMock.On("Head", mock.Anything).Return(res, nil)
 			},
 		},
 		"Returns the zip URL with .git inside URL preserved": {
@@ -143,7 +143,7 @@ func Test_generateGitZipFileURL(t *testing.T) {
 			expectedURL: "https://github.com/slack-samples/deno.git-starter-template/archive/refs/heads/main.zip",
 			setupHTTPClientMock: func(httpClientMock *slackhttp.HTTPClientMock) {
 				res := slackhttp.MockHTTPResponse(http.StatusOK, "OK")
-				httpClientMock.On("Get", mock.Anything).Return(res, nil)
+				httpClientMock.On("Head", mock.Anything).Return(res, nil)
 			},
 		},
 	}

--- a/internal/slackhttp/http.go
+++ b/internal/slackhttp/http.go
@@ -29,6 +29,7 @@ const (
 type HTTPClient interface {
 	Do(req *http.Request) (*http.Response, error)
 	Get(url string) (*http.Response, error)
+	Head(url string) (*http.Response, error)
 }
 
 // HTTPClientOptions allows for the customization of a http.Client.

--- a/internal/slackhttp/http_mock.go
+++ b/internal/slackhttp/http_mock.go
@@ -53,6 +53,19 @@ func (m *HTTPClientMock) Get(url string) (*http.Response, error) {
 	return httpResp, args.Error(1)
 }
 
+// Head is a mock that tracks the calls to Head and returns the mocked http.Response and error.
+func (m *HTTPClientMock) Head(url string) (*http.Response, error) {
+	args := m.Called(url)
+
+	// http.Response can be nil when an error is provided.
+	var httpResp *http.Response
+	if _httpResp, ok := args.Get(0).(*http.Response); ok {
+		httpResp = _httpResp
+	}
+
+	return httpResp, args.Error(1)
+}
+
 // MockHTTPResponse is a helper that returns a mocked http.Response with the provided httpStatus and body.
 func MockHTTPResponse(httpStatus int, body string) *http.Response {
 	resWriter := httptest.NewRecorder()


### PR DESCRIPTION
### CHANGELOG

> Fix a bug to allow new projects to be created quicker by using a HTTP HEAD request to check if the template URL exists.

### Summary

This pull request updates the `URLChecker(http, url)` to check if the URL exists using a `HEAD` request instead of a `GET` request. This should improve performance, since it will not download the zip to only confirm that the URL is valid.

There should be no change to functionality.

### Reviewers

```bash
$ lack create asdf
# → Select any app, since all apps are downloaded from template URLS
# → Confirm that the app is created

# Cleanup
$ rm -rf asdf/
```

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).