### PR TITLE
docs: list flags before examples in generated reference

### DIFF
--- a/cmd/docgen/docgen.go
+++ b/cmd/docgen/docgen.go
@@ -177,12 +177,12 @@ func genMarkdownCommand(cmd *cobra.Command, w io.Writer) error {
 	if cmd.Runnable() {
 		fmt.Fprintf(buf, "```\n%s\n```\n\n", cmd.UseLine())
 	}
+	if err := genMarkdownCommandFlags(buf, cmd); err != nil {
+		return err
+	}
 	if len(cmd.Example) > 0 {
 		fmt.Fprintf(buf, "## Examples\n\n")
 		fmt.Fprintf(buf, "```\n%s\n```\n\n", cmd.Example)
-	}
-	if err := genMarkdownCommandFlags(buf, cmd); err != nil {
-		return err
 	}
 	if hasSeeAlso(cmd) {
 		fmt.Fprintf(buf, "## See also\n\n")


### PR DESCRIPTION
### Summary

This PR lists flags before examples in generated reference to match outputs of the `--help` commands 🤖

### Preview

The following page and command might demonstrate the purpose of this change:

- Docs: https://docs.slack.dev/tools/slack-cli/reference/commands/slack_app_link
- CLI: `slack app link --help`

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).