### PR TITLE
ci: use make rc to release candidate without tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
         run: |
           git config user.name "slack-cli-releaser[bot]"
           git config user.email "122933866+slack-cli-releaser[bot]@users.noreply.github.com"
-          make tag RELEASE_VERSION="$RELEASE_VERSION"
+          make rc RELEASE_VERSION="$RELEASE_VERSION"
           git push origin "HEAD:refs/heads/rc" --force
 
       - name: Create or update release PR


### PR DESCRIPTION
### Changelog

> Nothing but an oopsies in prior change...

### Summary

This PR follows #552 to use the correct `make` target.

### Preview

🔗 https://github.com/slackapi/slack-cli/actions/runs/26257441914/job/77283314836

### Testing

https://github.com/slackapi/slack-cli/blob/dd404fe3d719a598bd9df938119b1d325787de47/Makefile#L76-L79

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-cli/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
