### PR TITLE
build: make releases with a "make tag" build command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,3 +69,22 @@ build-ci: clean
 .PHONY: build-snapshot
 build-snapshot: clean
 	BUILD_VERSION="$(BUILD_VERSION)" LDFLAGS="$(LDFLAGS)" goreleaser --snapshot --clean --skip=publish --config .goreleaser.yml
+
+# Update documentation in a commit tagged as the release
+.PHONY: release
+release:
+	git diff --quiet
+	@if echo "$(RELEASE_VERSION)" | grep -q '^v'; then \
+		echo "Error: Release version should not begin with a version prefix."; \
+		exit 1; \
+	fi
+	@sed -i -E "s#slack_cli_[0-9]+\.[0-9]+\.[0-9]+_macOS_arm64\.tar\.gz#slack_cli_$(RELEASE_VERSION)_macOS_arm64.tar.gz#" docs/guides/installing-the-slack-cli-for-mac-and-linux.md
+	@sed -i -E "s#slack_cli_[0-9]+\.[0-9]+\.[0-9]+_macOS_amd64\.tar\.gz#slack_cli_$(RELEASE_VERSION)_macOS_amd64.tar.gz#" docs/guides/installing-the-slack-cli-for-mac-and-linux.md
+	@sed -i -E "s#slack_cli_[0-9]+\.[0-9]+\.[0-9]+_linux_64-bit\.tar\.gz#slack_cli_$(RELEASE_VERSION)_linux_64-bit.tar.gz#" docs/guides/installing-the-slack-cli-for-mac-and-linux.md
+	@sed -i -E "s/Using slack v[0-9]+\.[0-9]+\.[0-9]+/Using slack v$(RELEASE_VERSION)/" docs/guides/installing-the-slack-cli-for-mac-and-linux.md
+	@sed -i -E "s#slack_cli_[0-9]+\.[0-9]+\.[0-9]+_windows_64-bit\.zip#slack_cli_$(RELEASE_VERSION)_windows_64-bit.zip#" docs/guides/installing-the-slack-cli-for-windows.md
+	@sed -i -E "s/Using slack v[0-9]+\.[0-9]+\.[0-9]+/Using slack v$(RELEASE_VERSION)/" docs/guides/installing-the-slack-cli-for-windows.md
+	git add docs/guides/installing-the-slack-cli-for-mac-and-linux.md
+	git add docs/guides/installing-the-slack-cli-for-windows.md
+	git commit -m "chore: release slack-cli $(RELEASE_VERSION)"
+	git tag v$(RELEASE_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -80,12 +80,14 @@ tag:
 		echo "Error: Release version should not begin with a version prefix."; \
 		exit 1; \
 	fi
-	sed -i -E "s#slack_cli_[0-9]+\.[0-9]+\.[0-9]+_macOS_arm64\.tar\.gz#slack_cli_$(RELEASE_VERSION)_macOS_arm64.tar.gz#" docs/guides/installing-the-slack-cli-for-mac-and-linux.md
-	sed -i -E "s#slack_cli_[0-9]+\.[0-9]+\.[0-9]+_macOS_amd64\.tar\.gz#slack_cli_$(RELEASE_VERSION)_macOS_amd64.tar.gz#" docs/guides/installing-the-slack-cli-for-mac-and-linux.md
-	sed -i -E "s#slack_cli_[0-9]+\.[0-9]+\.[0-9]+_linux_64-bit\.tar\.gz#slack_cli_$(RELEASE_VERSION)_linux_64-bit.tar.gz#" docs/guides/installing-the-slack-cli-for-mac-and-linux.md
-	sed -i -E "s#slack_cli_[0-9]+\.[0-9]+\.[0-9]+_windows_64-bit\.zip#slack_cli_$(RELEASE_VERSION)_windows_64-bit.zip#" docs/guides/installing-the-slack-cli-for-windows.md
-	sed -i -E "s/Using slack v[0-9]+\.[0-9]+\.[0-9]+/Using slack v$(RELEASE_VERSION)/" docs/guides/installing-the-slack-cli-for-mac-and-linux.md
-	sed -i -E "s/Using slack v[0-9]+\.[0-9]+\.[0-9]+/Using slack v$(RELEASE_VERSION)/" docs/guides/installing-the-slack-cli-for-windows.md
+	sed -i.bak -E "s#slack_cli_[0-9]+\.[0-9]+\.[0-9]+_macOS_arm64\.tar\.gz#slack_cli_$(RELEASE_VERSION)_macOS_arm64.tar.gz#" docs/guides/installing-the-slack-cli-for-mac-and-linux.md
+	sed -i.bak -E "s#slack_cli_[0-9]+\.[0-9]+\.[0-9]+_macOS_amd64\.tar\.gz#slack_cli_$(RELEASE_VERSION)_macOS_amd64.tar.gz#" docs/guides/installing-the-slack-cli-for-mac-and-linux.md
+	sed -i.bak -E "s#slack_cli_[0-9]+\.[0-9]+\.[0-9]+_linux_64-bit\.tar\.gz#slack_cli_$(RELEASE_VERSION)_linux_64-bit.tar.gz#" docs/guides/installing-the-slack-cli-for-mac-and-linux.md
+	sed -i.bak -E "s#slack_cli_[0-9]+\.[0-9]+\.[0-9]+_windows_64-bit\.zip#slack_cli_$(RELEASE_VERSION)_windows_64-bit.zip#" docs/guides/installing-the-slack-cli-for-windows.md
+	sed -i.bak -E "s/Using slack v[0-9]+\.[0-9]+\.[0-9]+/Using slack v$(RELEASE_VERSION)/" docs/guides/installing-the-slack-cli-for-mac-and-linux.md
+	sed -i.bak -E "s/Using slack v[0-9]+\.[0-9]+\.[0-9]+/Using slack v$(RELEASE_VERSION)/" docs/guides/installing-the-slack-cli-for-windows.md
+	rm docs/guides/installing-the-slack-cli-for-mac-and-linux.md.bak
+	rm docs/guides/installing-the-slack-cli-for-windows.md.bak
 	git add docs/guides/installing-the-slack-cli-for-mac-and-linux.md
 	git add docs/guides/installing-the-slack-cli-for-windows.md
 	git commit -m "chore: release slack-cli v$(RELEASE_VERSION)"

--- a/Makefile
+++ b/Makefile
@@ -71,9 +71,10 @@ build-snapshot: clean
 	BUILD_VERSION="$(BUILD_VERSION)" LDFLAGS="$(LDFLAGS)" goreleaser --snapshot --clean --skip=publish --config .goreleaser.yml
 
 # Update documentation in a commit tagged as the release
-.PHONY: release
-release:
-	git diff --quiet
+.PHONY: tag
+tag:
+	git diff --quiet --cached
+	git diff --quiet docs/guides/installing-the-slack-cli-*.md
 	@if echo "$(RELEASE_VERSION)" | grep -q '^v'; then \
 		echo "Error: Release version should not begin with a version prefix."; \
 		exit 1; \
@@ -86,5 +87,5 @@ release:
 	@sed -i -E "s/Using slack v[0-9]+\.[0-9]+\.[0-9]+/Using slack v$(RELEASE_VERSION)/" docs/guides/installing-the-slack-cli-for-windows.md
 	git add docs/guides/installing-the-slack-cli-for-mac-and-linux.md
 	git add docs/guides/installing-the-slack-cli-for-windows.md
-	git commit -m "chore: release slack-cli $(RELEASE_VERSION)"
+	git commit -m "chore: release slack-cli v$(RELEASE_VERSION)"
 	git tag v$(RELEASE_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,7 @@ tag:
 	@printf "$(FONT_BOLD)Removing Backups$(FONT_RESET)\n"
 	rm docs/guides/installing-the-slack-cli-for-mac-and-linux.md.bak
 	rm docs/guides/installing-the-slack-cli-for-windows.md.bak
+	@printf "$(FONT_BOLD)Git Add$(FONT_RESET)\n"
 	git add docs/guides/installing-the-slack-cli-for-mac-and-linux.md
 	git add docs/guides/installing-the-slack-cli-for-windows.md
 	@printf "$(FONT_BOLD)Git Commit$(FONT_RESET)\n"

--- a/Makefile
+++ b/Makefile
@@ -79,12 +79,12 @@ tag:
 		echo "Error: Release version should not begin with a version prefix."; \
 		exit 1; \
 	fi
-	@sed -i -E "s#slack_cli_[0-9]+\.[0-9]+\.[0-9]+_macOS_arm64\.tar\.gz#slack_cli_$(RELEASE_VERSION)_macOS_arm64.tar.gz#" docs/guides/installing-the-slack-cli-for-mac-and-linux.md
-	@sed -i -E "s#slack_cli_[0-9]+\.[0-9]+\.[0-9]+_macOS_amd64\.tar\.gz#slack_cli_$(RELEASE_VERSION)_macOS_amd64.tar.gz#" docs/guides/installing-the-slack-cli-for-mac-and-linux.md
-	@sed -i -E "s#slack_cli_[0-9]+\.[0-9]+\.[0-9]+_linux_64-bit\.tar\.gz#slack_cli_$(RELEASE_VERSION)_linux_64-bit.tar.gz#" docs/guides/installing-the-slack-cli-for-mac-and-linux.md
-	@sed -i -E "s/Using slack v[0-9]+\.[0-9]+\.[0-9]+/Using slack v$(RELEASE_VERSION)/" docs/guides/installing-the-slack-cli-for-mac-and-linux.md
-	@sed -i -E "s#slack_cli_[0-9]+\.[0-9]+\.[0-9]+_windows_64-bit\.zip#slack_cli_$(RELEASE_VERSION)_windows_64-bit.zip#" docs/guides/installing-the-slack-cli-for-windows.md
-	@sed -i -E "s/Using slack v[0-9]+\.[0-9]+\.[0-9]+/Using slack v$(RELEASE_VERSION)/" docs/guides/installing-the-slack-cli-for-windows.md
+	sed -i -E "s#slack_cli_[0-9]+\.[0-9]+\.[0-9]+_macOS_arm64\.tar\.gz#slack_cli_$(RELEASE_VERSION)_macOS_arm64.tar.gz#" docs/guides/installing-the-slack-cli-for-mac-and-linux.md
+	sed -i -E "s#slack_cli_[0-9]+\.[0-9]+\.[0-9]+_macOS_amd64\.tar\.gz#slack_cli_$(RELEASE_VERSION)_macOS_amd64.tar.gz#" docs/guides/installing-the-slack-cli-for-mac-and-linux.md
+	sed -i -E "s#slack_cli_[0-9]+\.[0-9]+\.[0-9]+_linux_64-bit\.tar\.gz#slack_cli_$(RELEASE_VERSION)_linux_64-bit.tar.gz#" docs/guides/installing-the-slack-cli-for-mac-and-linux.md
+	sed -i -E "s#slack_cli_[0-9]+\.[0-9]+\.[0-9]+_windows_64-bit\.zip#slack_cli_$(RELEASE_VERSION)_windows_64-bit.zip#" docs/guides/installing-the-slack-cli-for-windows.md
+	sed -i -E "s/Using slack v[0-9]+\.[0-9]+\.[0-9]+/Using slack v$(RELEASE_VERSION)/" docs/guides/installing-the-slack-cli-for-mac-and-linux.md
+	sed -i -E "s/Using slack v[0-9]+\.[0-9]+\.[0-9]+/Using slack v$(RELEASE_VERSION)/" docs/guides/installing-the-slack-cli-for-windows.md
 	git add docs/guides/installing-the-slack-cli-for-mac-and-linux.md
 	git add docs/guides/installing-the-slack-cli-for-windows.md
 	git commit -m "chore: release slack-cli v$(RELEASE_VERSION)"

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,7 @@ build-snapshot: clean
 	BUILD_VERSION="$(BUILD_VERSION)" LDFLAGS="$(LDFLAGS)" goreleaser --snapshot --clean --skip=publish --config .goreleaser.yml
 
 # Update documentation in a commit tagged as the release
+# Usage: `make tag RELEASE_VERSION=3.7.0-example`
 .PHONY: tag
 tag:
 	git diff --quiet --cached

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,9 @@ RELEASE_VERSION := $(shell git describe --tags --match 'v*.*.*')
 testdir ?= ...
 testname ?= ./...
 
+FONT_BOLD := $(shell tput bold)
+FONT_RESET := $(shell tput sgr0)
+
 # Remove files
 .PHONY: clean
 clean:
@@ -80,15 +83,19 @@ tag:
 		echo "Error: Release version should not begin with a version prefix."; \
 		exit 1; \
 	fi
+	@printf "$(FONT_BOLD)Updating Docs$(FONT_RESET)\n"
 	sed -i.bak -E "s#slack_cli_[0-9]+\.[0-9]+\.[0-9]+_macOS_arm64\.tar\.gz#slack_cli_$(RELEASE_VERSION)_macOS_arm64.tar.gz#" docs/guides/installing-the-slack-cli-for-mac-and-linux.md
 	sed -i.bak -E "s#slack_cli_[0-9]+\.[0-9]+\.[0-9]+_macOS_amd64\.tar\.gz#slack_cli_$(RELEASE_VERSION)_macOS_amd64.tar.gz#" docs/guides/installing-the-slack-cli-for-mac-and-linux.md
 	sed -i.bak -E "s#slack_cli_[0-9]+\.[0-9]+\.[0-9]+_linux_64-bit\.tar\.gz#slack_cli_$(RELEASE_VERSION)_linux_64-bit.tar.gz#" docs/guides/installing-the-slack-cli-for-mac-and-linux.md
 	sed -i.bak -E "s#slack_cli_[0-9]+\.[0-9]+\.[0-9]+_windows_64-bit\.zip#slack_cli_$(RELEASE_VERSION)_windows_64-bit.zip#" docs/guides/installing-the-slack-cli-for-windows.md
 	sed -i.bak -E "s/Using slack v[0-9]+\.[0-9]+\.[0-9]+/Using slack v$(RELEASE_VERSION)/" docs/guides/installing-the-slack-cli-for-mac-and-linux.md
 	sed -i.bak -E "s/Using slack v[0-9]+\.[0-9]+\.[0-9]+/Using slack v$(RELEASE_VERSION)/" docs/guides/installing-the-slack-cli-for-windows.md
+	@printf "$(FONT_BOLD)Removing Backups$(FONT_RESET)\n"
 	rm docs/guides/installing-the-slack-cli-for-mac-and-linux.md.bak
 	rm docs/guides/installing-the-slack-cli-for-windows.md.bak
 	git add docs/guides/installing-the-slack-cli-for-mac-and-linux.md
 	git add docs/guides/installing-the-slack-cli-for-windows.md
+	@printf "$(FONT_BOLD)Git Commit$(FONT_RESET)\n"
 	git commit -m "chore: release slack-cli v$(RELEASE_VERSION)"
+	@printf "$(FONT_BOLD)Git Tag$(FONT_RESET)\n"
 	git tag v$(RELEASE_VERSION)


### PR DESCRIPTION
### Summary

This PR adds a `make tag` build command for tagging releases with updates to the docs happening in the commit being tagged 🏁 

### Preview

The ellipse output takes great inspiration from https://github.com/slackapi/slack-cli/pull/224 👾 ✨ 

```
$ make tag RELEASE_VERSION=3.7.0-example
...
git tag v3.7.0-example
```

````diff
diff --git a/docs/guides/installing-the-slack-cli-for-mac-and-linux.md b/docs/guides/installing-the-slack-cli-for-mac-and-linux.md
index 124d64f..a0f7d2e 100644
--- a/docs/guides/installing-the-slack-cli-for-mac-and-linux.md
+++ b/docs/guides/installing-the-slack-cli-for-mac-and-linux.md
@@ -99,11 +99,11 @@ Manual installation allows you to customize certain paths used when installing t
 
 **2\. Download the** `slack` **CLI installer for your environment.**
 
-🍎 ⚡️ [**Download for macOS Apple Silicon (.tar.gz)**](https://downloads.slack-edge.com/slack-cli/slack_cli_3.7.0_macOS_arm64.tar.gz)
+🍎 ⚡️ [**Download for macOS Apple Silicon (.tar.gz)**](https://downloads.slack-edge.com/slack-cli/slack_cli_3.7.0-example_macOS_arm64.tar.gz)
 
-🍏 🪨 [**Download for macOS Intel (.tar.gz)**](https://downloads.slack-edge.com/slack-cli/slack_cli_3.7.0_macOS_amd64.tar.gz)
+🍏 🪨 [**Download for macOS Intel (.tar.gz)**](https://downloads.slack-edge.com/slack-cli/slack_cli_3.7.0-example_macOS_amd64.tar.gz)
 
-🐧 💾 [**Download for Linux (.tar.gz)**](https://downloads.slack-edge.com/slack-cli/slack_cli_3.7.0_linux_64-bit.tar.gz)
+🐧 💾 [**Download for Linux (.tar.gz)**](https://downloads.slack-edge.com/slack-cli/slack_cli_3.7.0-example_linux_64-bit.tar.gz)
 
 **3\. Add the** `slack` **CLI to your path.**
 
@@ -121,7 +121,7 @@ We recommend using an alias if another `slack` binary exists. To do this, change
 
 ```sh
 $ slack version
-Using slack v3.7.0
+Using slack v3.7.0-example
 ```
 
 </TabItem>
diff --git a/docs/guides/installing-the-slack-cli-for-windows.md b/docs/guides/installing-the-slack-cli-for-windows.md
index cfec7b1..86911b6 100644
--- a/docs/guides/installing-the-slack-cli-for-windows.md
+++ b/docs/guides/installing-the-slack-cli-for-windows.md
@@ -88,7 +88,7 @@ Manual installation allows you to customize certain paths used when installing t
 
 **2\. Download the** `slack` **CLI installer for your environment.**
 
-<ts-icon class="ts_icon_windows"></ts-icon> &nbsp; <a href="https://downloads.slack-edge.com/slack-cli/slack_cli_3.7.0_windows_64-bit.zip"><strong>Windows (.zip)</strong></a>
+<ts-icon class="ts_icon_windows"></ts-icon> &nbsp; <a href="https://downloads.slack-edge.com/slack-cli/slack_cli_3.7.0-example_windows_64-bit.zip"><strong>Windows (.zip)</strong></a>
 
 **3\. Add the** `slack` **CLI to your path.**
 
@@ -104,7 +104,7 @@ We recommend using an alias if another `slack` binary exists. To do this, change
 
 ```pwsh
 $ slack version
-Using slack v3.7.0
+Using slack v3.7.0-example
 ```
 
 </TabItem>

````

### Reviewers

Please feel free to make a tag! But be warned that pushing such to the upstream might start a release process more 🌚 

```
$ make tag RELEASE_VERSION=1.2.3
...
$ git tag --delete v1.2.3  # Delete the tagged version
$ git rebase -i HEAD~2     # Remove the release commit
```

### Notes

- Planning to update runbooks elsewhere if this script is alright!
- The version prefix "v" causes an error if used with this script to avoid confusion around download links, but additional checks aren't included. Instead these might happen before pushing the tag upstream?

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).