### PR TITLE
test: support fish deploy hook checks

### DIFF
--- a/cmd/platform/deploy_test.go
+++ b/cmd/platform/deploy_test.go
@@ -213,6 +213,7 @@ func TestDeployCommand_DeployHook(t *testing.T) {
 				"./deployer.sh: No such file or directory",
 				"./deployer.sh: not found",
 				"no such file or directory: ./deployer.sh",
+				"Unknown command: ./deployer.sh",
 			},
 		},
 		"echos stdout output to standard out": {
@@ -220,7 +221,7 @@ func TestDeployCommand_DeployHook(t *testing.T) {
 			expectedStdout: "example_output_goes_here",
 		},
 		"echos stderr output to standard err": {
-			command:        ">&2 echo 'uhoh'",
+			command:        "echo 'uhoh' >&2",
 			expectedStderr: []string{"uhoh"},
 		},
 		"works well with shell built ins": {


### PR DESCRIPTION
### Changelog

> N/A - Testing changes.

### Summary

Fixes #462 by making the deploy hook test expectations work when the test process runs with `SHELL` set to fish.

The stderr hook case now uses redirection syntax that works in fish and POSIX-like shells, and the missing deployer case accepts fish's `Unknown command` wording in addition to the existing shell-specific messages.

### Validation

- `PATH="/opt/homebrew/bin:$PATH" SHELL=/opt/homebrew/bin/fish go test ./cmd/platform -count=1`
- `PATH="/opt/homebrew/bin:$PATH" SHELL=/bin/bash go test ./cmd/platform -count=1`
- `PATH="/opt/homebrew/bin:$PATH" SHELL=/opt/homebrew/bin/fish go test ./...`

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-cli/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
