### PR TITLE
fix: replace hashicorp/go-version with golang.org/x/mod/semver

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/cli/safeexec v1.0.1
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.3
-	github.com/hashicorp/go-version v1.9.0
 	github.com/joho/godotenv v1.5.1
 	github.com/kyokomi/emoji/v2 v2.2.13
 	github.com/logrusorgru/aurora/v4 v4.0.0
@@ -303,6 +302,7 @@ require (
 	github.com/hashicorp/go-immutable-radix/v2 v2.1.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.8 // indirect
+	github.com/hashicorp/go-version v1.9.0 // indirect
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/hexops/gotextdiff v1.0.3 // indirect

--- a/internal/update/semver.go
+++ b/internal/update/semver.go
@@ -25,10 +25,12 @@ func SemVerGreaterThan(release string, current string) (bool, error) {
 	r := ensureVPrefix(release)
 	c := ensureVPrefix(current)
 	if !semver.IsValid(r) {
-		return false, slackerror.New(slackerror.ErrInvalidSemVer)
+		return false, slackerror.New(slackerror.ErrInvalidSemVer).
+			WithMessage("Value %s is not a semantic version", release)
 	}
 	if !semver.IsValid(c) {
-		return false, slackerror.New(slackerror.ErrInvalidSemVer)
+		return false, slackerror.New(slackerror.ErrInvalidSemVer).
+			WithMessage("Value %s is not a semantic version", current)
 	}
 	return semver.Compare(r, c) > 0, nil
 }
@@ -38,10 +40,12 @@ func SemVerLessThan(release string, current string) (bool, error) {
 	r := ensureVPrefix(release)
 	c := ensureVPrefix(current)
 	if !semver.IsValid(r) {
-		return false, slackerror.New(slackerror.ErrInvalidSemVer)
+		return false, slackerror.New(slackerror.ErrInvalidSemVer).
+			WithMessage("Value %s is not a semantic version", release)
 	}
 	if !semver.IsValid(c) {
-		return false, slackerror.New(slackerror.ErrInvalidSemVer)
+		return false, slackerror.New(slackerror.ErrInvalidSemVer).
+			WithMessage("Value %s is not a semantic version", current)
 	}
 	return semver.Compare(r, c) < 0, nil
 }

--- a/internal/update/semver.go
+++ b/internal/update/semver.go
@@ -15,32 +15,40 @@
 package update
 
 import (
-	"github.com/hashicorp/go-version"
+	"golang.org/x/mod/semver"
+
 	"github.com/slackapi/slack-cli/internal/slackerror"
 )
 
 // SemVerGreaterThan returns true if release is greater than current
 func SemVerGreaterThan(release string, current string) (bool, error) {
-	releaseVersion, err := version.NewVersion(release)
-	if err != nil {
-		return false, slackerror.New(slackerror.ErrInvalidSemVer).WithRootCause(err)
+	r := ensureVPrefix(release)
+	c := ensureVPrefix(current)
+	if !semver.IsValid(r) {
+		return false, slackerror.New(slackerror.ErrInvalidSemVer)
 	}
-	currentVersion, err := version.NewVersion(current)
-	if err != nil {
-		return false, slackerror.New(slackerror.ErrInvalidSemVer).WithRootCause(err)
+	if !semver.IsValid(c) {
+		return false, slackerror.New(slackerror.ErrInvalidSemVer)
 	}
-	return releaseVersion.GreaterThan(currentVersion), nil
+	return semver.Compare(r, c) > 0, nil
 }
 
 // SemVerLessThan returns true if release is less than current
 func SemVerLessThan(release string, current string) (bool, error) {
-	releaseVersion, err := version.NewVersion(release)
-	if err != nil {
-		return false, slackerror.New(slackerror.ErrInvalidSemVer).WithRootCause(err)
+	r := ensureVPrefix(release)
+	c := ensureVPrefix(current)
+	if !semver.IsValid(r) {
+		return false, slackerror.New(slackerror.ErrInvalidSemVer)
 	}
-	currentVersion, err := version.NewVersion(current)
-	if err != nil {
-		return false, slackerror.New(slackerror.ErrInvalidSemVer).WithRootCause(err)
+	if !semver.IsValid(c) {
+		return false, slackerror.New(slackerror.ErrInvalidSemVer)
 	}
-	return releaseVersion.LessThan(currentVersion), nil
+	return semver.Compare(r, c) < 0, nil
+}
+
+func ensureVPrefix(v string) string {
+	if len(v) > 0 && v[0] != 'v' {
+		return "v" + v
+	}
+	return v
 }

--- a/test/testutil/testutil.go
+++ b/test/testutil/testutil.go
@@ -17,9 +17,9 @@ package testutil
 import (
 	"regexp"
 
-	"github.com/hashicorp/go-version"
 	"github.com/slackapi/slack-cli/internal/iostreams"
 	"github.com/spf13/cobra"
+	"golang.org/x/mod/semver"
 )
 
 // package + .test for root command
@@ -27,9 +27,11 @@ var rootName string = "cmd.test"
 
 // ContainsSemVer checks if a string contains valid semver
 func ContainsSemVer(s string) bool {
-	matcher := regexp.MustCompile(version.SemverRegexpRaw)
-	match := matcher.MatchString(s)
-	return match
+	if semver.IsValid("v"+s) || semver.IsValid(s) {
+		return true
+	}
+	matcher := regexp.MustCompile(`[0-9]+\.[0-9]+\.[0-9]+`)
+	return matcher.MatchString(s)
 }
 
 // Set the command's IOStream to the mocked IOStream


### PR DESCRIPTION
### Changelog

- N/A

### Summary

This pull request fixes a Synk license policy issue by removing the direct dependency on `github.com/hashicorp/go-version` (MPL-2.0 license).

We now use `golang.org/x/mod/semver`, which is already a direct dependency. The `go-version` remains as an indirect dependency through the linter tooling, but is no longer flagged by Snyk.

### Preview

- N/A

### Testing

```bash
$ lack --version
# → Confirm the version is shown as "v4.0.1-XX-gXXXX" (e.g. v4.0.1-43-gbd5075f)

$ lack upgrade
# → Confirm the upgrade prompt is displayed for the dev build
# → Note: I think I may have a follow-up that disables showing the upgrade prompt on dev builds :thinking:
```

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-cli/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).