### PR TITLE
chore: add preview and testing and notes section to pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,18 @@
 
 (Please describe the goal of this pull request and mention any related issue numbers)
 
+### Preview
+
+(Add screenshots, GIFs, or recordings that show the changes)
+
+### Testing
+
+(List the steps used to verify these changes)
+
+### Notes
+
+(Add any additional context, trade-offs, or follow-up items)
+
 ### Requirements
 
 - [ ] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-cli/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.


### PR DESCRIPTION
### Changelog

> N/A - But we hope to improve PRs onward!

### Summary

This PR adds the "preview" and "testing" and "notes" section to PR templates as placeholders for more detailed changes.

### Notes

Multiple templates were considered but AFAICT a good solution for selecting these doesn't exist. IMHO removing unneeded sections is easier than adding these?
- GitHub Docs: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
- GitHub Docs: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/using-query-parameters-to-create-a-pull-request
- Stack Overflow: https://stackoverflow.com/questions/73771068/multiple-templates-for-pull-requests-on-github

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-cli/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
