### PR TITLE
build: regenerate reference docs from nothing for each release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,7 @@ tag:
 		exit 1; \
 	fi
 	@printf "$(FONT_BOLD)Updating Docs$(FONT_RESET)\n"
+	rm -rf ./docs/reference/commands ./docs/reference/errors.md
 	./bin/slack docgen ./docs/reference --skip-update
 	sed -i.bak -E "s#slack_cli_[0-9]+\.[0-9]+\.[0-9]+_macOS_arm64\.tar\.gz#slack_cli_$(RELEASE_VERSION)_macOS_arm64.tar.gz#" docs/guides/installing-the-slack-cli-for-mac-and-linux.md
 	sed -i.bak -E "s#slack_cli_[0-9]+\.[0-9]+\.[0-9]+_macOS_amd64\.tar\.gz#slack_cli_$(RELEASE_VERSION)_macOS_amd64.tar.gz#" docs/guides/installing-the-slack-cli-for-mac-and-linux.md


### PR DESCRIPTION
### Changelog

> N/A. But we hope to continue with current reference 🤓 

### Summary

This PR regenerates reference docs from nothing for each release to avoid issues where "stale" files from removed commands might remain in reference.

### Reviewers

Please confirm no `diff` is created when running the following commands:

```sh
rm -rf ./docs/reference/commands ./docs/reference/errors.md
./bin/slack docgen ./docs/reference --skip-update
```

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-cli/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
