### PR TITLE
ci: use idempotent labels when creating a release candidate pull request

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,6 +139,6 @@ jobs:
             gh pr edit "$EXISTING_PR" --title "$PR_TITLE" --body "$PR_BODY" --milestone "Next Release" --add-label "release" --add-label "semver:${SEMVER}"
             echo "Updated PR #$EXISTING_PR"
           else
-            gh pr create --draft --head rc --base main --title "$PR_TITLE" --body "$PR_BODY" --milestone "Next Release" --add-label "release" --add-label "semver:${SEMVER}"
+            gh pr create --draft --head rc --base main --title "$PR_TITLE" --body "$PR_BODY" --milestone "Next Release" --label "release" --label "semver:${SEMVER}"
             echo "Created new release PR"
           fi


### PR DESCRIPTION
### Changelog

> N/A - We're testing RC in "production" it seems...

### Summary

This PR follows #558 to use idempotent labels when creating a release candidate pull request instead of attempting to add labels to a new request.

### Preview

Error: https://github.com/slackapi/slack-cli/actions/runs/26968804619/job/79578379382

```
unknown flag: --add-label
```

### Testing

Sharing here with findings 🫡 

### Notes

The "remove" tag and "add" tag in updated PRs causes clutter but might be separate to follow up on I think!

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-cli/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
