### PR TITLE
chore: add snyk security scan skill

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -29,6 +29,7 @@
       "Bash(make build:*)",
       "Bash(make lint:*)",
       "Bash(make test:*)",
+      "Bash(snyk:*)",
       "Bash(mkdir:*)",
       "Bash(tree:*)",
       "Bash(vhs:*)",

--- a/.claude/skills/snyk/SKILL.md
+++ b/.claude/skills/snyk/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: snyk
+description: Run Snyk security scans to find dependency vulnerabilities and source code issues. Use for monthly security reviews or when checking for new vulnerabilities.
+---
+
+Run a Snyk security scan on this project.
+
+## 1. Check prerequisites
+
+Run `which snyk` to verify Snyk is installed. If not found, tell the user to install it with `brew install snyk` or `npm install -g snyk`.
+
+Run `snyk auth check` or `snyk whoami` to verify authentication. If not authenticated, tell the user to run `! snyk auth` to log in interactively.
+
+## 2. Run `snyk test` (dependency vulnerabilities — primary scan)
+
+Run `snyk test` to scan Go module dependencies for known vulnerabilities.
+
+**This is the most important scan.** Summarize the results:
+
+- Group vulnerabilities by severity: **Critical > High > Medium > Low**
+- For each vulnerability, note:
+  - The affected package and version
+  - Whether a fix is available (upgrade path exists) or requires waiting on the upstream maintainer
+- For fixable issues, propose the specific `go get` upgrade commands
+- For unfixable issues, note them as "waiting on upstream" — these are deferred
+
+## 3. Run `snyk code test` (source code analysis — secondary scan)
+
+Run `snyk code test` to scan the project's own Go source code for security issues.
+
+**This scan is optional and secondary.** Summarize the results:
+
+- Group findings by severity
+- Identify which issues are simple/quick to fix vs. complex
+- Focus on simple fixes that can be resolved quickly
+
+## 4. Present a prioritized action plan
+
+Combine both scan results into a single prioritized plan:
+
+1. **Fix now** — dependency upgrades with available fixes (propose commands)
+2. **Fix now** — simple source code issues from `snyk code test`
+3. **Defer** — dependency vulnerabilities waiting on upstream fixes
+4. **Defer** — complex source code issues that need more investigation
+
+Ask the user which items they'd like to tackle, then help resolve them.


### PR DESCRIPTION
### Changelog

- N/A

### Summary

This pull request adds a `/snyk` Claude Code skill for running monthly Snyk security scans.

The skill runs `snyk test` (dependencies) and `snyk code test` (source code), summarizes findings by severity, and presents a prioritized action plan.

### Preview

- N/A

### Testing

- Invoke `/snyk` in Claude Code and verify both `snyk test` and `snyk code test` execute and produce a summary

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-cli/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).