### PR TITLE
fix: cleanup after checks for saved apps when opening "app settings" outside of a project

### DIFF
--- a/cmd/app/settings.go
+++ b/cmd/app/settings.go
@@ -101,6 +101,9 @@ func appSettingsCommandRunE(clients *shared.ClientFactory, cmd *cobra.Command, a
 	if err != nil {
 		// If no apps exist, open the list of all apps known to the developer
 		if slackerror.Is(err, slackerror.ErrInstallationRequired) {
+			// Clean up any empty .slack directory and files created during app selection
+			clients.AppClient().CleanUp()
+
 			host := clients.API().Host()
 			parsed, err := url.Parse(host)
 			if err != nil {


### PR DESCRIPTION
### Summary

This PR follows #314 to remove the temporary ".slack" directory made when the `app settings` command is run outside of a project directory.

### Reviewers

The example below shows expected behavior after this change:

```
$ cd /tmp
$ slack app settings

🏠 App Settings
   https://api.slack.com/apps

$ ls .slack
".slack": No such file or directory (os error 2)
```

### Requirements

* [x] I've read and understood the [Contributing Guidelines](/blob/main/.github/contributing.md) and have done my best effort to follow them.
* [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).