### PR TITLE
chore: release slack-cli v3.15.0

### DIFF
--- a/docs/guides/installing-the-slack-cli-for-mac-and-linux.md
+++ b/docs/guides/installing-the-slack-cli-for-mac-and-linux.md
@@ -99,11 +99,11 @@ Manual installation allows you to customize certain paths used when installing t
 
 **2\. Download the** `slack` **CLI installer for your environment.**
 
-🍎 ⚡️ [**Download for macOS Apple Silicon (.tar.gz)**](https://downloads.slack-edge.com/slack-cli/slack_cli_3.14.0_macOS_arm64.tar.gz)
+🍎 ⚡️ [**Download for macOS Apple Silicon (.tar.gz)**](https://downloads.slack-edge.com/slack-cli/slack_cli_3.15.0_macOS_arm64.tar.gz)
 
-🍏 🪨 [**Download for macOS Intel (.tar.gz)**](https://downloads.slack-edge.com/slack-cli/slack_cli_3.14.0_macOS_amd64.tar.gz)
+🍏 🪨 [**Download for macOS Intel (.tar.gz)**](https://downloads.slack-edge.com/slack-cli/slack_cli_3.15.0_macOS_amd64.tar.gz)
 
-🐧 💾 [**Download for Linux (.tar.gz)**](https://downloads.slack-edge.com/slack-cli/slack_cli_3.14.0_linux_64-bit.tar.gz)
+🐧 💾 [**Download for Linux (.tar.gz)**](https://downloads.slack-edge.com/slack-cli/slack_cli_3.15.0_linux_64-bit.tar.gz)
 
 **3\. Add the** `slack` **CLI to your path.**
 
@@ -121,7 +121,7 @@ We recommend using an alias if another `slack` binary exists. To do this, change
 
 ```sh
 $ slack version
-Using slack v3.14.0
+Using slack v3.15.0
 ```
 
 </TabItem>

--- a/docs/guides/installing-the-slack-cli-for-windows.md
+++ b/docs/guides/installing-the-slack-cli-for-windows.md
@@ -88,7 +88,7 @@ Manual installation allows you to customize certain paths used when installing t
 
 **2\. Download the** `slack` **CLI installer for your environment.**
 
-<ts-icon class="ts_icon_windows"></ts-icon> &nbsp; <a href="https://downloads.slack-edge.com/slack-cli/slack_cli_3.14.0_windows_64-bit.zip"><strong>Windows (.zip)</strong></a>
+<ts-icon class="ts_icon_windows"></ts-icon> &nbsp; <a href="https://downloads.slack-edge.com/slack-cli/slack_cli_3.15.0_windows_64-bit.zip"><strong>Windows (.zip)</strong></a>
 
 **3\. Add the** `slack` **CLI to your path.**
 
@@ -104,7 +104,7 @@ We recommend using an alias if another `slack` binary exists. To do this, change
 
 ```pwsh
 $ slack version
-Using slack v3.14.0
+Using slack v3.15.0
 ```
 
 </TabItem>

--- a/docs/reference/commands/slack.md
+++ b/docs/reference/commands/slack.md
@@ -64,6 +64,7 @@ $ slack docs    # Open Slack developer docs
 * [slack project](slack_project)	 - Create, manage, and doctor a project
 * [slack run](slack_run)	 - Start a local server to develop and run the app locally
 * [slack samples](slack_samples)	 - List available sample apps
+* [slack sandbox](slack_sandbox)	 - Manage developer sandboxes
 * [slack trigger](slack_trigger)	 - List details of existing triggers
 * [slack uninstall](slack_uninstall)	 - Uninstall the app from a team
 * [slack upgrade](slack_upgrade)	 - Checks for available updates to the CLI or SDK

--- a/docs/reference/commands/slack_sandbox.md
+++ b/docs/reference/commands/slack_sandbox.md
@@ -1,0 +1,44 @@
+# `slack sandbox`
+
+Manage developer sandboxes
+
+## Description
+
+Manage Slack developer sandboxes without leaving your terminal.
+Use the --team flag to select the authentication to use for these commands.
+
+Prefer a UI? Head over to
+[https://api.slack.com/developer-program/sandboxes](https://api.slack.com/developer-program/sandboxes)
+
+New to the Developer Program? Sign up at
+[https://api.slack.com/developer-program/join](https://api.slack.com/developer-program/join)
+
+```
+slack sandbox <subcommand> [flags] --experiment=sandboxes
+```
+
+## Flags
+
+```
+  -h, --help   help for sandbox
+```
+
+## Global flags
+
+```
+  -a, --app string           use a specific app ID or environment
+      --config-dir string    use a custom path for system config directory
+  -e, --experiment strings   use the experiment(s) in the command
+  -f, --force                ignore warnings and continue executing command
+      --no-color             remove styles and formatting from outputs
+  -s, --skip-update          skip checking for latest version of CLI
+  -w, --team string          select workspace or organization by team name or ID
+      --token string         set the access token associated with a team
+  -v, --verbose              print debug logging and additional info
+```
+
+## See also
+
+* [slack](slack)	 - Slack command-line tool
+* [slack sandbox list](slack_sandbox_list)	 - List developer sandboxes
+

--- a/docs/reference/commands/slack_sandbox_list.md
+++ b/docs/reference/commands/slack_sandbox_list.md
@@ -1,0 +1,47 @@
+# `slack sandbox list`
+
+List developer sandboxes
+
+## Description
+
+List details about your developer sandboxes.
+
+The listed developer sandboxes belong to a developer program account
+that matches the email address of the authenticated user.
+
+```
+slack sandbox list [flags]
+```
+
+## Flags
+
+```
+  -h, --help            help for list
+      --status string   Filter by status: active, archived
+```
+
+## Global flags
+
+```
+  -a, --app string           use a specific app ID or environment
+      --config-dir string    use a custom path for system config directory
+  -e, --experiment strings   use the experiment(s) in the command
+  -f, --force                ignore warnings and continue executing command
+      --no-color             remove styles and formatting from outputs
+  -s, --skip-update          skip checking for latest version of CLI
+  -w, --team string          select workspace or organization by team name or ID
+      --token string         set the access token associated with a team
+  -v, --verbose              print debug logging and additional info
+```
+
+## Examples
+
+```
+$ slack sandbox list                  # List developer sandboxes
+$ slack sandbox list --status active  # List active sandboxes only
+```
+
+## See also
+
+* [slack sandbox](slack_sandbox)	 - Manage developer sandboxes
+


### PR DESCRIPTION
### Changelog

- N/A

### Summary

This pull request updates the documentation for release `v3.15.0`.

We've disabled tagging when running `make tag` to fix an issue with orphaned tagged commits. We'll continue to rework this in the future.

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-cli/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
