### PR TITLE
fix: disable upgrade notification for the manifest info command

### DIFF
--- a/cmd/manifest/manifest.go
+++ b/cmd/manifest/manifest.go
@@ -72,6 +72,8 @@ func NewCommand(clients *shared.ClientFactory) *cobra.Command {
 			clients.Config.SetFlags(cmd)
 			return cmdutil.IsValidProjectDirectory(clients)
 		},
+		// DEPRECATED(semver:major): remove RunE so this command prints help like other parent commands
+		// and remove "manifest" from the ignore list in internal/update/update.go
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runInfoCommand(cmd, clients)
 		},

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -19,11 +19,11 @@ import (
 	"net/http"
 	"os"
 	"reflect"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/slackapi/slack-cli/internal/api"
-	"github.com/slackapi/slack-cli/internal/goutils"
 	"github.com/slackapi/slack-cli/internal/shared"
 	"github.com/slackapi/slack-cli/internal/slackerror"
 	"github.com/spf13/cobra"
@@ -223,13 +223,17 @@ func (u *UpdateNotification) isCI() bool {
 
 // isIgnoredCommand returns true when the process is in the list of commands.
 func (u *UpdateNotification) isIgnoredCommand() bool {
-	ignoredCommands := []string{"_fingerprint", "api", "version"}
-	osStr := os.Args[0:]
-	if len(osStr) < 2 {
+	ignoredCommands := []string{"_fingerprint", "api", "manifest info", "version"}
+	if len(os.Args) < 2 {
 		return false
 	}
-	commandName := osStr[1]
-	return goutils.Contains(ignoredCommands, commandName, true)
+	commandStr := strings.Join(os.Args[1:], " ")
+	for _, ignored := range ignoredCommands {
+		if commandStr == ignored || strings.HasPrefix(commandStr, ignored+" ") {
+			return true
+		}
+	}
+	return false
 }
 
 // isLastUpdateCheckedAtGreaterThan returns true when the time since the last update check is greater

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -223,14 +223,27 @@ func (u *UpdateNotification) isCI() bool {
 
 // isIgnoredCommand returns true when the process is in the list of commands.
 func (u *UpdateNotification) isIgnoredCommand() bool {
-	ignoredCommands := []string{"_fingerprint", "api", "manifest info", "version"}
+	// "manifest" is included because it's an alias that runs "manifest info"
+	ignoredCommands := []string{"_fingerprint", "api", "manifest", "manifest info", "version"}
 	if len(os.Args) < 2 {
 		return false
 	}
 	commandStr := strings.Join(os.Args[1:], " ")
 	for _, ignored := range ignoredCommands {
-		if commandStr == ignored || strings.HasPrefix(commandStr, ignored+" ") {
+		if commandStr == ignored {
 			return true
+		}
+		// Match commands with additional flags (e.g. "manifest info --source local")
+		// but not subcommands (e.g. "manifest validate" should not match "manifest")
+		if strings.HasPrefix(commandStr, ignored+" ") {
+			rest := commandStr[len(ignored)+1:]
+			if strings.HasPrefix(rest, "-") {
+				return true
+			}
+			// Allow prefix match for multi-word commands (e.g. "manifest info --flag")
+			if strings.Contains(ignored, " ") {
+				return true
+			}
 		}
 	}
 	return false

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -166,8 +166,20 @@ func Test_UpdateNotification_isIgnoredCommand(t *testing.T) {
 			command:  "version",
 			expected: true,
 		},
+		"manifest command": {
+			command:  "manifest",
+			expected: true,
+		},
+		"manifest command with flags": {
+			command:  "manifest --source local",
+			expected: true,
+		},
 		"manifest info command": {
 			command:  "manifest info",
+			expected: true,
+		},
+		"manifest info command with flags": {
+			command:  "manifest info --source local",
 			expected: true,
 		},
 		"manifest validate command": {

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -17,6 +17,7 @@ package update
 import (
 	"context"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/slackapi/slack-cli/internal/config"
@@ -165,6 +166,14 @@ func Test_UpdateNotification_isIgnoredCommand(t *testing.T) {
 			command:  "version",
 			expected: true,
 		},
+		"manifest info command": {
+			command:  "manifest info",
+			expected: true,
+		},
+		"manifest validate command": {
+			command:  "manifest validate",
+			expected: false,
+		},
 		"auth command": {
 			command:  "auth",
 			expected: false,
@@ -172,7 +181,7 @@ func Test_UpdateNotification_isIgnoredCommand(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			if tc.command != "" {
-				os.Args = []string{"placeholder", tc.command}
+				os.Args = append([]string{"placeholder"}, strings.Split(tc.command, " ")...)
 			} else {
 				os.Args = []string{"placeholder"}
 			}


### PR DESCRIPTION
### Changelog

> Disable upgrade notification for the `slack manifest` and `slack manifest info` command. The command returns JSON that may be used for scripting and the upgrade notifications interfere with parsing the response output.

### Summary

This pull request adds `manifest info` to the list of commands that suppress update notifications. The `manifest info` command outputs structured data consumed by other tools, so injecting an upgrade banner would corrupt the output.

Also extends `isIgnoredCommand()` to support multi-word subcommands (e.g., `manifest info` is ignored but `manifest validate` is not).

### Preview

N/A

### Testing

1. Build with an artificially old version to trigger the upgrade notification:
   ```bash
   go build -ldflags="-X 'github.com/slackapi/slack-cli/internal/version.Version=v1.0.0'" -o bin/slack
   ```
2. Delete the `lastUpdateCheckedAt` timestamp from `~/.slack/config.json` so the check isn't skipped due to recency.
3. Create a project:
   ```bash
   ./bin/slack create my-app/
   cd my-app/
   ```
4. Verify `slack manifest info` does NOT show an upgrade notification:
   ```bash
   ./bin/slack manifest info --source local
   ```
6. Verify another command DOES show the upgrade notification.
   ```bash
   ./bin/slack manifest validate
   ```

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-cli/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).