### PR TITLE
build: run the docgen command with make tag release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ tag:
 		exit 1; \
 	fi
 	@printf "$(FONT_BOLD)Updating Docs$(FONT_RESET)\n"
-	./bin/slack docgen ./docs/reference
+	./bin/slack docgen ./docs/reference --skip-update
 	sed -i.bak -E "s#slack_cli_[0-9]+\.[0-9]+\.[0-9]+_macOS_arm64\.tar\.gz#slack_cli_$(RELEASE_VERSION)_macOS_arm64.tar.gz#" docs/guides/installing-the-slack-cli-for-mac-and-linux.md
 	sed -i.bak -E "s#slack_cli_[0-9]+\.[0-9]+\.[0-9]+_macOS_amd64\.tar\.gz#slack_cli_$(RELEASE_VERSION)_macOS_amd64.tar.gz#" docs/guides/installing-the-slack-cli-for-mac-and-linux.md
 	sed -i.bak -E "s#slack_cli_[0-9]+\.[0-9]+\.[0-9]+_linux_64-bit\.tar\.gz#slack_cli_$(RELEASE_VERSION)_linux_64-bit.tar.gz#" docs/guides/installing-the-slack-cli-for-mac-and-linux.md

--- a/Makefile
+++ b/Makefile
@@ -78,12 +78,13 @@ build-snapshot: clean
 .PHONY: tag
 tag:
 	git diff --quiet --cached
-	git diff --quiet docs/guides/installing-the-slack-cli-*.md
+	git diff --quiet
 	@if echo "$(RELEASE_VERSION)" | grep -q '^v'; then \
 		echo "Error: Release version should not begin with a version prefix."; \
 		exit 1; \
 	fi
 	@printf "$(FONT_BOLD)Updating Docs$(FONT_RESET)\n"
+	./bin/slack docgen ./docs/reference
 	sed -i.bak -E "s#slack_cli_[0-9]+\.[0-9]+\.[0-9]+_macOS_arm64\.tar\.gz#slack_cli_$(RELEASE_VERSION)_macOS_arm64.tar.gz#" docs/guides/installing-the-slack-cli-for-mac-and-linux.md
 	sed -i.bak -E "s#slack_cli_[0-9]+\.[0-9]+\.[0-9]+_macOS_amd64\.tar\.gz#slack_cli_$(RELEASE_VERSION)_macOS_amd64.tar.gz#" docs/guides/installing-the-slack-cli-for-mac-and-linux.md
 	sed -i.bak -E "s#slack_cli_[0-9]+\.[0-9]+\.[0-9]+_linux_64-bit\.tar\.gz#slack_cli_$(RELEASE_VERSION)_linux_64-bit.tar.gz#" docs/guides/installing-the-slack-cli-for-mac-and-linux.md
@@ -94,6 +95,7 @@ tag:
 	rm docs/guides/installing-the-slack-cli-for-mac-and-linux.md.bak
 	rm docs/guides/installing-the-slack-cli-for-windows.md.bak
 	@printf "$(FONT_BOLD)Git Add$(FONT_RESET)\n"
+	git add docs/reference
 	git add docs/guides/installing-the-slack-cli-for-mac-and-linux.md
 	git add docs/guides/installing-the-slack-cli-for-windows.md
 	@printf "$(FONT_BOLD)Git Commit$(FONT_RESET)\n"


### PR DESCRIPTION
### Summary

This PR follows up on #228 and adds the `docgen` command to the "make tag" release script. Might substitute #197?

### Preview

https://github.com/user-attachments/assets/f2a0c1c7-bfe7-4fad-8b85-127dffe3084d

### Reviewers

Please feel free to comment out the "diff" and  "commit" and "tag" steps for fast testing:

```diff
diff --git a/Makefile b/Makefile
index e6d9c24..dca25b0 100644
--- a/Makefile
+++ b/Makefile
@@ -77,8 +77,8 @@ build-snapshot: clean
 # Usage: `make tag RELEASE_VERSION=3.7.0-example`
 .PHONY: tag
 tag:
-	git diff --quiet --cached
-	git diff --quiet
+	# git diff --quiet --cached
+	# git diff --quiet
 	@if echo "$(RELEASE_VERSION)" | grep -q '^v'; then \
 		echo "Error: Release version should not begin with a version prefix."; \
 		exit 1; \
@@ -99,6 +99,6 @@ tag:
 	git add docs/guides/installing-the-slack-cli-for-mac-and-linux.md
 	git add docs/guides/installing-the-slack-cli-for-windows.md
 	@printf "$(FONT_BOLD)Git Commit$(FONT_RESET)\n"
-	git commit -m "chore: release slack-cli v$(RELEASE_VERSION)"
+	# git commit -m "chore: release slack-cli v$(RELEASE_VERSION)"
 	@printf "$(FONT_BOLD)Git Tag$(FONT_RESET)\n"
-	git tag v$(RELEASE_VERSION)
+	# git tag v$(RELEASE_VERSION)

```

Then confirm reference is regenerated and versions are updated as expected!

```
$ rm docs/reference/errors.md
$ rm docs/reference/commands/slack_app_list.md
$ git status
...
        modified:   Makefile
        deleted:    docs/reference/commands/slack_app_list.md
        deleted:    docs/reference/errors.md
... 
$ make tag RELEASE_VERSION=3.7.1
...
git tag v3.7.1
$ git status
On branch zimeg-build-release-docgen
Your branch is up to date with 'origin/zimeg-build-release-docgen'.

Changes to be committed:
  (use "git restore --staged <file>..." to unstage)
        modified:   docs/guides/installing-the-slack-cli-for-mac-and-linux.md
        modified:   docs/guides/installing-the-slack-cli-for-windows.md

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
        modified:   Makefile
```

### Notes

I'm still interested in the PR approach @lukegalbraithrussell shares in #197 in quest to automate more releases, but for now I think this'll match our current processes 👾 

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).