### PR TITLE
fix: improve confirm prompt button contrast in ThemeSurvey

### DIFF
--- a/internal/style/theme.go
+++ b/internal/style/theme.go
@@ -203,5 +203,18 @@ func themeSurvey(isDark bool) *huh.Styles {
 		Bold(true).
 		SetString("[ ] ")
 
+	// Confirm button styles.
+	// ThemeBase defaults (black-on-white / white-on-black) are hard to
+	// distinguish in many terminal themes.  Use blue+bold for the selected
+	// button and a subdued gray for the unselected one so the choice is
+	// immediately obvious regardless of terminal background.
+	t.Focused.FocusedButton = lipgloss.NewStyle().
+		Foreground(ansiBlue).
+		Bold(true).
+		Padding(0, 1)
+	t.Focused.BlurredButton = lipgloss.NewStyle().
+		Foreground(ansiGray).
+		Padding(0, 1)
+
 	return t
 }


### PR DESCRIPTION
## Problem

Closes #562.

`ThemeSurvey` did not set `FocusedButton` or `BlurredButton` styles, so it fell through to `ThemeBase` defaults:
- **FocusedButton**: black text on white background (ANSI 0 on 7)
- **BlurredButton**: white text on black background (ANSI 7 on 0)

In many terminal color schemes these look nearly identical, making it unclear which Yes/No button is currently selected.

## Fix

Add explicit `FocusedButton` and `BlurredButton` styles in `themeSurvey`:

```go
t.Focused.FocusedButton = lipgloss.NewStyle().
    Foreground(ansiBlue).
    Bold(true).
    Padding(0, 1)
t.Focused.BlurredButton = lipgloss.NewStyle().
    Foreground(ansiGray).
    Padding(0, 1)
```

- **Focused** (selected): blue + bold — matches the existing `SelectSelector` / `SelectedOption` color used throughout `ThemeSurvey`, visually consistent.
- **Blurred** (unselected): gray, no bold — clearly inactive.

The contrast no longer depends on terminal background color.