### PR TITLE
feat: add User-Agent header to API request debug output

### DIFF
--- a/internal/api/debug.go
+++ b/internal/api/debug.go
@@ -42,6 +42,8 @@ func (c *Client) printRequest(ctx context.Context, req *http.Request, skipDebugL
 	var output string
 	// HTTP Request
 	outputLines = append(outputLines, fmt.Sprintf("HTTP Request: %v %v %v", req.Method, req.URL, req.Proto))
+	// HTTP User-Agent
+	outputLines = append(outputLines, fmt.Sprintf("HTTP Request User-Agent: %s", req.Header.Get("User-Agent")))
 	// HTTP Body
 	outputLines = append(outputLines, fmt.Sprintf("HTTP Request Body:\n%s", reqBody))
 	output = strings.Join(outputLines, "\n")

--- a/internal/api/debug_test.go
+++ b/internal/api/debug_test.go
@@ -15,12 +15,63 @@
 package api
 
 import (
+	"fmt"
+	"net/http"
 	"os"
 	"testing"
 
+	"github.com/slackapi/slack-cli/internal/config"
 	"github.com/slackapi/slack-cli/internal/goutils"
+	"github.com/slackapi/slack-cli/internal/iostreams"
+	"github.com/slackapi/slack-cli/internal/slackcontext"
+	"github.com/slackapi/slack-cli/internal/slackdeps"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
+
+func Test_printRequest(t *testing.T) {
+	tests := map[string]struct {
+		userAgent string
+		expected  string
+	}{
+		"includes User-Agent header in output": {
+			userAgent: "slack-cli/v1.2.3 (os: darwin)",
+			expected:  "HTTP Request User-Agent: slack-cli/v1.2.3 (os: darwin)",
+		},
+		"includes empty User-Agent when header is not set": {
+			userAgent: "",
+			expected:  "HTTP Request User-Agent: ",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx := slackcontext.MockContext(t.Context())
+			fs := slackdeps.NewFsMock()
+			osMock := slackdeps.NewOsMock()
+			osMock.AddDefaultMocks()
+			cfg := config.NewConfig(fs, osMock)
+			cfg.DebugEnabled = true
+			ioMock := iostreams.NewIOStreamsMock(cfg, fs, osMock)
+			ioMock.On("PrintDebug", mock.Anything, mock.Anything, mock.MatchedBy(func(args ...any) bool { return true }))
+
+			c := &Client{io: ioMock}
+			req, _ := http.NewRequest("GET", "https://slack.com/api/test", nil)
+			if tc.userAgent != "" {
+				req.Header.Set("User-Agent", tc.userAgent)
+			}
+
+			c.printRequest(ctx, req, false)
+
+			var output string
+			for _, call := range ioMock.Calls {
+				if call.Method == "PrintDebug" {
+					output = fmt.Sprintf(call.Arguments[1].(string), call.Arguments[2].([]any)...)
+				}
+			}
+			require.Contains(t, output, tc.expected)
+		})
+	}
+}
 
 func Test_RedactPII(t *testing.T) {
 	home, _ := os.UserHomeDir()


### PR DESCRIPTION
### Changelog

> When a command runs with the verbose flag (`--verbose`) and makes an HTTP request, then the output now includes the HTTP Header's User-Agent.
> ```
> [2026-03-23 16:30:30] HTTP Request User-Agent: slack-cli/v3.15.0 (os: darwin)
> ```

### Summary

This pull request outputs the HTTP Request's User-Agent in the `--verbose` debug logs.

The motivation is to improve manual testing that requires confirming that the user-agent is set correctly and enrich our log data with more information. Currently, we output the Request URL and Body, so this was a minor addition.

### Test Steps

```bash
$ ./bin/slack auth login --verbose 2>&1 | grep 'User-Agent'
# → Expect: HTTP Request User-Agent: slack-cli/v3.15.0 (os: darwin)
# CTRL+C
```

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-cli/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
