### PR TITLE
feat: include sandbox type when listing partner sandboxes

### DIFF
--- a/cmd/sandbox/list.go
+++ b/cmd/sandbox/list.go
@@ -125,6 +125,12 @@ func printSandboxes(cmd *cobra.Command, clients *shared.ClientFactory, token str
 			}
 		}
 
+		sandboxType := "Regular"
+		if s.IsPartner {
+			sandboxType = "Partner"
+		}
+		clients.IO.PrintInfo(ctx, false, "    %s", style.Secondary(fmt.Sprintf("Type: %s", sandboxType)))
+
 		if s.DateCreated > 0 {
 			clients.IO.PrintInfo(ctx, false, "    %s", style.Secondary(fmt.Sprintf("Created: %s", time.Unix(s.DateCreated, 0).Format(timeFormat))))
 		}

--- a/cmd/sandbox/list.go
+++ b/cmd/sandbox/list.go
@@ -16,6 +16,7 @@ package sandbox
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 
@@ -108,6 +109,8 @@ func printSandboxes(cmd *cobra.Command, clients *shared.ClientFactory, token str
 		return nil
 	}
 
+	hasPartner := slices.ContainsFunc(sandboxes, func(s types.Sandbox) bool { return s.IsPartner })
+
 	timeFormat := "2006-01-02" // We only support the granularity of the day for now, rather than a more precise datetime
 	for _, s := range sandboxes {
 		clients.IO.PrintInfo(ctx, false, "  %s (%s)", style.Bold(s.Name), s.TeamID)
@@ -125,11 +128,13 @@ func printSandboxes(cmd *cobra.Command, clients *shared.ClientFactory, token str
 			}
 		}
 
