### PR TITLE
build: create release branch as part of tag script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,8 @@ tag:
 		echo "Error: Release version should not begin with a version prefix."; \
 		exit 1; \
 	fi
+	@printf "$(FONT_BOLD)Creating Branch$(FONT_RESET)\n"
+	git checkout -b "chore-release-$(RELEASE_VERSION)"
 	@printf "$(FONT_BOLD)Updating Docs$(FONT_RESET)\n"
 	rm -rf ./docs/reference/commands ./docs/reference/errors.md
 	./bin/slack docgen ./docs/reference --skip-update


### PR DESCRIPTION
### Changelog

> N/A - But we remain excited to test this 🚀 

### Summary

This PR adds a step to create the release branch as part of the `tag` script to bring us one step closer to one-click releases.

### Notes

This changes our suggested release branch from the format `chore-release-3-14-0` to `chore-release-3.14.0` but automates most of this. I will follow up to runbooks if this is alright!

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-cli/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
