### PR TITLE
build(fix): output pinned version during install if provided

### DIFF
--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -166,7 +166,7 @@ install_slack_cli() {
         if [ "$SLACK_CLI_DEV_VERSION" == "dev" ]; then
                 delay 0.2 "💾 Successfully downloaded the latest build to $(home_path "$slack_cli_install_dir/slack-cli.tar.gz")"
         else
-                delay 0.2 "💾 Successfully downloaded Slack CLI v$LATEST_SLACK_CLI_VERSION to $(home_path "$slack_cli_install_dir/slack-cli.tar.gz")"
+                delay 0.2 "💾 Successfully downloaded Slack CLI v$SLACK_CLI_DEV_VERSION to $(home_path "$slack_cli_install_dir/slack-cli.tar.gz")"
         fi
 
         delay 0.3 "📦 Extracting the Slack CLI command binary to $(home_path "$slack_cli_bin_path")"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -165,7 +165,7 @@ install_slack_cli() {
         echo -e "\x1b[2m\n$slack_cli_url"
         curl -# -fLo "$slack_cli_install_dir/slack-cli.tar.gz" "$slack_cli_url"
         echo -e "\x1b[0m"
-        delay 0.2 "💾 Successfully downloaded Slack CLI v$LATEST_SLACK_CLI_VERSION to $(home_path "$slack_cli_install_dir/slack-cli.tar.gz")"
+        delay 0.2 "💾 Successfully downloaded Slack CLI v$SLACK_CLI_VERSION to $(home_path "$slack_cli_install_dir/slack-cli.tar.gz")"
 
         delay 0.3 "📦 Extracting the Slack CLI command binary to $(home_path "$slack_cli_bin_path")"
         tar -xf "$slack_cli_install_dir/slack-cli.tar.gz" -C "$slack_cli_install_dir"


### PR DESCRIPTION
### Changelog

> The Slack CLI installer now outputs the pinned version provided if a particular version is provided instead of a version and a blank space.

### Summary

This PR outputs the pinned version during install if one is provided to the installer 👾 

### Preview

#### Before changes

Line 78 shows the issue noted above 🐛 

<img width="686" height="404" alt="version" src="https://github.com/user-attachments/assets/e1999fb1-c523-4220-ba9c-777f51ae471e" />

#### After changes

Line 78 appears again with our tested version 🔬

<img width="645" height="385" alt="after" src="https://github.com/user-attachments/assets/9a6ab78a-d0e7-4b8f-90b9-62fe90c869c7" />


### Testing

🔗 Before: https://github.com/slackapi/slack-cli/actions/runs/25587779137/job/75119661795?pr=533#step:6:79
🔗 After: https://github.com/slackapi/slack-cli/actions/runs/25593635345/job/75135694937?pr=536#step:6:76

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-cli/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