-		sandboxType := "Regular"
-		if s.IsPartner {
-			sandboxType = "Partner"
+		if hasPartner {
+			sandboxType := "Regular"
+			if s.IsPartner {
+				sandboxType = "Partner"
+			}
+			clients.IO.PrintInfo(ctx, false, "    %s", style.Secondary(fmt.Sprintf("Type: %s", sandboxType)))
 		}
-		clients.IO.PrintInfo(ctx, false, "    %s", style.Secondary(fmt.Sprintf("Type: %s", sandboxType)))
 
 		if s.DateCreated > 0 {
 			clients.IO.PrintInfo(ctx, false, "    %s", style.Secondary(fmt.Sprintf("Created: %s", time.Unix(s.DateCreated, 0).Format(timeFormat))))

--- a/cmd/sandbox/list.go
+++ b/cmd/sandbox/list.go
@@ -16,7 +16,6 @@ package sandbox
 
 import (
 	"fmt"
-	"slices"
 	"strings"
 	"time"
 
@@ -109,14 +108,16 @@ func printSandboxes(cmd *cobra.Command, clients *shared.ClientFactory, token str
 		return nil
 	}
 
-	hasPartner := slices.ContainsFunc(sandboxes, func(s types.Sandbox) bool { return s.IsPartner })
-
 	timeFormat := "2006-01-02" // We only support the granularity of the day for now, rather than a more precise datetime
 	for _, s := range sandboxes {
 		clients.IO.PrintInfo(ctx, false, "  %s (%s)", style.Bold(s.Name), s.TeamID)
 
 		if s.Domain != "" {
 			clients.IO.PrintInfo(ctx, false, "    %s", style.Secondary(fmt.Sprintf("URL: https://%s.slack.com", s.Domain)))
+		}
+
+		if s.IsPartner {
+			clients.IO.PrintInfo(ctx, false, "    %s", style.Secondary("Type: Partner"))
 		}
 
 		if s.Status != "" {
@@ -126,14 +127,6 @@ func printSandboxes(cmd *cobra.Command, clients *shared.ClientFactory, token str
 			} else {
 				clients.IO.PrintInfo(ctx, false, "    %s", style.Green(status))
 			}
-		}
-
-		if hasPartner {
-			sandboxType := "Regular"
-			if s.IsPartner {
-				sandboxType = "Partner"
-			}
-			clients.IO.PrintInfo(ctx, false, "    %s", style.Secondary(fmt.Sprintf("Type: %s", sandboxType)))
 		}
 
 		if s.DateCreated > 0 {

--- a/cmd/sandbox/list_test.go
+++ b/cmd/sandbox/list_test.go
@@ -107,6 +107,35 @@ func TestListCommand(t *testing.T) {
 				cm.API.AssertCalled(t, "ListSandboxes", mock.Anything, "xoxb-test-token", "")
 			},
 		},
+		"with partner sandbox": {
+			CmdArgs: []string{"--experiment=sandboxes", "--token", "xoxb-test-token"},
+			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
+				testToken := "xoxb-test-token"
+				cm.Auth.On("AuthWithToken", mock.Anything, testToken).Return(types.SlackAuth{Token: testToken}, nil)
+				cm.Auth.On("ResolveAPIHost", mock.Anything, mock.Anything, mock.Anything).Return("https://api.slack.com")
+				cm.Auth.On("ResolveLogstashHost", mock.Anything, mock.Anything, mock.Anything).Return("https://slackb.com/events/cli")
+				sandboxes := []types.Sandbox{
+					{
+						TeamID:      "T789",
+						Name:        "partner-sandbox",
+						Domain:      "partner-sandbox",
+						Status:      "active",
+						DateCreated: 1700000000,
+						IsPartner:   true,
+					},
+				}
+				cm.API.On("ListSandboxes", mock.Anything, testToken, "").Return(sandboxes, nil)
+				cm.API.On("UsersInfo", mock.Anything, mock.Anything, mock.Anything).Return(&types.UserInfo{Profile: types.UserProfile{}}, nil)
+
+				cm.AddDefaultMocks()
+				cm.Config.ExperimentsFlag = []string{string(experiment.Sandboxes)}
+				cm.Config.LoadExperiments(ctx, cm.IO.PrintDebug)
+			},
+			ExpectedStdoutOutputs: []string{"partner-sandbox", "T789", "Type: Partner"},
+			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
+				cm.API.AssertCalled(t, "ListSandboxes", mock.Anything, "xoxb-test-token", "")
+			},
+		},
 		"with status": {
 			CmdArgs: []string{"--experiment=sandboxes", "--token", "xoxb-test-token", "--status", "active"},
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {

--- a/cmd/sandbox/list_test.go
+++ b/cmd/sandbox/list_test.go
@@ -140,7 +140,7 @@ func TestListCommand(t *testing.T) {
 				cm.Config.ExperimentsFlag = []string{string(experiment.Sandboxes)}
 				cm.Config.LoadExperiments(ctx, cm.IO.PrintDebug)
 			},
-			ExpectedStdoutOutputs: []string{"regular-sandbox", "Type: Regular", "partner-sandbox", "Type: Partner"},
+			ExpectedStdoutOutputs: []string{"regular-sandbox", "partner-sandbox", "Type: Partner"},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
 				cm.API.AssertCalled(t, "ListSandboxes", mock.Anything, "xoxb-test-token", "")
 			},

--- a/cmd/sandbox/list_test.go
+++ b/cmd/sandbox/list_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/slackapi/slack-cli/internal/shared/types"
 	"github.com/slackapi/slack-cli/test/testutil"
 	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -76,6 +77,7 @@ func TestListCommand(t *testing.T) {
 			ExpectedStdoutOutputs: []string{"my-sandbox", "T123", "https://my-sandbox.slack.com", "Status: ACTIVE"},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
 				cm.API.AssertCalled(t, "ListSandboxes", mock.Anything, "xoxb-test-token", "")
+				assert.NotContains(t, cm.GetStdoutOutput(), "Type:")
 			},
 		},
 		"with archived sandbox": {
@@ -107,7 +109,7 @@ func TestListCommand(t *testing.T) {
 				cm.API.AssertCalled(t, "ListSandboxes", mock.Anything, "xoxb-test-token", "")
 			},
 		},
-		"with partner sandbox": {
+		"with partner sandbox shows type for all sandboxes": {
 			CmdArgs: []string{"--experiment=sandboxes", "--token", "xoxb-test-token"},
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
 				testToken := "xoxb-test-token"
@@ -115,6 +117,13 @@ func TestListCommand(t *testing.T) {
 				cm.Auth.On("ResolveAPIHost", mock.Anything, mock.Anything, mock.Anything).Return("https://api.slack.com")
 				cm.Auth.On("ResolveLogstashHost", mock.Anything, mock.Anything, mock.Anything).Return("https://slackb.com/events/cli")
 				sandboxes := []types.Sandbox{
+					{
+						TeamID:      "T123",
+						Name:        "regular-sandbox",
+						Domain:      "regular-sandbox",
+						Status:      "active",
+						DateCreated: 1700000000,
+					},
 					{
 						TeamID:      "T789",
 						Name:        "partner-sandbox",
@@ -131,7 +140,7 @@ func TestListCommand(t *testing.T) {
 				cm.Config.ExperimentsFlag = []string{string(experiment.Sandboxes)}
 				cm.Config.LoadExperiments(ctx, cm.IO.PrintDebug)
 			},
-			ExpectedStdoutOutputs: []string{"partner-sandbox", "T789", "Type: Partner"},
+			ExpectedStdoutOutputs: []string{"regular-sandbox", "Type: Regular", "partner-sandbox", "Type: Partner"},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
 				cm.API.AssertCalled(t, "ListSandboxes", mock.Anything, "xoxb-test-token", "")
 			},

--- a/internal/shared/types/sandbox.go
+++ b/internal/shared/types/sandbox.go
@@ -22,4 +22,5 @@ type Sandbox struct {
 	Name         string `json:"sandbox_name"`
 	TeamID       string `json:"sandbox_team_id"`
 	Status       string `json:"status"`
+	IsPartner    bool   `json:"is_partner"`
 }


### PR DESCRIPTION
### Changelog

This does not need to be included in the Changelog

### Summary

This PR updates the Sandbox model to include the 'is_partner' bool which indicates whether this is a regular sandbox or a partner sandbox, and display it when listing one's partner sandboxes. We do not display the 'type' label for regular sandboxes to reduce visual noise

### Preview

<img width="1034" height="467" alt="Screenshot 2026-04-28 at 1 34 29 PM" src="https://github.com/user-attachments/assets/4aef63ea-ddcf-4c3d-9f7e-c6cb163af256" />


### Testing

`% hermes sandbox list --experiment=sandboxes `


### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-cli/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
