### PR TITLE
feat: output logs from the apps.activities.list method if verbose is expected

### DIFF
--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -366,7 +366,7 @@ func (c *Client) SetHost(host string) {
 func shouldSkipDebugLog(endpoint string) bool {
 	// A list of API endpoints of which the requests/response won't be written into slack-debug-[date].log
 	var skipDebuglogEndpoints = []string{
-		"apps.activities.list",
+		// "apps.activities.list",
 		"apps.hosted.exchangeAuthTicket",
 		"apps.connections.open",
 	}


### PR DESCRIPTION
### Summary

This PR outputs verbose logs for the "[apps.activities.list](https://docs.slack.dev/reference/methods/apps.activities.list/)" command if the verbose flag is used for better insight into unexpected errors.

### Notes

Initial changes are being used to test in CI but I'm not sure if this is something we want to release? Perhaps this method was skipped to avoid cluttering debug logs during development.

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).