### PR TITLE
docs: escapes special characters in source description

### DIFF
--- a/cmd/api/api.go
+++ b/cmd/api/api.go
@@ -57,7 +57,7 @@ func NewCommand(clients *shared.ClientFactory) *cobra.Command {
 			"",
 			"Body format is auto-detected from positional arguments:",
 			"  - Multiple key=value args: form-encoded (token in request body)",
-			"  - Single arg starting with { or [: JSON (Bearer token in header)",
+			"  - Single arg starting with \\{ or \\[: JSON (Bearer token in header)",
 			"  - No args: token sent in Authorization header",
 			"",
 			"Use --json to explicitly send a JSON body, or --data for a form-encoded body string.",

--- a/docs/reference/commands/slack_api.md
+++ b/docs/reference/commands/slack_api.md
@@ -11,7 +11,7 @@ Parameters are passed as key=value pairs, a JSON body, or via flags.
 
 Body format is auto-detected from positional arguments:
   - Multiple key=value args: form-encoded (token in request body)
-  - Single arg starting with { or [: JSON (Bearer token in header)
+  - Single arg starting with \{ or \[: JSON (Bearer token in header)
   - No args: token sent in Authorization header
 
 Use --json to explicitly send a JSON body, or --data for a form-encoded body string.


### PR DESCRIPTION

### Summary

This messes with the generated md and breaks the site. (Not currently - site is now deploying off a temporary branch that reverted the release commit) 

### Requirements

- [X] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-cli/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
- [X] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
