### PR TITLE
fix: run command shows all workspaces option first in org grant prompt

### DIFF
--- a/cmd/platform/run.go
+++ b/cmd/platform/run.go
@@ -125,7 +125,7 @@ func RunRunCommand(clients *shared.ClientFactory, cmd *cobra.Command, args []str
 		}
 	}
 
-	runFlags.orgGrantWorkspaceID, err = prompts.ValidateGetOrgWorkspaceGrant(ctx, clients, &selection, runFlags.orgGrantWorkspaceID, false /* top prompt option should be 'all workspaces' */)
+	runFlags.orgGrantWorkspaceID, err = prompts.ValidateGetOrgWorkspaceGrant(ctx, clients, &selection, runFlags.orgGrantWorkspaceID, true /* top prompt option should be 'all workspaces' */)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### Changelog

> Fix `slack run` for Enterprise Organizations to always show "All workspaces" as the first option when prompted to choose whether to grant to all workspaces or a specific workspace. This reduces friction and streamlines the development experience for developers.

### Summary

This pull request updates the `slack run` command to be consistent with `slack deploy` by displaying "All workspaces" as the first option when prompted to grant to either all workspaces or a specific workspace.

Unfortunately, testing this is non-trivial in this area of the code. So, we'll have to go without tests for now.

### Preview

**Run Command:**

<details>
<summary>Before</summary>

<img width="762" height="574" alt="image" src="https://github.com/user-attachments/assets/43e05f30-51d1-4ac6-8ca9-c1b06a091e86" />

</details>

After:

<img width="762" height="574" alt="image" src="https://github.com/user-attachments/assets/05b8b56c-5e8e-4214-ac78-5428ef3ed894" />

**Deploy Command:**

<img width="762" height="574" alt="image" src="https://github.com/user-attachments/assets/86db682c-3115-40c4-b808-78369799695a" />

### Test Steps

```bash
# Create a Deno Project because it supports Deploy and Run
$ slack create my-app -t https://github.com/slack-samples/deno-starter-template
$ cd my-app/

# Test Deploy
$ slack deploy
# → Select Enterprise Org
# → Confirm Grant Prompt shows "All" first
# CTRL+C

# Test Run
$ slack run
# → Select Enterprise Org
# → Confirm Grant Prompt shows "All" first
# CTRL+C

# Cleanup
$ lack delete -f
$ lack delete -f
$ cd ../
$ rm -rf my-app
```

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-cli/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
