### PR TITLE
tests(charm): adds tests to charm experiment

### DIFF
--- a/internal/iostreams/charm.go
+++ b/internal/iostreams/charm.go
@@ -22,6 +22,7 @@ import (
 	"slices"
 
 	"github.com/charmbracelet/huh"
+	"github.com/slackapi/slack-cli/internal/style"
 )
 
 // buildInputForm constructs a huh form for text input prompts.
@@ -32,7 +33,7 @@ func buildInputForm(message string, cfg InputPromptConfig, input *string) *huh.F
 	if cfg.Required {
 		field.Validate(huh.ValidateMinLength(1))
 	}
-	return huh.NewForm(huh.NewGroup(field)).WithTheme(ThemeSlack())
+	return huh.NewForm(huh.NewGroup(field)).WithTheme(style.ThemeSlack())
 }
 
 // charmInputPrompt prompts for text input using a charm huh form
@@ -50,7 +51,7 @@ func buildConfirmForm(message string, choice *bool) *huh.Form {
 	field := huh.NewConfirm().
 		Title(message).
 		Value(choice)
-	return huh.NewForm(huh.NewGroup(field)).WithTheme(ThemeSlack())
+	return huh.NewForm(huh.NewGroup(field)).WithTheme(style.ThemeSlack())
 }
 
 // charmConfirmPrompt prompts for a yes/no confirmation using a charm huh form
@@ -85,7 +86,7 @@ func buildSelectForm(msg string, options []string, cfg SelectPromptConfig, selec
 		field.Height(cfg.PageSize + 2)
 	}
 
-	return huh.NewForm(huh.NewGroup(field)).WithTheme(ThemeSlack())
+	return huh.NewForm(huh.NewGroup(field)).WithTheme(style.ThemeSlack())
 }
 
 // charmSelectPrompt prompts the user to select one option using a charm huh form
@@ -109,7 +110,7 @@ func buildPasswordForm(message string, cfg PasswordPromptConfig, input *string) 
 	if cfg.Required {
 		field.Validate(huh.ValidateMinLength(1))
 	}
-	return huh.NewForm(huh.NewGroup(field)).WithTheme(ThemeSlack())
+	return huh.NewForm(huh.NewGroup(field)).WithTheme(style.ThemeSlack())
 }
 
 // charmPasswordPrompt prompts for a password (hidden input) using a charm huh form
@@ -134,7 +135,7 @@ func buildMultiSelectForm(message string, options []string, selected *[]string) 
 		Options(opts...).
 		Value(selected)
 
-	return huh.NewForm(huh.NewGroup(field)).WithTheme(ThemeSlack())
+	return huh.NewForm(huh.NewGroup(field)).WithTheme(style.ThemeSlack())
 }
 
 // charmMultiSelectPrompt prompts the user to select multiple options using a charm huh form

