### PR TITLE
fix: gather version for windows installation from latest releases metadata

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,35 +42,6 @@ jobs:
           files: ./coverage.out
           fail_ci_if_error: false
 
-  install:
-    name: Install
-    strategy:
-      matrix:
-        include:
-          - os: ubuntu-latest
-          - os: windows-latest
-    runs-on: ${{ matrix.os }}
-    permissions:
-      contents: read
-    steps:
-      - name: Checkout the latest changes
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-        with:
-          persist-credentials: false
-      - name: Attempt the installation (Unix)
-        if: runner.os == 'Linux'
-        shell: bash
-        run: |
-          set -euo pipefail
-          ./scripts/install.sh
-      - name: Attempt the installation (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          & ./scripts/install-windows.ps1
-      - name: Confirm the version exists
-        run: slack --version
-
   # Monitor code coverage and TODO/FIXME-type comments
   health-score:
     name: Health Score


### PR DESCRIPTION
### Summary

This PR gathers the latest version for Windows installations from the releases metadata now found at:

🔗 https://docs.slack.dev/tools/metadata.json

This fixes #296 which might've relied on multiple entries of releases beforehand 🤔

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).