### PR TITLE
build: upload floating major and minor versions on release

### DIFF
--- a/scripts/archive-test.sh
+++ b/scripts/archive-test.sh
@@ -33,6 +33,16 @@ set -e
 
 DIST_DIR=${1}
 
+get_version_major() {
+    local version="$1"
+    echo "${version}" | cut -d'.' -f1
+}
+
+get_version_major_minor() {
+    local version="$1"
+    echo "${version}" | cut -d'.' -f1-2
+}
+
 main() {
     if [ $# -lt 2 ]; then
         echo "Missing parameters: $0 <path> <version>"
@@ -40,11 +50,19 @@ main() {
     fi
 
     VERSION=${2}
+    VERSION_MAJOR=$(get_version_major "$VERSION")
+    VERSION_MAJOR_MINOR=$(get_version_major_minor "$VERSION")
 
     echo "Checking macOS archives"
     check_tar "$DIST_DIR/slack_cli_${VERSION}_macOS_64-bit.tar.gz"
     check_tar "$DIST_DIR/slack_cli_${VERSION}_macOS_amd64.tar.gz"
     check_tar "$DIST_DIR/slack_cli_${VERSION}_macOS_arm64.tar.gz"
+    check_tar "$DIST_DIR/slack_cli_${VERSION_MAJOR}.x.x_macOS_64-bit.tar.gz"
+    check_tar "$DIST_DIR/slack_cli_${VERSION_MAJOR}.x.x_macOS_amd64.tar.gz"
+    check_tar "$DIST_DIR/slack_cli_${VERSION_MAJOR}.x.x_macOS_arm64.tar.gz"
+    check_tar "$DIST_DIR/slack_cli_${VERSION_MAJOR_MINOR}.x_macOS_64-bit.tar.gz"
+    check_tar "$DIST_DIR/slack_cli_${VERSION_MAJOR_MINOR}.x_macOS_amd64.tar.gz"
+    check_tar "$DIST_DIR/slack_cli_${VERSION_MAJOR_MINOR}.x_macOS_arm64.tar.gz"
     check_tar "$DIST_DIR/slack_cli_dev_macOS_64-bit.tar.gz"
     check_tar "$DIST_DIR/slack_cli_dev_macOS_amd64.tar.gz"
     check_tar "$DIST_DIR/slack_cli_dev_macOS_arm64.tar.gz"
@@ -59,11 +77,15 @@ main() {
 
     echo "Checking Linux archives"
     check_tar "$DIST_DIR/slack_cli_${VERSION}_linux_64-bit.tar.gz"
+    check_tar "$DIST_DIR/slack_cli_${VERSION_MAJOR}.x.x_linux_64-bit.tar.gz"
+    check_tar "$DIST_DIR/slack_cli_${VERSION_MAJOR_MINOR}.x_linux_64-bit.tar.gz"
     check_tar "$DIST_DIR/slack_cli_dev_linux_64-bit.tar.gz"
     check_tar "$DIST_DIR/slack_cli_latest_linux_64-bit.tar.gz"
 
     echo "Checking Windows archives"
     check_exe "$DIST_DIR/slack_cli_${VERSION}_windows_64-bit.zip"
+    check_exe "$DIST_DIR/slack_cli_${VERSION_MAJOR}.x.x_windows_64-bit.zip"
+    check_exe "$DIST_DIR/slack_cli_${VERSION_MAJOR_MINOR}.x_windows_64-bit.zip"
     check_exe "$DIST_DIR/slack_cli_dev_windows_64-bit.zip"
     check_exe "$DIST_DIR/slack_cli_latest_windows_64-bit.zip"
 

--- a/scripts/archive-test.sh
+++ b/scripts/archive-test.sh
@@ -49,6 +49,14 @@ main() {
         exit 1
     fi
 
+    echo "Checking version parsing"
+    check_version "3.4.0" "3" "3.4"
+    check_version "3.6.2" "3" "3.6"
+    check_version "10.15.7" "10" "10.15"
+    check_version "1.0.0" "1" "1.0"
+    check_version "3.1.4-example-feature" "3" "3.1"
+    check_version "3.6.0-6-g859d4f1" "3" "3.6"
+
     VERSION=${2}
     VERSION_MAJOR=$(get_version_major "$VERSION")
     VERSION_MAJOR_MINOR=$(get_version_major_minor "$VERSION")
@@ -112,6 +120,26 @@ check_tar() {
 
     if ! [[ -x "$tmpdir/bin/slack" ]]; then
         echo "-> Failed to find executable: $1"
+        return 1
+    fi
+}
+
+check_version() {
+    local version="$1"
+    local expected_major="$2"
+    local expected_major_minor="$3"
+    local actual_major
+    local actual_major_minor
+
+    echo "-> Testing version parsing: '$version'"
+    actual_major=$(get_version_major "$version")
+    actual_major_minor=$(get_version_major_minor "$version")
+    if [[ "$expected_major" != "$actual_major" ]]; then
+        echo "-> Failed to get major version('$version') = '$actual_major'"
+        return 1
+    fi
+    if [[ "$expected_major_minor" != "$actual_major_minor" ]]; then
+        echo "-> Failed to get major minor version('$version') = '$actual_major_minor'"
         return 1
     fi
 }

--- a/scripts/archive.sh
+++ b/scripts/archive.sh
@@ -32,6 +32,16 @@ set -e
 
 DIST_DIR=${1}
 
+get_version_major() {
+    local version="$1"
+    echo "${version}" | cut -d'.' -f1
+}
+
+get_version_major_minor() {
+    local version="$1"
+    echo "${version}" | cut -d'.' -f1-2
+}
+
 main() {
     if [ $# -lt 2 ]; then
         echo "Missing parameters: $0 <path> <version>"
@@ -39,12 +49,20 @@ main() {
     fi
 
     VERSION=${2}
+    VERSION_MAJOR=$(get_version_major "$VERSION")
+    VERSION_MAJOR_MINOR=$(get_version_major_minor "$VERSION")
 
     echo "Creating macOS archives"
 
     macos_targz_file_path_version_universal="$DIST_DIR/slack_cli_${VERSION}_macOS_64-bit.tar.gz"
     macos_targz_file_path_version_amd64="$DIST_DIR/slack_cli_${VERSION}_macOS_amd64.tar.gz"
     macos_targz_file_path_version_arm64="$DIST_DIR/slack_cli_${VERSION}_macOS_arm64.tar.gz"
+    macos_targz_file_path_version_major_universal="$DIST_DIR/slack_cli_${VERSION_MAJOR}.x.x_macOS_64-bit.tar.gz"
+    macos_targz_file_path_version_major_amd64="$DIST_DIR/slack_cli_${VERSION_MAJOR}.x.x_macOS_amd64.tar.gz"
+    macos_targz_file_path_version_major_arm64="$DIST_DIR/slack_cli_${VERSION_MAJOR}.x.x_macOS_arm64.tar.gz"
+    macos_targz_file_path_version_major_minor_universal="$DIST_DIR/slack_cli_${VERSION_MAJOR_MINOR}.x_macOS_64-bit.tar.gz"
+    macos_targz_file_path_version_major_minor_amd64="$DIST_DIR/slack_cli_${VERSION_MAJOR_MINOR}.x_macOS_amd64.tar.gz"
+    macos_targz_file_path_version_major_minor_arm64="$DIST_DIR/slack_cli_${VERSION_MAJOR_MINOR}.x_macOS_arm64.tar.gz"
     macos_targz_file_path_dev_universal="$DIST_DIR/slack_cli_dev_macOS_64-bit.tar.gz"
     macos_targz_file_path_dev_amd64="$DIST_DIR/slack_cli_dev_macOS_amd64.tar.gz"
     macos_targz_file_path_dev_arm64="$DIST_DIR/slack_cli_dev_macOS_arm64.tar.gz"
@@ -59,9 +77,17 @@ main() {
 
     echo "-> Creating macOS versioned tar.gz files"
     unzip_tar "$macos_zip_file_path_universal" "$macos_targz_file_path_version_universal"
+    unzip_tar "$macos_zip_file_path_universal" "$macos_targz_file_path_version_major_universal"
+    unzip_tar "$macos_zip_file_path_universal" "$macos_targz_file_path_version_major_minor_universal"
     unzip_tar "$macos_zip_file_path_amd64" "$macos_targz_file_path_version_amd64"
+    unzip_tar "$macos_zip_file_path_amd64" "$macos_targz_file_path_version_major_amd64"
+    unzip_tar "$macos_zip_file_path_amd64" "$macos_targz_file_path_version_major_minor_amd64"
     unzip_tar "$macos_zip_file_path_arm64" "$macos_targz_file_path_version_arm64"
+    unzip_tar "$macos_zip_file_path_arm64" "$macos_targz_file_path_version_major_arm64"
+    unzip_tar "$macos_zip_file_path_arm64" "$macos_targz_file_path_version_major_minor_arm64"
     ls -l "$DIST_DIR"/*_"$VERSION"_macOS*
+    ls -l "$DIST_DIR"/*_"$VERSION_MAJOR".x.x_macOS*
+    ls -l "$DIST_DIR"/*_"$VERSION_MAJOR_MINOR".x_macOS*
 
     echo "-> Creating macOS development tar.gz files"
     cp "$macos_targz_file_path_version_universal" "$macos_targz_file_path_dev_universal"
@@ -82,8 +108,17 @@ main() {
     echo "Creating Linux archives"
 
     linux_targz_file_path_version="$DIST_DIR/slack_cli_${VERSION}_linux_64-bit.tar.gz"
+    linux_targz_file_path_version_major="$DIST_DIR/slack_cli_${VERSION_MAJOR}.x.x_linux_64-bit.tar.gz"
+    linux_targz_file_path_version_major_minor="$DIST_DIR/slack_cli_${VERSION_MAJOR_MINOR}.x_linux_64-bit.tar.gz"
     linux_targz_file_path_dev="$DIST_DIR/slack_cli_dev_linux_64-bit.tar.gz"
     linux_targz_file_path_latest="$DIST_DIR/slack_cli_latest_linux_64-bit.tar.gz"
+
+    echo "-> Creating Linux versioned tar.gz file"
+    cp "$linux_targz_file_path_version" "$linux_targz_file_path_version_major"
+    cp "$linux_targz_file_path_version" "$linux_targz_file_path_version_major_minor"
+    ls -l "$DIST_DIR"/*_"$VERSION"_linux*
+    ls -l "$DIST_DIR"/*_"$VERSION_MAJOR".x.x_linux*
+    ls -l "$DIST_DIR"/*_"$VERSION_MAJOR_MINOR".x_linux*
 
     echo "-> Creating Linux development tar.gz file"
     cp "$linux_targz_file_path_version" "$linux_targz_file_path_dev"
@@ -96,8 +131,17 @@ main() {
     echo "Creating Windows archives"
 
     windows_zip_file_path_version="$DIST_DIR/slack_cli_${VERSION}_windows_64-bit.zip"
+    windows_zip_file_path_version_major="$DIST_DIR/slack_cli_${VERSION_MAJOR}.x.x_windows_64-bit.zip"
+    windows_zip_file_path_version_major_minor="$DIST_DIR/slack_cli_${VERSION_MAJOR_MINOR}.x_windows_64-bit.zip"
     windows_zip_file_path_dev="$DIST_DIR/slack_cli_dev_windows_64-bit.zip"
     windows_zip_file_path_latest="$DIST_DIR/slack_cli_latest_windows_64-bit.zip"
+
+    echo "-> Creating Windows versioned zip file"
+    cp "$windows_zip_file_path_version" "$windows_zip_file_path_version_major"
+    cp "$windows_zip_file_path_version" "$windows_zip_file_path_version_major_minor"
+    ls -l "$DIST_DIR"/*_"$VERSION"_windows*
+    ls -l "$DIST_DIR"/*_"$VERSION_MAJOR".x.x_windows*
+    ls -l "$DIST_DIR"/*_"$VERSION_MAJOR_MINOR".x_windows*
 
     echo "-> Creating Windows development zip file"
     cp "$windows_zip_file_path_version" "$windows_zip_file_path_dev"

--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -19,7 +19,7 @@ SKIP_DENO_INSTALL=false
 SLACK_CLI_NAME="slack-dev"
 FINGERPRINT="d41d8cd98f00b204e9800998ecf8427e"
 SLACK_CLI_DEV_VERSION="dev"
-rx='^([0-9]+\.){2}(\*|[0-9]+)(-.*)?$'
+rx='^[0-9]+\.[0-9x]+\.[0-9x]+(-[A-Za-z0-9._-]+)?$'
 
 # As this script is for internal usage only, we should set SLACK_DISABLE_TELEMETRY environment variable
 export SLACK_DISABLE_TELEMETRY="true"
@@ -31,7 +31,7 @@ while getopts "v:d" flag; do
                                 SLACK_CLI_DEV_VERSION=$OPTARG
                         else
                                 echo "Slack CLI requires a valid semver version number." >&2
-                                return 1
+                                exit 1
                         fi
                         ;;
                 d)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -19,7 +19,7 @@ SKIP_DENO_INSTALL=false
 SLACK_CLI_NAME="slack"
 FINGERPRINT="d41d8cd98f00b204e9800998ecf8427e"
 SLACK_CLI_VERSION=
-rx='^([0-9]+\.){2}(\*|[0-9]+)(-.*)?$'
+rx='^[0-9]+\.[0-9x]+\.[0-9x]+(-[A-Za-z0-9._-]+)?$'
 
 while getopts "v:d" flag; do
         case "$flag" in
@@ -28,7 +28,7 @@ while getopts "v:d" flag; do
                                 SLACK_CLI_VERSION=$OPTARG
                         else
                                 echo "Slack CLI requires a valid semver version number." >&2
-                                return 1
+                                exit 1
                         fi
                         ;;
                 d)


### PR DESCRIPTION
### Summary

This PR uploads floating `major` and `minor` versions on release to avoid unexpected breaking changes when installing the `latest` version in downstream actions.

This might unlock the following for whatever the latest of `v3` is:

```
curl -fsSL https://downloads.slack-edge.com/slack-cli/install.sh | bash -s -- -v 3.x.x
```

### Preview

```
slack_cli_3.6.0-6-g859d4f1_linux_64-bit.tar.gz
slack_cli_3.6.x_linux_64-bit.tar.gz
slack_cli_3.x.x_linux_64-bit.tar.gz
```

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).