### PR TITLE
fix: broken Content-MD5 header for S3 upload

### DIFF
--- a/internal/api/s3_upload.go
+++ b/internal/api/s3_upload.go
@@ -17,8 +17,6 @@ package api
 import (
 	"bytes"
 	"context"
-	"crypto/md5"
-	"encoding/base64"
 	"fmt"
 	"io"
 	"mime/multipart"
@@ -76,13 +74,6 @@ func (c *Client) UploadPackageToS3(ctx context.Context, fs afero.Fs, appID strin
 		}
 	}
 
-	md5hash := md5.New()
-	if _, err := io.Copy(md5hash, archive); err != nil {
-		return fileName, err
-	}
-
-	md5s := base64.StdEncoding.EncodeToString(md5hash.Sum(nil))
-
 	var part io.Writer
 	h := make(textproto.MIMEHeader)
 	h.Set("Content-Disposition", fmt.Sprintf(`form-data; name="%s"; filename="%s"`, "file", fileName))
@@ -105,7 +96,6 @@ func (c *Client) UploadPackageToS3(ctx context.Context, fs afero.Fs, appID strin
 		return fileName, err
 	}
 	request.Header.Add("Content-Type", writer.FormDataContentType())
-	request.Header.Add("Content-MD5", md5s)
 	cliVersion, err := slackcontext.Version(ctx)
 	if err != nil {
 		return fileName, err

--- a/internal/api/s3_upload_test.go
+++ b/internal/api/s3_upload_test.go
@@ -67,9 +67,6 @@ func TestClient_UploadPackageToS3(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "this is the package", string(contentBytes))
 
-		md5Header := r.Header["Content-Md5"][0]
-		require.Equal(t, "1B2M2Y8AsgTpgAmY7PhCfg==", md5Header)
-
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	defer server.Close()


### PR DESCRIPTION
### Changelog

> Fix the S3 `Content-MD5` header when deploy a Deno app to Slack.

### Summary

This pull request removes the MD5 hash computation and `Content-MD5` header from S3 presigned POST uploads.

- Flagged by Snyk as `[LOW] Use of Password Hash With Insufficient Computational Effort` for using `crypto/md5` in `internal/api/s3_upload.go`.
- The hash was also bugged - it was always 0 bytes and produced an empty content digest (`1B2M2Y8AsgTpgAmY7PhCfg==`) because it was hashed over an already-exhausted `io.Reader`.
- `Content-MD5` is optional for S3 presigned POST uploads since integrity is enforced by the signed policy.
- The tests were testing for a 0 byte empty content hash (`1B2M2Y8AsgTpgAmY7PhCfg==`) 🤷🏻 

### Preview

N/A

### Testing

```bash
# Create Deno app
$ slack create my-app
# -> Select Automation App -> Deno SDK

$ cd my-app/

# Deploy the app
$ slack deploy

# Test the app
# -> Copy & paste trigger in Slack

# Clean up
$ slack delete -f
$ cd ../
$ rm -rf my-app/
```

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-cli/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).