### PR TITLE
feat: remove guard from "external-auth add-secret" command for non-hosted apps

### DIFF
--- a/cmd/externalauth/add_secret.go
+++ b/cmd/externalauth/add_secret.go
@@ -38,9 +38,6 @@ func NewAddClientSecretCommand(clients *shared.ClientFactory) *cobra.Command {
 			"Add the client secret for an external provider of a workflow app.",
 			"",
 			"This secret will be used when initiating the OAuth2 flow.",
-			"",
-			"This command is supported for apps deployed to Slack managed infrastructure but",
-			"other apps can attempt to run the command with the --force flag.",
 		}, "\n"),
 		Example: style.ExampleCommandsf([]style.ExampleCommand{
 			{
@@ -67,18 +64,10 @@ func NewAddClientSecretCommand(clients *shared.ClientFactory) *cobra.Command {
 	return cmd
 }
 
-// preRunAddClientSecretCommand determines if the command is supported for a
-// project and configures flags
-func preRunAddClientSecretCommand(ctx context.Context, clients *shared.ClientFactory, cmd *cobra.Command) error {
+// preRunAddClientSecretCommand configures flags and validates the project directory
+func preRunAddClientSecretCommand(_ context.Context, clients *shared.ClientFactory, cmd *cobra.Command) error {
 	clients.Config.SetFlags(cmd)
-	err := cmdutil.IsValidProjectDirectory(clients)
-	if err != nil {
-		return err
-	}
-	if clients.Config.ForceFlag {
-		return nil
-	}
-	return cmdutil.IsSlackHostedProject(ctx, clients)
+	return cmdutil.IsValidProjectDirectory(clients)
 }
 
 // runAddClientSecretCommand adds a client secret to an authentication provider

--- a/cmd/externalauth/add_secret_test.go
+++ b/cmd/externalauth/add_secret_test.go
@@ -19,8 +19,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/slackapi/slack-cli/internal/app"
-	"github.com/slackapi/slack-cli/internal/config"
 	"github.com/slackapi/slack-cli/internal/iostreams"
 	"github.com/slackapi/slack-cli/internal/shared"
 	"github.com/slackapi/slack-cli/internal/shared/types"
@@ -34,88 +32,22 @@ import (
 
 func TestExternalAuthAddClientSecretCommandPreRun(t *testing.T) {
 	tests := map[string]struct {
-		mockFlagForce        bool
-		mockManifestResponse types.SlackYaml
-		mockManifestError    error
-		mockManifestSource   config.ManifestSource
 		mockWorkingDirectory string
 		expectedError        error
 	}{
-		"continues if the application is hosted on slack": {
-			mockManifestResponse: types.SlackYaml{
-				AppManifest: types.AppManifest{
-					Settings: &types.AppSettings{
-						FunctionRuntime: types.SlackHosted,
-					},
-				},
-			},
-			mockManifestError:    nil,
+		"continues if the command is run in a valid project directory": {
 			mockWorkingDirectory: "/slack/path/to/project",
 			expectedError:        nil,
-		},
-		"errors if the application is not hosted on slack": {
-			mockManifestResponse: types.SlackYaml{
-				AppManifest: types.AppManifest{
-					Settings: &types.AppSettings{
-						FunctionRuntime: types.Remote,
-					},
-				},
-			},
-			mockManifestError:    nil,
-			mockManifestSource:   config.ManifestSourceLocal,
-			mockWorkingDirectory: "/slack/path/to/project",
-			expectedError:        slackerror.New(slackerror.ErrAppNotHosted),
-		},
-		"continues if the force flag is used in a project": {
-			mockFlagForce:        true,
-			mockWorkingDirectory: "/slack/path/to/project",
-			expectedError:        nil,
-		},
-		"errors if the project manifest cannot be retrieved": {
-			mockManifestResponse: types.SlackYaml{},
-			mockManifestError:    slackerror.New(slackerror.ErrSDKHookInvocationFailed),
-			mockManifestSource:   config.ManifestSourceLocal,
-			mockWorkingDirectory: "/slack/path/to/project",
-			expectedError:        slackerror.New(slackerror.ErrSDKHookInvocationFailed),
 		},
 		"errors if the command is not run in a project": {
-			mockManifestResponse: types.SlackYaml{},
-			mockManifestError:    slackerror.New(slackerror.ErrSDKHookNotFound),
-			mockManifestSource:   config.ManifestSourceLocal,
 			mockWorkingDirectory: "",
 			expectedError:        slackerror.New(slackerror.ErrInvalidAppDirectory),
-		},
-		"errors if the manifest source is set to remote": {
-			mockManifestSource:   config.ManifestSourceRemote,
-			mockWorkingDirectory: "/slack/path/to/project",
-			expectedError:        slackerror.New(slackerror.ErrAppNotHosted),
 		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			clientsMock := shared.NewClientsMock()
-			manifestMock := &app.ManifestMockObject{}
-			manifestMock.On(
-				"GetManifestLocal",
-				mock.Anything,
-				mock.Anything,
-				mock.Anything,
-			).Return(
-				tc.mockManifestResponse,
-				tc.mockManifestError,
-			)
-			clientsMock.AppClient.Manifest = manifestMock
-			projectConfigMock := config.NewProjectConfigMock()
-			projectConfigMock.On(
-				"GetManifestSource",
-				mock.Anything,
-			).Return(
-				tc.mockManifestSource,
-				nil,
-			)
-			clientsMock.Config.ProjectConfig = projectConfigMock
 			clients := shared.NewClientFactory(clientsMock.MockClientFactory(), func(cf *shared.ClientFactory) {
-				cf.Config.ForceFlag = tc.mockFlagForce
 				cf.SDKConfig.WorkingDirectory = tc.mockWorkingDirectory
 			})
 			cmd := NewAddClientSecretCommand(clients)


### PR DESCRIPTION
### Changelog

The `external-auth add-secret` command is now available to all apps instead of just apps run on Slack-managed infrastructure.

### Summary

This PR removes the ROSI guards from the `external-auth add-secret` command to unlock this option for configuring external auth providers outside of WFB.

### Testing

Follow these setup steps without using the "--force" flag:

🔗 https://github.com/slack-samples/bolt-js-examples/tree/feat/mcp-client-examples/ai/mcp-client/external-auth

### Notes

- I'm unsure if other `external-select` commands are meaningful to ungate or if we should wait for feedback on a use case? Open to follow up however!
- Will follow up with updating the linked doc above if this merges 📚 

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-cli/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).