### PR TITLE
docs: redirect issue tracker template option links

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -83,5 +83,5 @@ There are more details about processes and workflow in the
 [commits]: https://www.conventionalcommits.org/en/v1.0.0/
 [conduct]: https://slackhq.github.io/code-of-conduct
 [empathy]: https://slack.engineering/on-empathy-pull-requests-979e4257d158#.awxtvmb2z
-[issues]: /issues/new
+[issues]: https://github.com/slackapi/slack-cli/issues/new/choose
 [maintainers]: ./MAINTAINERS_GUIDE.md

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Thanks for stopping by! You're awesome :sunglasses:
 [dev]: https://github.com/slackapi/slack-cli/releases/tag/dev-build
 [enhancements]: https://github.com/slackapi/slack-cli/pulls
 [install]: https://docs.slack.dev/tools/slack-cli/guides/installing-the-slack-cli-for-mac-and-linux
-[issues]: https://github.com/slackapi/slack-cli/issues/new?template=04_bug.md
+[issues]: https://github.com/slackapi/slack-cli/issues/new?template=01-bug.yml
 [maintainers]: .github/MAINTAINERS_GUIDE.md
 [releases]: https://github.com/slackapi/slack-cli/releases
-[suggestions]: https://github.com/slackapi/slack-cli/issues/new?template=02_enhancement.md
+[suggestions]: https://github.com/slackapi/slack-cli/issues/new?template=02-feature.yml


### PR DESCRIPTION
### Changelog

> N/A - Settings for this repository 🐙 

### Summary

This PR redirects issue tracker template option links to the format introduced in #488 📚 

### Preview

- https://github.com/slackapi/slack-cli/blob/3923e918cffe2e48571c35be862b9a301134fb0a/README.md#hammer_and_wrench-contributions

### Testing

🔍 Confirm these links arrive to expected pages please!

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-cli/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