--- a/internal/iostreams/charm_test.go
+++ b/internal/iostreams/charm_test.go
@@ -121,7 +121,7 @@ func TestCharmSelect(t *testing.T) {
 		f.Update(f.Init())
 
 		view := ansi.Strip(f.View())
-		assert.Contains(t, view, "> Foo")
+		assert.Contains(t, view, "❱ Foo")
 	})
 
 	t.Run("cursor navigation moves selection", func(t *testing.T) {
@@ -132,8 +132,8 @@ func TestCharmSelect(t *testing.T) {
 
 		m, _ := f.Update(tea.KeyMsg{Type: tea.KeyDown})
 		view := ansi.Strip(m.View())
-		assert.Contains(t, view, "> Bar")
-		assert.False(t, strings.Contains(view, "> Foo"))
+		assert.Contains(t, view, "❱ Bar")
+		assert.False(t, strings.Contains(view, "❱ Foo"))
 	})
 
 	t.Run("submit selects the hovered option", func(t *testing.T) {
@@ -280,7 +280,7 @@ func TestCharmFormsUseSlackTheme(t *testing.T) {
 		f.Update(f.Init())
 
 		view := ansi.Strip(f.View())
-		assert.Contains(t, view, "> A")
+		assert.Contains(t, view, "❱ A")
 	})
 
 	t.Run("multi-select form renders themed prefixes", func(t *testing.T) {

--- a/internal/style/charm_theme.go
+++ b/internal/style/charm_theme.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package iostreams
+package style
 
 // Slack brand theme for charmbracelet/huh prompts.
 // Uses official Slack brand colors to give the CLI a fun, playful feel.

--- a/internal/style/charm_theme_test.go
+++ b/internal/style/charm_theme_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package iostreams
+package style
 
 import (
 	"testing"
@@ -34,13 +34,13 @@ func TestThemeSlack(t *testing.T) {
 
 	t.Run("focused title uses aubergine foreground", func(t *testing.T) {
 		theme := ThemeSlack()
-		assert.Equal(t, lipgloss.Color("#4a154b"), theme.Focused.Title.GetForeground())
+		assert.Equal(t, lipgloss.Color("#7C2852"), theme.Focused.Title.GetForeground())
 	})
 
 	t.Run("focused select selector renders cursor", func(t *testing.T) {
 		theme := ThemeSlack()
 		rendered := theme.Focused.SelectSelector.Render()
-		assert.Contains(t, rendered, ">")
+		assert.Contains(t, rendered, "❱")
 	})
 
 	t.Run("focused multi-select selected prefix renders checkmark", func(t *testing.T) {
@@ -62,7 +62,7 @@ func TestThemeSlack(t *testing.T) {
 
 	t.Run("focused button uses aubergine background", func(t *testing.T) {
 		theme := ThemeSlack()
-		assert.Equal(t, lipgloss.Color("#4a154b"), theme.Focused.FocusedButton.GetBackground())
+		assert.Equal(t, lipgloss.Color("#7C2852"), theme.Focused.FocusedButton.GetBackground())
 	})
 
 	t.Run("focused button is bold", func(t *testing.T) {
@@ -74,14 +74,14 @@ func TestThemeSlack(t *testing.T) {
 		theme := ThemeSlack()
 		rendered := theme.Blurred.SelectSelector.Render()
 		assert.Contains(t, rendered, "  ")
-		assert.NotContains(t, rendered, ">")
+		assert.NotContains(t, rendered, "❱")
 	})
 
 	t.Run("blurred multi-select selector is blank", func(t *testing.T) {
 		theme := ThemeSlack()
 		rendered := theme.Blurred.MultiSelectSelector.Render()
 		assert.Contains(t, rendered, "  ")
-		assert.NotContains(t, rendered, ">")
+		assert.NotContains(t, rendered, "❱")
 	})
 
 	t.Run("blurred border is hidden", func(t *testing.T) {
@@ -90,9 +90,9 @@ func TestThemeSlack(t *testing.T) {
 		assert.Equal(t, lipgloss.HiddenBorder(), borderStyle)
 	})
 
-	t.Run("focused border uses bright aubergine", func(t *testing.T) {
+	t.Run("focused border uses aubergine", func(t *testing.T) {
 		theme := ThemeSlack()
-		assert.Equal(t, lipgloss.Color("#611f69"), theme.Focused.Base.GetBorderLeftForeground())
+		assert.Equal(t, lipgloss.Color("#7C2852"), theme.Focused.Base.GetBorderLeftForeground())
 	})
 
 	t.Run("focused text input prompt uses blue", func(t *testing.T) {


### PR DESCRIPTION
### Changelog

 Added unit tests for charm prompt implementations and Slack brand theme 🦋 

### Summary

This PR adds unit tests for all 5 charm/huh prompt types (input, confirm, select, password, multi-select) and the Slack brand theme. It refactors charm prompt functions to extract `buildXxxForm` builders, separating form construction from execution to enable programmatic testing via huh's `Update`/`View` API   

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-cli/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
