### PR TITLE
style: use command section headers in create command output

### DIFF
--- a/cmd/project/create.go
+++ b/cmd/project/create.go
@@ -231,7 +231,7 @@ func printCreateSuccess(ctx context.Context, clients *shared.ClientFactory, appP
 
 		clients.IO.PrintInfo(ctx, false, "%s", style.Sectionf(style.TextSection{
 			Emoji:     "clipboard",
-			Text:      "Next steps to begin development",
+			Text:      "Docs Help",
 			Secondary: secondaryOutput,
 		}))
 	}

--- a/cmd/project/create.go
+++ b/cmd/project/create.go
@@ -231,7 +231,7 @@ func printCreateSuccess(ctx context.Context, clients *shared.ClientFactory, appP
 
 		clients.IO.PrintInfo(ctx, false, "%s", style.Sectionf(style.TextSection{
 			Emoji:     "clipboard",
-			Text:      "Docs Help",
+			Text:      "Next Steps",
 			Secondary: secondaryOutput,
 		}))
 	}

--- a/cmd/project/init.go
+++ b/cmd/project/init.go
@@ -141,7 +141,7 @@ func printNextStepSection(ctx context.Context, clients *shared.ClientFactory, pr
 
 	clients.IO.PrintInfo(ctx, false, "%s", style.Sectionf(style.TextSection{
 		Emoji:     "clipboard",
-		Text:      "Next steps to begin development",
+		Text:      "Docs Help",
 		Secondary: secondaryOutput,
 	}))
 }

--- a/cmd/project/init.go
+++ b/cmd/project/init.go
@@ -141,7 +141,7 @@ func printNextStepSection(ctx context.Context, clients *shared.ClientFactory, pr
 
 	clients.IO.PrintInfo(ctx, false, "%s", style.Sectionf(style.TextSection{
 		Emoji:     "clipboard",
-		Text:      "Docs Help",
+		Text:      "Next Steps",
 		Secondary: secondaryOutput,
 	}))
 }

--- a/cmd/project/init_test.go
+++ b/cmd/project/init_test.go
@@ -61,9 +61,9 @@ func Test_Project_InitCommand(t *testing.T) {
 				cm.IO.On("ConfirmPrompt", mock.Anything, app.LinkAppConfirmPromptText, mock.Anything).Return(false, nil)
 			},
 			ExpectedStdoutOutputs: []string{
-				"Project Initialization",          // Assert section header
-				"App Link",                        // Assert section header
-				"Next steps to begin development", // Assert section header
+				"Project Initialization", // Assert section header
+				"App Link",               // Assert section header
+				"Docs Help",              // Assert section header
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
 				// Assert installing project dependencies
@@ -148,9 +148,9 @@ func Test_Project_InitCommand(t *testing.T) {
 				).Return(api.GetAppStatusResult{}, nil)
 			},
 			ExpectedStdoutOutputs: []string{
-				"Project Initialization",          // Assert section header
-				"App Link",                        // Assert section header
-				"Next steps to begin development", // Assert section header
+				"Project Initialization", // Assert section header
+				"App Link",               // Assert section header
+				"Docs Help",              // Assert section header
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
 				// Assert prompt to add existing apps was called

--- a/cmd/project/init_test.go
+++ b/cmd/project/init_test.go
@@ -63,7 +63,7 @@ func Test_Project_InitCommand(t *testing.T) {
 			ExpectedStdoutOutputs: []string{
 				"Project Initialization", // Assert section header
 				"App Link",               // Assert section header
-				"Docs Help",              // Assert section header
+				"Next Steps",             // Assert section header
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
 				// Assert installing project dependencies
@@ -150,7 +150,7 @@ func Test_Project_InitCommand(t *testing.T) {
 			ExpectedStdoutOutputs: []string{
 				"Project Initialization", // Assert section header
 				"App Link",               // Assert section header
-				"Docs Help",              // Assert section header
+				"Next Steps",             // Assert section header
 			},
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
 				// Assert prompt to add existing apps was called

--- a/cmd/project/init_test.go
+++ b/cmd/project/init_test.go
@@ -68,7 +68,7 @@ func Test_Project_InitCommand(t *testing.T) {
 			ExpectedAsserts: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock) {
 				// Assert installing project dependencies
 				output := cm.GetCombinedOutput()
-				require.Contains(t, output, "Installed project dependencies")
+				require.Contains(t, output, "Project Dependencies")
 				require.Contains(t, output, "Added "+filepath.Join("project-name", ".slack"))
 				require.Contains(t, output, "Added "+filepath.Join("project-name", ".slack", ".gitignore"))
 				require.Contains(t, output, "Added "+filepath.Join("project-name", ".slack", "hooks.json"))

--- a/internal/pkg/create/create.go
+++ b/internal/pkg/create/create.go
@@ -126,7 +126,7 @@ func Create(ctx context.Context, clients *shared.ClientFactory, createArgs Creat
 	)
 	clients.IO.PrintInfo(ctx, false, "\n%s", style.Sectionf(style.TextSection{
 		Emoji:     "open_file_folder",
-		Text:      "Created a new Slack project",
+		Text:      "Project Create",
 		Secondary: projectDetails,
 	}))
 
@@ -447,8 +447,8 @@ func InstallProjectDependencies(
 
 	// Start the spinner
 	spinnerText := fmt.Sprintf(
-		"Installing project dependencies %s",
-		style.Secondary("(this may take a few seconds)"),
+		"Project Dependencies %s",
+		style.Secondary("(installing... this may take a second)"),
 	)
 	spinner := style.NewSpinner(clients.IO.WriteErr())
 	spinner.Update(spinnerText, "").Start()
@@ -456,7 +456,7 @@ func InstallProjectDependencies(
 	// Stop the spinner when the function returns
 	defer func() {
 		spinnerText = style.Sectionf(style.TextSection{
-			Text:      "Installed project dependencies",
+			Text:      "Project Dependencies",
 			Secondary: outputs,
 		})
 		spinner.Update(spinnerText, "package").Stop()


### PR DESCRIPTION
### Changelog

More polish to outputs is arriving to the `create` command section headers to now reference commands.

### Summary

This PR uses command section headers in `create` command output.

https://github.com/slackapi/slack-cli/blob/ace60ea78a1ba77d2807eba405a0a00a61831d3e/.github/STYLE_GUIDE.md?plain=1#L65-L73

### Preview

<details><summary>Before</summary>

https://github.com/user-attachments/assets/dc4a4fa9-76e6-4e31-8b5d-d6f1e2a54195

</details>

After

https://github.com/user-attachments/assets/c45a9057-7862-4d04-a886-f5193099b217

### Testing

Build this branch and use a judgmental taste! ☕ 😋 

```
$ slack create
```

### Notes

- We don't have a generic "docs help" command but I like how this reads 📚 🐑 💨
- The last line doesn't balance so well but I avoid changing this now

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-cli/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
