### PR TITLE
fix(install): show windows alias step after installer is downloaded if overwrites were avoided

### DIFF
--- a/scripts/install-windows-dev.ps1
+++ b/scripts/install-windows-dev.ps1
@@ -66,7 +66,8 @@ function check_slack_binary_exist() {
         Write-Host "Halting the install to avoid accidentally overwriting it."
 
         Write-Host "`nTry using an alias when installing to avoid name conflicts:"
-        Write-Host "`nirm https://downloads.slack-edge.com/slack-cli/install-windows.ps1 -Alias your-preferred-alias | iex"
+        Write-Host "`nInvoke-WebRequest -Uri https://downloads.slack-edge.com/slack-cli/install-windows.ps1 -OutFile 'install-windows.ps1'"
+        Write-Host ".\install-windows.ps1 -Alias your-preferred-alias"
         throw
       }
     }

--- a/scripts/install-windows.ps1
+++ b/scripts/install-windows.ps1
@@ -63,7 +63,8 @@ function check_slack_binary_exist() {
         Write-Host "Halting the install to avoid accidentally overwriting it."
 
         Write-Host "`nTry using an alias when installing to avoid name conflicts:"
-        Write-Host "`nirm https://downloads.slack-edge.com/slack-cli/install-windows.ps1 -Alias your-preferred-alias | iex"
+        Write-Host "`nInvoke-WebRequest -Uri https://downloads.slack-edge.com/slack-cli/install-windows.ps1 -OutFile 'install-windows.ps1'"
+        Write-Host ".\install-windows.ps1 -Alias your-preferred-alias"
         throw
       }
     }


### PR DESCRIPTION
### Changelog

> The Windows installer now suggests providing an optional alias as a separate step from downloading the installer if overwrites earlier were avoided but still caused that installation to fail.

### Summary

This PR updates the Windows installation scripts to show alias recommendations after the installer is downloaded if overwrites were avoided.

Fixes an issue where flags weren't parsed in the initial request - Thanks @amarinelli for the note! 🐛 ✨

### Preview

These changes appear afterward:

<img width="1114" height="714" alt="demo" src="https://github.com/user-attachments/assets/b5ddd079-39c8-41d8-908c-9f28ab79d8bc" />

### Reviewers

Overwrite previous installs for the session and test this branch:

```pwsh
> Set-Alias slack cat
> .\scripts\install-windows.ps1
```

### Notes

📚 https://docs.slack.dev/tools/slack-cli/guides/installing-the-slack-cli-for-windows

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-cli/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
