### PR TITLE
docs: clarify update check behavior in non-interactive environments

### DIFF
--- a/cmd/upgrade/upgrade.go
+++ b/cmd/upgrade/upgrade.go
@@ -40,6 +40,11 @@ func NewCommand(clients *shared.ClientFactory) *cobra.Command {
 			"",
 			"If there are any, then you will be prompted to upgrade",
 			"",
+			"In non-interactive environments (CI/CD, scripts, piped output),",
+			"update checks still run but the auto-update prompt is skipped.",
+			"To suppress update checks entirely on other commands, use",
+			"--skip-update or set SLACK_SKIP_UPDATE.",
+			"",
 			fmt.Sprintf(`The changelog can be found at {{LinkText "%s"}}`, changelogURL),
 		}, "\n"),
 		Example: style.ExampleCommandsf([]style.ExampleCommand{

--- a/docs/guides/authorizing-the-slack-cli.md
+++ b/docs/guides/authorizing-the-slack-cli.md
@@ -65,7 +65,8 @@ Update notifications can be disabled using a command-line flag or an environment
 
 When the CLI runs in a non-interactive environment, such as inside a CI/CD pipeline or when the output is piped, the update check runs without the auto-update confirmation prompt. The notification text may still appear in command output, however. You can suppress the check entirely with the `--skip-update` flag or `SLACK_SKIP_UPDATE` environment variable to keep the automation output clean.
 
-Note: `--skip-update` and `SLACK_SKIP_UPDATE` are intentionally ignored when running `slack upgrade` directly, since that command's purpose is to check for updates.
+:::info[The `--skip-update` flag and the `SLACK_SKIP_UPDATE` environment variable are intentionally ignored when running the `slack upgrade` command directly, since that command's purpose is to check for updates.
+:::
 
 ## CI/CD authorization {#ci-cd}
 

--- a/docs/guides/authorizing-the-slack-cli.md
+++ b/docs/guides/authorizing-the-slack-cli.md
@@ -63,7 +63,7 @@ Once a day, the Slack CLI checks for updates after running any command. When an 
 
 Update notifications can be disabled using a command-line flag or an environment variable. When running any command, you can append the `--skip-update` or `-s` flag. Alternatively, you can set the `SLACK_SKIP_UPDATE` environment variable and assign it any value.
 
-When the CLI runs in a non-interactive environment (no TTY) - for example, inside a CI/CD pipeline or when output is piped - the update check still runs but the auto-update confirmation prompt is skipped. Notification text may still appear in command output. To keep automation output clean, suppress the check entirely with `--skip-update` or `SLACK_SKIP_UPDATE`.
+When the CLI runs in a non-interactive environment, such as inside a CI/CD pipeline or when the output is piped, the update check runs without the auto-update confirmation prompt. The notification text may still appear in command output, however. You can suppress the check entirely with the `--skip-update` flag or `SLACK_SKIP_UPDATE` environment variable to keep the automation output clean.
 
 Note: `--skip-update` and `SLACK_SKIP_UPDATE` are intentionally ignored when running `slack upgrade` directly, since that command's purpose is to check for updates.
 

--- a/docs/guides/authorizing-the-slack-cli.md
+++ b/docs/guides/authorizing-the-slack-cli.md
@@ -63,6 +63,10 @@ Once a day, the Slack CLI checks for updates after running any command. When an 
 
 Update notifications can be disabled using a command-line flag or an environment variable. When running any command, you can append the `--skip-update` or `-s` flag. Alternatively, you can set the `SLACK_SKIP_UPDATE` environment variable and assign it any value.
 
+When the CLI runs in a non-interactive environment (no TTY) - for example, inside a CI/CD pipeline or when output is piped - the update check still runs but the auto-update confirmation prompt is skipped. Notification text may still appear in command output. To keep automation output clean, suppress the check entirely with `--skip-update` or `SLACK_SKIP_UPDATE`.
+
+Note: `--skip-update` and `SLACK_SKIP_UPDATE` are intentionally ignored when running `slack upgrade` directly, since that command's purpose is to check for updates.
+
 ## CI/CD authorization {#ci-cd}
 
 Setting up a CI/CD pipeline requires authorization using a service token. Service tokens are **long-lived, non-rotatable user tokens** &mdash; they won't expire, so they can be used to perform any Slack CLI action without the need to refresh tokens.

--- a/docs/guides/setting-up-ci-cd-with-the-slack-cli.md
+++ b/docs/guides/setting-up-ci-cd-with-the-slack-cli.md
@@ -60,7 +60,7 @@ In addition, you'll need to obtain a service token to authorize your CI/CD setup
 
 ### Disabling update checks {#disable-updates}
 
-In CI/CD pipelines, set `SLACK_SKIP_UPDATE=1` (or pass `--skip-update` on each command) to prevent the CLI from checking for new versions on every run. See [Version update notifications](/tools/slack-cli/guides/authorizing-the-slack-cli#version-updates) for details.
+In CI/CD pipelines, set a `SLACK_SKIP_UPDATE` environment variable to `1` (or pass `--skip-update` on each command) to prevent the CLI from checking for new versions on every run. See [Version update notifications](/tools/slack-cli/guides/authorizing-the-slack-cli#version-updates) for details.
 
 Once you've done those things, you're ready to get started! Let's walk through an example.
 

--- a/docs/guides/setting-up-ci-cd-with-the-slack-cli.md
+++ b/docs/guides/setting-up-ci-cd-with-the-slack-cli.md
@@ -58,6 +58,10 @@ You'll also need to accommodate requests from your network to a variety of hosts
 
 In addition, you'll need to obtain a service token to authorize your CI/CD setup. Refer to [CI/CD authorization](/tools/slack-cli/guides/authorizing-the-slack-cli#ci-cd) for more details about obtaining, using, and revoking service tokens.
 
+### Disabling update checks {#disable-updates}
+
+In CI/CD pipelines, set `SLACK_SKIP_UPDATE=1` (or pass `--skip-update` on each command) to prevent the CLI from checking for new versions on every run. See [Version update notifications](/tools/slack-cli/guides/authorizing-the-slack-cli#version-updates) for details.
+
 Once you've done those things, you're ready to get started! Let's walk through an example.
 
 Let's take a look at the [Virtual Running Buddies sample app](https://github.com/slack-samples/deno-virtual-running-buddies).

--- a/docs/reference/commands/slack_upgrade.md
+++ b/docs/reference/commands/slack_upgrade.md
@@ -8,6 +8,11 @@ Checks for available updates to the CLI or the SDKs of a project
 
 If there are any, then you will be prompted to upgrade
 
+In non-interactive environments (CI/CD, scripts, piped output),
+update checks still run but the auto-update prompt is skipped.
+To suppress update checks entirely on other commands, use
+--skip-update or set SLACK_SKIP_UPDATE.
+
 The changelog can be found at [https://docs.slack.dev/changelog](https://docs.slack.dev/changelog)
 
 ```


### PR DESCRIPTION
### Changelog

> Document how update checks and `--skip-update` behaves in non-interactive environments such as CI/CD pipelines.

### Summary

This pull request documents the existing non-TTY behavior of `slack upgrade` and the `--skip-update` / `SLACK_SKIP_UPDATE` controls so that users running the CLI in CI/CD or scripts can find clear guidance.

- Adds a non-interactive note to `slack upgrade --help`.
- Expands the "Version update notifications" section in the authorizing guide to cover non-TTY behavior.
- Adds a small "Disabling update checks" subsection in the CI/CD setup guide that links back.

### Preview

`slack upgrade --help`:

<img width="1524" height="1148" alt="image" src="https://github.com/user-attachments/assets/fe458e43-4987-4967-8851-bd3e5f8660c7" />

### Testing

- Run \`./bin/slack upgrade --help\` and confirm the new paragraph renders without terminal wrapping.

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-cli/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).