### PR TITLE
feat: add `bot_optional` and `user_optional` scopes to app manifest

### DIFF
--- a/internal/shared/types/app_manifest.go
+++ b/internal/shared/types/app_manifest.go
@@ -239,8 +239,10 @@ type ManifestInteractivity struct {
 
 // ManifestScopes
 type ManifestScopes struct {
-	Bot  []string `json:"bot,omitempty" yaml:"bot,flow,omitempty"`
-	User []string `json:"user,omitempty" yaml:"user,flow,omitempty"`
+	Bot          []string `json:"bot,omitempty" yaml:"bot,flow,omitempty"`
+	BotOptional  []string `json:"bot_optional,omitempty" yaml:"bot_optional,flow,omitempty"`
+	User         []string `json:"user,omitempty" yaml:"user,flow,omitempty"`
+	UserOptional []string `json:"user_optional,omitempty" yaml:"user_optional,flow,omitempty"`
 }
 
 // ManifestShortcutsItem

--- a/internal/shared/types/app_manifest_test.go
+++ b/internal/shared/types/app_manifest_test.go
@@ -336,6 +336,62 @@ func Test_AppManifest_AppSettings_IncomingWebhooks(t *testing.T) {
 	}
 }
 
+func Test_AppManifest_OAuthConfig_Scopes(t *testing.T) {
+	tests := map[string]struct {
+		oauthConfig  *OAuthConfig
+		expectedJSON string
+	}{
+		"undefined scopes are omitted": {
+			oauthConfig:  &OAuthConfig{},
+			expectedJSON: `{}`,
+		},
+		"empty scopes are included": {
+			oauthConfig:  &OAuthConfig{Scopes: &ManifestScopes{}},
+			expectedJSON: `{"scopes":{}}`,
+		},
+		"bot scopes are included": {
+			oauthConfig: &OAuthConfig{Scopes: &ManifestScopes{
+				Bot: []string{"chat:write", "channels:read"},
+			}},
+			expectedJSON: `{"scopes":{"bot":["chat:write","channels:read"]}}`,
+		},
+		"user scopes are included": {
+			oauthConfig: &OAuthConfig{Scopes: &ManifestScopes{
+				User: []string{"users:read"},
+			}},
+			expectedJSON: `{"scopes":{"user":["users:read"]}}`,
+		},
+		"bot optional scopes are included": {
+			oauthConfig: &OAuthConfig{Scopes: &ManifestScopes{
+				BotOptional: []string{"channels:history"},
+			}},
+			expectedJSON: `{"scopes":{"bot_optional":["channels:history"]}}`,
+		},
+		"user optional scopes are included": {
+			oauthConfig: &OAuthConfig{Scopes: &ManifestScopes{
+				UserOptional: []string{"users:read.email"},
+			}},
+			expectedJSON: `{"scopes":{"user_optional":["users:read.email"]}}`,
+		},
+		"all scope types are included": {
+			oauthConfig: &OAuthConfig{Scopes: &ManifestScopes{
+				Bot:          []string{"chat:write"},
+				BotOptional:  []string{"channels:history"},
+				User:         []string{"users:read"},
+				UserOptional: []string{"users:read.email"},
+			}},
+			expectedJSON: `{"scopes":{"bot":["chat:write"],"bot_optional":["channels:history"],"user":["users:read"],"user_optional":["users:read.email"]}}`,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			actualJSON, err := json.Marshal(tc.oauthConfig)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedJSON, string(actualJSON))
+		})
+	}
+}
+
 func Test_AppManifest_AppSettings_FunctionRuntime(t *testing.T) {
 	tests := map[string]struct {
 		settings        *AppSettings


### PR DESCRIPTION
### Changelog

> Add support for optional OAuth scopes (`bot_optional` and `user_optional`) in the app manifest schema.

### Summary

This pull request adds two new optional properties to the manifest schema: `oauth_config.scopes.bot_optional` and `oauth_config.scopes.user_optional`. These allow apps to declare optional OAuth scopes for both bot and user tokens.

### Notes

- The new fields use `omitempty`, so they are fully backwards-compatible and only serialized when set.
- We may need to update the `developerInstall` endpoint to accept the optional scopes. We can investigate this next.

### Testing

```bash
# Create a Starter App
$ ./bin/slack create my-app -t https://github.com/slack-samples/bolt-js-starter-template
$ cd my-app/

# Add optional scopes
$ vim manifest.json
# Replace "oauth_config: { .... }" with:
```

```json
    "oauth_config": {
        "scopes": {
            "user": [
                "search:read.public",
                "search:read.private",
                "search:read.mpim",
                "search:read.im",
                "search:read.files",
                "search:read.users",
                "chat:write",
                "channels:history",
                "groups:history",
                "mpim:history",
                "im:history",
                "canvases:read",
                "canvases:write",
                "users:read",
                "users:read.email",
                "reactions:write"
            ],
            "user_optional": [
                "search:read.private",
                "search:read.mpim",
                "search:read.im",
                "search:read.files",
                "chat:write",
                "groups:history",
                "mpim:history",
                "im:history",
                "canvases:read",
                "canvases:write"
            ],
            "bot": [
                "app_mentions:read",
                "assistant:write",
                "im:history",
                "channels:history",
                "chat:write",
                "commands"
            ],
            "bot_optional": [
                "canvases:read"
            ]
        }
    },
```

```bash
# Confirm production CLI is missing optional scopes
$ lack-prod manifest info --source local
# → Confirm no `user_optional` or `bot_optional` scopes

# Confirm new CLI includes the optional scopes
$ ../bin/slack manifest info --source local

# Confirm new CLI installs the app
$ ../bin/slack run

# Cleanup
$ lack delete -f
```

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-cli/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).