### PR TITLE
build: group charm dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,8 @@ updates:
     groups:
       charmbracelet:
         patterns:
-          - "github.com/charmbracelet/*"
           - "charm.land/*"
+          - "github.com/charmbracelet/*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
     labels:
       - "build"
       - "semver:patch"
+    groups:
+      charmbracelet:
+        patterns:
+          - "github.com/charmbracelet/*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,7 @@ updates:
       charmbracelet:
         patterns:
           - "github.com/charmbracelet/*"
+          - "charm.land/*"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
### Summary

Group `charm.land/*` and `github.com/charmbracelet/*` Go module dependencies into a single Dependabot PR instead of individual PRs for each package.

#### References

- [Dependabot grouped updates documentation](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups)

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-cli/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).