### PR TITLE
docs: update suggestions to use "set" and "unset" environment commands

### DIFF
--- a/.github/STYLE_GUIDE.md
+++ b/.github/STYLE_GUIDE.md
@@ -31,7 +31,7 @@ The square brackets surrounding command arguments hint that these are optional:
 
 ```
 USAGE
-  $ slack env add [name] [value] [flags]
+  $ slack env set [name] [value] [flags]
 ```
 
 The angled brackets around arguments hint that these are required:

--- a/cmd/env/unset.go
+++ b/cmd/env/unset.go
@@ -112,7 +112,7 @@ func runEnvUnsetCommandFunc(clients *shared.ClientFactory, cmd *cobra.Command, a
 				Emoji: "evergreen_tree",
 				Text:  "Environment Unset",
 				Secondary: []string{
-					"The app has no environment variables to remove",
+					"The app has no environment variables to unset",
 				},
 			}))
 			return nil
@@ -141,7 +141,7 @@ func runEnvUnsetCommandFunc(clients *shared.ClientFactory, cmd *cobra.Command, a
 				Emoji: "evergreen_tree",
 				Text:  "Environment Unset",
 				Secondary: []string{
-					"The project has no environment variables to remove",
+					"The project has no environment variables to unset",
 				},
 			}))
 			return nil

--- a/cmd/env/unset_test.go
+++ b/cmd/env/unset_test.go
@@ -79,7 +79,7 @@ func Test_Env_RemoveCommand(t *testing.T) {
 				cm.API.AssertNotCalled(t, "RemoveVariable")
 			},
 			ExpectedStdoutOutputs: []string{
-				"The project has no environment variables to remove",
+				"The project has no environment variables to unset",
 			},
 		},
 		"exit without errors when hosted app has zero variables": {
@@ -94,7 +94,7 @@ func Test_Env_RemoveCommand(t *testing.T) {
 				cm.API.AssertNotCalled(t, "RemoveVariable")
 			},
 			ExpectedStdoutOutputs: []string{
-				"The app has no environment variables to remove",
+				"The app has no environment variables to unset",
 			},
 		},
 		"remove a hosted variable using arguments": {

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -494,7 +494,7 @@ func (c *Client) ResolveAPIHost(ctx context.Context, apiHostFlag string, customA
 		c.io.PrintDebug(
 			ctx,
 			"You're using a custom apihost. Run %s to add it to your app's Run on Slack environment",
-			style.Commandf(fmt.Sprintf("var add SLACK_API_URL %s", apiHost), false),
+			style.Commandf(fmt.Sprintf("env set SLACK_API_URL %s", apiHost), false),
 		)
 	}
 


### PR DESCRIPTION
### Changelog

The `env` commands are suggested in a few places and some of these places were updated to use the preferred aliases `set` and `unset`.

### Summary

This pull request updates leftover references to the old `env add` and `env remove` command names that were missed when `set` and `unset` became the primary commands in #460.

- `.github/STYLE_GUIDE.md`: Example usage updated from `env add` to `env set`
- `cmd/env/unset.go`: User-facing "no variables to remove" messages changed to "unset"
- `internal/auth/auth.go`: Debug message updated from `var add SLACK_API_URL` to `env set SLACK_API_URL`

### Preview

N/A — text-only changes to output messages and docs.

### Testing

- Run `slack env unset` in a project with no `.env` file and confirm the message says "no environment variables to unset"
- Use a custom API host and check debug output references `env set SLACK_API_URL`

### Notes

Follow-up to #460.

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-cli/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).