### PR TITLE
feat: default manifest source to manifest.json for Bolt Framework projects

### DIFF
--- a/cmd/project/init.go
+++ b/cmd/project/init.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 
 	"github.com/slackapi/slack-cli/cmd/app"
-	"github.com/slackapi/slack-cli/internal/config"
 	"github.com/slackapi/slack-cli/internal/pkg/create"
 	"github.com/slackapi/slack-cli/internal/shared"
 	"github.com/slackapi/slack-cli/internal/shared/types"
@@ -108,7 +107,7 @@ func projectInitCommandRunE(clients *shared.ClientFactory, cmd *cobra.Command, a
 
 	// Install the project dependencies, such as .slack/ and runtime packages
 	// Existing projects initialized always default to config.ManifestSourceLocal.
-	_ = create.InstallProjectDependencies(ctx, clients, projectDirPath, config.ManifestSourceLocal)
+	_ = create.InstallProjectDependencies(ctx, clients, projectDirPath)
 
 	// Add an existing app to the project
 	err = app.LinkExistingApp(ctx, clients, &types.App{}, true)

--- a/cmd/project/init_test.go
+++ b/cmd/project/init_test.go
@@ -72,7 +72,7 @@ func Test_Project_InitCommand(t *testing.T) {
 				require.Contains(t, output, "Added "+filepath.Join("project-name", ".slack"))
 				require.Contains(t, output, "Added "+filepath.Join("project-name", ".slack", ".gitignore"))
 				require.Contains(t, output, "Added "+filepath.Join("project-name", ".slack", "hooks.json"))
-				require.Contains(t, output, `Updated config.json manifest source to "project" (local)`)
+				require.Contains(t, output, `Updated app manifest source to "project" (local)`)
 				// Assert prompt to add existing apps was called
 				cm.IO.AssertCalled(
 					t,

--- a/internal/pkg/create/create.go
+++ b/internal/pkg/create/create.go
@@ -156,7 +156,7 @@ func Create(ctx context.Context, clients *shared.ClientFactory, createArgs Creat
 
 	// Install project dependencies to add CLI support and cache dev dependencies.
 	// CLI created projects always default to config.ManifestSourceLocal.
-	InstallProjectDependencies(ctx, clients, projectDirPath, config.ManifestSourceLocal)
+	InstallProjectDependencies(ctx, clients, projectDirPath)
 	clients.IO.PrintTrace(ctx, slacktrace.CreateDependenciesSuccess)
 
 	return appDirPath, nil
@@ -413,7 +413,6 @@ func InstallProjectDependencies(
 	ctx context.Context,
 	clients *shared.ClientFactory,
 	projectDirPath string,
-	manifestSource config.ManifestSource,
 ) []string {
 	var outputs []string
 
@@ -516,30 +515,20 @@ func InstallProjectDependencies(
 		}
 	}
 
-	// Default manifest source to ManifestSourceLocal
-	if !manifestSource.Exists() {
-		manifestSource = config.ManifestSourceLocal
-	}
-
-	// Set non-Deno (non-ROSI) projects to ManifestSourceLocal.
-	// TODO: should check if Slack hosted project, but the SDKConfig has not been initialized yet.
-	if clients.Runtime != nil {
-		isDenoProject := strings.Contains(strings.ToLower(clients.Runtime.Name()), "deno")
-		if !isDenoProject {
-			manifestSource = config.ManifestSourceLocal
-		}
+	// Get the manifest source from the project-level config
+	manifestSource, err := clients.Config.ProjectConfig.GetManifestSource(ctx)
+	if err != nil {
+		clients.IO.PrintDebug(ctx, "Error getting manifest source: %s", err)
 	}
 
 	// Set "manifest.source" in .slack/config.json
 	if err := config.SetManifestSource(ctx, clients.Fs, clients.Os, manifestSource); err != nil {
 		clients.IO.PrintDebug(ctx, "Error setting manifest source in project-level config: %s", err)
 	} else {
-		configJSONFilename := config.ProjectConfigJSONFilename
 		manifestSourceStyled := style.Highlight(manifestSource.Human())
 
 		outputs = append(outputs, fmt.Sprintf(
-			"Updated %s manifest source to %s",
-			configJSONFilename,
+			"Updated app manifest source to %s",
 			manifestSourceStyled,
 		))
 	}

--- a/internal/pkg/create/create_test.go
+++ b/internal/pkg/create/create_test.go
@@ -366,6 +366,7 @@ func Test_Create_installProjectDependencies(t *testing.T) {
 		experiments            []string
 		runtime                string
 		manifestSource         config.ManifestSource
+		expectedManifestSource config.ManifestSource
 		existingFiles          map[string]string
 		expectedOutputs        []string
 		unexpectedOutputs      []string
@@ -418,24 +419,38 @@ func Test_Create_installProjectDependencies(t *testing.T) {
 		},
 		"When no manifest source, default to project (local)": {
 			expectedOutputs: []string{
-				`Updated config.json manifest source to "project" (local)`,
+				`Updated app manifest source to "project" (local)`,
 			},
 		},
-		"When manifest source is provided, should set it": {
-			manifestSource: config.ManifestSourceRemote,
+		"When remote manifest source is provided, should use it": {
+			manifestSource:         config.ManifestSourceRemote,
+			expectedManifestSource: config.ManifestSourceRemote,
+			existingFiles: map[string]string{
+				".slack/hooks.json": "{}",
+			},
 			expectedOutputs: []string{
-				`Updated config.json manifest source to "app settings" (remote)`,
+				`Updated app manifest source to "app settings" (remote)`,
+			},
+		},
+		"When local manifest source is provided, should use it": {
+			manifestSource:         config.ManifestSourceLocal,
+			expectedManifestSource: config.ManifestSourceLocal,
+			existingFiles: map[string]string{
+				".slack/hooks.json": "{}",
+			},
+			expectedOutputs: []string{
+				`Updated app manifest source to "project" (local)`,
 			},
 		},
 		"When Deno project, should set manifest source to project (local)": {
 			expectedOutputs: []string{
-				`Updated config.json manifest source to "project" (local)`,
+				`Updated app manifest source to "project" (local)`,
 			},
 		},
 		"When non-Deno project, should set manifest source to project (local)": {
 			runtime: "node",
 			expectedOutputs: []string{
-				`Updated config.json manifest source to "project" (local)`,
+				`Updated app manifest source to "project" (local)`,
 			},
 		},
 	}
@@ -490,8 +505,15 @@ func Test_Create_installProjectDependencies(t *testing.T) {
 				}
 			}
 
+			// Set manifest source
+			if tc.manifestSource != "" {
+				if err := config.SetManifestSource(ctx, clientsMock.Fs, clientsMock.Os, tc.manifestSource); err != nil {
+					require.FailNow(t, fmt.Sprintf("Failed to set the manifest source in the memory-based file system: %s", err))
+				}
+			}
+
 			// Run the test
-			outputs := InstallProjectDependencies(ctx, clients, projectDirPath, tc.manifestSource)
+			outputs := InstallProjectDependencies(ctx, clients, projectDirPath)
 
 			// Assertions
 			for _, expectedOutput := range tc.expectedOutputs {
@@ -502,6 +524,13 @@ func Test_Create_installProjectDependencies(t *testing.T) {
 			}
 			for _, expectedVerboseOutput := range tc.expectedVerboseOutputs {
 				clientsMock.IO.AssertCalled(t, "PrintDebug", mock.Anything, expectedVerboseOutput, tc.expectedVerboseArgs)
+			}
+			if tc.expectedManifestSource != "" {
+				actualManifestSource, err := clients.Config.ProjectConfig.GetManifestSource(ctx)
+				if err != nil {
+					require.FailNow(t, fmt.Sprintf("Failed to get the manifest source: %s", err))
+				}
+				assert.Equal(t, tc.expectedManifestSource, actualManifestSource)
 			}
 			assert.NotEmpty(t, clients.Config.ProjectID, "config.project_id")
 			// output := clientsMock.GetCombinedOutput()


### PR DESCRIPTION
### Changelog

> Bolt JavaScript and Bolt Python projects now default to using the local `manifest.json` as the app manifest.
> - Previously, it was a remote manifest from App Settings (https://api.slack.com/apps).
> - Changes to the app manifest on App Settings will be detected by the Slack CLI and a prompt will be displayed before any manifest update action (e.g. `slack run`).
> - The manifest source is set after creating a new project with `slack create` or initializing an existing project with `slack init` and the setting is stored as `"manifest.source": "local"` in `.slack/config.json`.

### Summary

This pull request defaults Bolt Framework projects to use a `manifest.source: "local"` when creating and initializing a project.

**Reason behind the change:** We're making this change after receiving feedback from multiple developers who are confused by the `remote` setting and would prefer `local` for Bolt projects. The rationale is that developers using the CLI would prefer to default to managing the manifest with the CLI/Project.

Related #396 that will update `app link` to not change the manifest source.

### Open Question

- Is this considered `feat: enhancement` or `fix: bug fix`? 

### Preview

https://github.com/user-attachments/assets/2cea0cc1-0f4c-4e56-afa5-29e3d0f9b3b3

### Test Steps

**Test Creating a Bolt Framework Project:**

```bash
# Create a new Bolt Project
$ lack create my-app -t https://github.com/slack-samples/bolt-js-starter-template
$ cd my-app/

# Confirm local manifest
$ cat .slack/config.json
# → Confirm manifest.source: "local"

# Create and run the app
$ lack run
# → Press CTRL+C to stop the server

# Change Something on App Setting to Introduce a Conflict
$ lack app settings
# → Change App Name
# → Set Description and Background Color
# → Save

# Test Manifest Change Warning
$ lack run
# → Confirm warning that manifest is out-of-sync
# → Select Y

# Clean up
$ lack delete -f
$ cd ..
$ rm -rf my-app
```

**Test Initializing a Bolt Framework Project:**

```bash
# Clone a Bolt Framework Project
$ git clone https://github.com/slack-samples/bolt-js-starter-template.git
$ cd bolt-js-starter-template/

# Initialize it
$ lack init

# Confirm local manifest
$ cat .slack/config.json
# → Confirm manifest.source: "local"

# Clean up
$ cd ..
$ rm -rf bolt-js-starter-template/
```

**Test a Deno Project:**

```bash
# Create a new Deno Project
$ lack create my-app -t https://github.com/slack-samples/deno-starter-template
$ cd my-app/

# Confirm local manifest
$ cat .slack/config.json
# → Confirm manifest.source: "local"

# Clean up
$ cd ..
$ rm -rf my-app
```

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-cli/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
