### PR TITLE
style: prefer formatting prints to mock output instead of writing string

### DIFF
--- a/internal/config/experiments_test.go
+++ b/internal/config/experiments_test.go
@@ -300,7 +300,7 @@ func Test_Config_GetExperiments(t *testing.T) {
 func setupMockPrintDebug() (*bytes.Buffer, func(context.Context, string, ...interface{})) {
 	mockOutput := &bytes.Buffer{}
 	mockPrintDebug := func(ctx context.Context, format string, a ...interface{}) {
-		mockOutput.WriteString(fmt.Sprintf(format, a))
+		fmt.Fprintf(mockOutput, format, a...)
 	}
 	return mockOutput, mockPrintDebug
 }


### PR DESCRIPTION
### Summary

This PR fixes a formatting issue on `main` to avoid build errors after updates to `golangci-lint` tooling:

```
golangci-lint run
internal/config/experiments_test.go:303:26: printf: missing ... in args forwarded to printf-like function (govet)
                mockOutput.WriteString(fmt.Sprintf(format, a))
                                       ^
1 issues:
* govet: 1
make: *** [Makefile:55: lint] Error 1
```

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).