### PR TITLE
test(ci): run the installation tests on circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,6 +129,10 @@ jobs:
           command: |
             make test
       - run:
+          name: Run Install Tests
+          command: |
+            make test-install
+      - run:
           name: Sync Tests Results
           command: |
             cp ./coverage.out /tmp/test-results


### PR DESCRIPTION
### Summary

This PR retruns the changes of https://github.com/slackapi/slack-cli/commit/6001989fd192d611ad37b84ed2991e4afa6024ca following #188! 👾 ✨ 

Reference: https://github.com/slackapi/slack-cli/pull/188#discussion_r2289132907
### Requirements

### Notes

These tests should now fallback to using the `$HOME/.local/bin` path in CircleCI due to permission setups, and `/usr/local/bin` on GitHub Actions IIRC?

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).