### PR TITLE
fix: upgrade generateBoundary from MD5 to SHA-256

### DIFF
--- a/internal/hooks/hook_executor_v2.go
+++ b/internal/hooks/hook_executor_v2.go
@@ -17,8 +17,8 @@ package hooks
 import (
 	"bytes"
 	"context"
-	"crypto/md5"
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"math/big"
 	"strings"
@@ -37,7 +37,7 @@ type HookExecutorMessageBoundaryProtocol struct {
 }
 
 // generateBoundary is a function for creating boundaries that can be mocked
-var generateBoundary = generateMD5FromRandomString
+var generateBoundary = generateRandomBoundary
 
 // Execute processes the data received by the SDK.
 func (e *HookExecutorMessageBoundaryProtocol) Execute(ctx context.Context, opts HookExecOpts) (string, error) {
@@ -100,24 +100,25 @@ func (e *HookExecutorMessageBoundaryProtocol) Execute(ctx context.Context, opts 
 	return buffout.String(), nil
 }
 
-// generateMD5FromRandomString returns the MD5 hash of a randomized string.
+// generateRandomBoundary returns the SHA-256 hash of a randomized string for use
+// as a message boundary between the CLI and SDK.
 //
 // Reference: https://gist.github.com/dopey/c69559607800d2f2f90b1b1ed4e550fb
-func generateMD5FromRandomString() string {
+func generateRandomBoundary() string {
 	const alphanumericCharacters = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 	const length = 10
 
-	randomBytes := make([]byte, 0)
+	randomBytes := make([]byte, 0, length)
 	for range length {
 		num, err := rand.Int(rand.Reader, big.NewInt(int64(len(alphanumericCharacters))))
 		if err != nil {
-			return "3561f3a3c5576e2ce0dc0d1e268bb9b2" // Return default value to continue execution
+			// Return default value to continue execution
+			return "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2"
 		}
 		randomBytes = append(randomBytes, alphanumericCharacters[num.Int64()])
 	}
 
-	MD5Hash := md5.New()
-	s := MD5Hash.Sum(randomBytes)
-
-	return hex.EncodeToString(s)
+	hash := sha256.New()
+	hash.Write(randomBytes)
+	return hex.EncodeToString(hash.Sum(nil))
 }

--- a/internal/hooks/hook_executor_v2_test.go
+++ b/internal/hooks/hook_executor_v2_test.go
@@ -15,6 +15,8 @@
 package hooks
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"io"
 	"strings"
@@ -215,11 +217,18 @@ func Test_Hook_Execute_V2_Protocol(t *testing.T) {
 	}
 }
 
-func Test_Hook_Execute_V2_GenerateMD5FromRandomString(t *testing.T) {
-	randomString1 := generateMD5FromRandomString()
-	randomString2 := generateMD5FromRandomString()
+func Test_Hook_Execute_V2_GenerateRandomBoundary(t *testing.T) {
+	randomString1 := generateRandomBoundary()
+	randomString2 := generateRandomBoundary()
 
 	assert.NotEqual(t, randomString1, randomString2)
-	assert.GreaterOrEqual(t, len(randomString1), 10)
-	assert.GreaterOrEqual(t, len(randomString2), 10)
+	assert.Equal(t, 64, len(randomString1))
+	assert.Equal(t, 64, len(randomString2))
+}
+
+func Test_Hook_Execute_V2_GenerateRandomBoundary_UsesSHA256(t *testing.T) {
+	boundary := generateRandomBoundary()
+	_, err := hex.DecodeString(boundary)
+	assert.NoError(t, err)
+	assert.Equal(t, sha256.Size*2, len(boundary))
 }


### PR DESCRIPTION
### Changelog

- N/A

### Summary

This pull request replaces MD5 with SHA-256 in the hook executor's boundary string generator to resolve a Snyk weak-hash finding.

Also fixes a subtle bug where the original code called `MD5Hash.Sum(randomBytes)` which appends the hash of empty input to `randomBytes`, rather than actually hashing the random bytes. The fix properly uses `hash.Write(randomBytes)` followed by `hash.Sum(nil)`.

### Testing

**Bolt JS:**

```bash
$ lack create my-app
# → Starter App → Bolt for JavaScript

$ lack run
# → Test the app and confirm the logs appear
# CTRL+C

$ lack manifest info
# → Confirm manifest appears

$ lack delete -f
$ cd ../
$ rm -rf my-app/

# Repeat for:
# → Bolt for Python
# → Deno SDK
```

### Notes

- Boundary output changes from 32 hex chars (MD5) to 64 hex chars (SHA-256); the SDK uses substring matching so any length works

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-cli/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).