### PR TITLE
ci: automerge updates to dependencies after running tests

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -4,6 +4,31 @@ on:
     - cron: "0 0 * * *"
   workflow_dispatch:
 jobs:
+  dependabot:
+    name: "@dependabot"
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Collect metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@08eff52bf64351f401fb50d4972fa95b9f2c2d1b # v2.4.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Approve
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      - name: Automerge
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   golang:
     name: Bump the Golang version
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Summary

This PR automerges updates to dependencies matching patch or minor versions from the most kind @dependabot!

- https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#enabling-automerge-on-a-pull-request

### Reviewers

I'm so curious if this is the right scope of dependencies to merge? When merging these I often use CI passing as validation while keeping watch for CVEs appearing later.

This automation matches that in a workflow. Before releasing a version to the public we might confirm dependencies continue to match our expectations 🤖 🔐 ✨ 

### Notes

Some changes are required to configurations of repositories:

- **Allow auto-merge**: This must be allowed!
- **Branch protection**: "Require status checks to pass before merging" ought be true and include all relevant tests!
- **Branch protection**: "Require branches to be up to date before merging" might be true also.

Related reading: https://github.blog/changelog/2025-10-06-upcoming-changes-to-github-dependabot-pull-request-comment-commands/

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).