### PR TITLE
fix: upgrade HashString from SHA1 to SHA-256

### DIFF
--- a/internal/goutils/strings.go
+++ b/internal/goutils/strings.go
@@ -15,7 +15,7 @@
 package goutils
 
 import (
-	"crypto/sha1"
+	"crypto/sha256"
 	"fmt"
 	"net/url"
 	"os"
@@ -23,9 +23,9 @@ import (
 	"strings"
 )
 
-// HashString will compute a short sha1 identity for a text blob
+// HashString will compute a short sha256 identity for a text blob
 func HashString(s string) (string, error) {
-	var hash = sha1.New()
+	var hash = sha256.New()
 	_, err := hash.Write([]byte(s))
 	if err != nil {
 		return "", err

--- a/internal/goutils/strings_test.go
+++ b/internal/goutils/strings_test.go
@@ -22,6 +22,12 @@ import (
 )
 
 func Test_HashString(t *testing.T) {
+	t.Run("produces a sha256 hex string", func(t *testing.T) {
+		hash, err := HashString("test")
+		require.NoError(t, err)
+		require.Len(t, hash, 64)
+	})
+
 	tests := map[string]struct {
 		text1    string
 		text2    string


### PR DESCRIPTION
### Changelog

- N/A

### Summary

This pull request upgrades the `HashString` function in `internal/goutils/strings.go` from SHA1 to SHA-256 to resolve a Snyk code analysis finding for use of a weak hash algorithm.

`HashString` is used only to anonymize PII (e.g. system hostname) in diagnostic data. No external system depends on the hash format, so the upgrade is safe.

### Preview

- N/A

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-cli/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).