### PR TITLE
fix: disable upgrade notification for the api command

### DIFF
--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -223,7 +223,7 @@ func (u *UpdateNotification) isCI() bool {
 
 // isIgnoredCommand returns true when the process is in the list of commands.
 func (u *UpdateNotification) isIgnoredCommand() bool {
-	ignoredCommands := []string{"_fingerprint", "version"}
+	ignoredCommands := []string{"_fingerprint", "api", "version"}
 	osStr := os.Args[0:]
 	if len(osStr) < 2 {
 		return false

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -153,6 +153,10 @@ func Test_UpdateNotification_isIgnoredCommand(t *testing.T) {
 			command:  "",
 			expected: false,
 		},
+		"api command": {
+			command:  "api",
+			expected: true,
+		},
 		"fingerprint command": {
 			command:  "_fingerprint",
 			expected: true,


### PR DESCRIPTION
### Changelog

> The `slack api` command no longer displays CLI upgrade notifications. The `slack api` command is intended for scripting and direct API calls, where upgrade notifications interfere with parsing the response output.

### Summary

Adds `slack api` to the list of ignored commands in the upgrade notification system. 

The `slack api` command is intended for scripting and direct API calls, where upgrade notifications interfere with parsing the response output.

### Preview

- N/A

### Testing

1. Build with an artificially old version to trigger the upgrade notification:
   ```bash
   go build -ldflags="-X 'github.com/slackapi/slack-cli/internal/version.Version=v1.0.0'" -o bin/slack
   ```
2. Delete the `lastUpdateCheckedAt` timestamp from `~/.slack/config.json` so the check isn't skipped due to recency.
3. Verify `slack api` does NOT show an upgrade notification:
   ```bash
   ./bin/slack api apps.connections.open --token xoxb-fake
   ```
4. Verify another command DOES show the upgrade notification.
   ```bash
   ./bin/slack auth list
   ```

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-cli/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).