### PR TITLE
feat: add search app feature to the app manifest

### DIFF
--- a/internal/shared/types/app_manifest.go
+++ b/internal/shared/types/app_manifest.go
@@ -75,6 +75,7 @@ type AppFeatures struct {
 	UnfurlDomains              []string                    `json:"unfurl_domains,omitempty" yaml:"unfurl_domains,flow,omitempty"`
 	ManifestShortcutsItems     []ManifestShortcutsItem     `json:"shortcuts,omitempty" yaml:"shortcuts,flow,omitempty"`
 	ManifestSlashCommandsItems []ManifestSlashCommandsItem `json:"slash_commands,omitempty" yaml:"slash_commands,flow,omitempty"`
+	Search                     *Search                     `json:"search,omitempty" yaml:"search,flow,omitempty"`
 }
 
 type AssistantView struct {
@@ -250,6 +251,13 @@ type ManifestSlashCommandsItem struct {
 	Description  string `json:"description" yaml:"description"`
 	ShouldEscape *bool  `json:"should_escape,omitempty" yaml:"should_escape,omitempty"`
 	UsageHint    string `json:"usage_hint,omitempty" yaml:"usage_hint,omitempty"`
+}
+
+// Search contains the search function of an app.
+type Search struct {
+	SearchFunctionCallbackID        string `json:"search_function_callback_id,omitempty" yaml:"search_function_callback_id,omitempty"`
+	SearchFiltersFunctionCallbackID string `json:"search_filters_function_callback_id,omitempty" yaml:"search_filters_function_callback_id,omitempty"`
+	EnableAIAnswers                 *bool  `json:"enable_ai_answers,omitempty" yaml:"enable_ai_answers,omitempty"`
 }
 
 // Workflow defines the structure of a workflow in the app manifest.

--- a/internal/shared/types/app_manifest_test.go
+++ b/internal/shared/types/app_manifest_test.go
@@ -166,6 +166,19 @@ func Test_AppManifest_AppFeatures(t *testing.T) {
 			},
 			want: `{"app_home":{},"assistant_view":{"assistant_description":"magic","suggested_prompts":[{"title":"visit the beach","message":"what is glass"}]},"bot_user":{"display_name":"einstein"}}`,
 		},
+		"includes search when provided": {
+			features: AppFeatures{
+				BotUser: BotUser{
+					DisplayName: "kubrick",
+				},
+				Search: &Search{
+					SearchFunctionCallbackID:        "movie_search",
+					SearchFiltersFunctionCallbackID: "movie_filters",
+					EnableAIAnswers:                 &truth,
+				},
+			},
+			want: `{"app_home":{},"bot_user":{"display_name":"kubrick"},"search":{"search_function_callback_id":"movie_search","search_filters_function_callback_id":"movie_filters","enable_ai_answers":true}}`,
+		},
 	}
 	for name, tt := range tests {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
### Changelog

> We now parse the app manifest fields of `features.search` when gathering an app manifest.

### Summary

This PR adds the `search` attribute to the app manifest 👾 ✨ 

### Preview

The following can be added to a manifest as a proof of concept:

```json
{
  "features": {
    "search": {
      "search_function_callback_id": "movie_search",
      "search_filters_function_callback_id": "movie_filters",
      "enable_ai_answers": true
    }
  }
}
```

### Reviewers

Confirm this value is detected when parsing the manifest:

```sh
$ slack create asdf              # Create a Bolt JS application
$ cd asdf
$ vim manifest.json              # Update the app manifest
$ slack manifest --source local  # Find expected values appear!
```

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).