### PR TITLE
docs(maintainers): style guide adds help arguments use opinionated brackets

### DIFF
--- a/.github/STYLE_GUIDE.md
+++ b/.github/STYLE_GUIDE.md
@@ -27,14 +27,28 @@ Results of a command go toward informing current happenings and suggesting next 
 
 ### Help Arguments use Opinionated Brackets
 
-The brackets surrounding command arguments hint that these are optional:
+The square brackets surrounding command arguments hint that these are optional:
 
 ```
 USAGE
   $ slack env add [name] [value] [flags]
 ```
 
-This example has meaningful arguments and forms as fallback. Angle brackets would surround required values.
+The angled brackets around arguments hint that these are required:
+
+```
+USAGE
+  $ slack <command>
+```
+
+Optional and required arguments can be mixed-and-matched:
+
+```
+USAGE
+  $ slack <command> [args] [flags]
+```
+
+These examples have meaningful argument placeholders and sometimes forms as fallback.
 
 ### Help Descriptions find Complete Sentences
 


### PR DESCRIPTION
### Changelog

> N/A - But more to follow!

### Summary

This PR adds a section to the style guide for `help` arguments use opinionated brackets. This follows earlier discussion and matches common patterns with form fallbacks. A note of required arguments is kept.

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-cli/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
