### PR TITLE
docs: replace circleci badge with an authenticated shield

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![tests](https://github.com/slackapi/slack-cli/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/slackapi/slack-cli/actions/workflows/tests.yml)
 [![codecov](https://codecov.io/gh/slackapi/slack-cli/branch/main/graph/badge.svg?token=G5TU59IV9I)](https://codecov.io/gh/slackapi/slack-cli)
-[![circleci](https://dl.circleci.com/status-badge/img/gh/slackapi/slack-cli/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/slackapi/slack-cli/tree/main)
+[![CircleCI](https://dl.circleci.com/status-badge/img/gh/slackapi/slack-cli/tree/main.svg?style=shield&circle-token=CCIPRJ_K7pGxh2PtW5AurUdJTKWpb_2845116e5a6f641726a73654f618e450b0c4e95b)](https://dl.circleci.com/status-badge/redirect/gh/slackapi/slack-cli/tree/main)
 
 > Command-line interface for building apps on the Slack Platform.
 


### PR DESCRIPTION
### Changelog

> N/A - Fixes an issue that appears with adjacent experiments 🤓 🧪 

### Summary

This PR replaces the `circleci` badge with an authenticated shield. This allows us to continue sharing status of our development builds on **main** without exposing logs related to code signing.

### Preview

<img width="961" height="290" alt="preview" src="https://github.com/user-attachments/assets/bdf8e19a-2f8e-4c1c-bae5-1f10197eec0c" />

### Notes

📚 https://circleci.com/docs/guides/integration/status-badges/#creating-badges-for-private-repositories

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-cli/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
