### PR TITLE
feat: update 'create' cmd section to 'AI Agent app'

### DIFF
--- a/cmd/project/create_template.go
+++ b/cmd/project/create_template.go
@@ -82,7 +82,7 @@ func getSelectionOptionsForCategory(clients *shared.ClientFactory) []promptObjec
 			Repository: "slack-cli#getting-started",
 		},
 		{
-			Title:      fmt.Sprintf("AI Agent apps %s", style.Secondary("Slack agents and assistants")),
+			Title:      fmt.Sprintf("AI Agent app %s", style.Secondary("Slack agents and assistants")),
 			Repository: "slack-cli#ai-apps",
 		},
 		{


### PR DESCRIPTION
### Changelog

> Updated the `slack create` command to display "AI Agent app" instead of "AI app" to align with Slack's new Agent app features.

### Summary

This pull request updates the `slack create` command's section from "AI app" to "Agentic AI app" to align with Slack's AI branding and the industry's general direction.

### Preview

<img width="762" height="570" alt="image" src="https://github.com/user-attachments/assets/1c1902da-0d27-45d3-9472-45a242d9bd4c" />

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).