### PR TITLE
docs: fix broken link to sandbox experimental commands

### DIFF
--- a/docs/reference/experiments.md
+++ b/docs/reference/experiments.md
@@ -12,7 +12,7 @@ The following is a list of currently available experiments. We'll remove experim
 ## Experiments changelog
 
 Below is a list of updates related to experiments.
-- **April 2026**: Concluded the `sandboxes` experiment with full support in the Slack CLI. Refer to the [`slack sandbox create`](/tools/slack-cli/reference/commands/slack_sandbox_create/), [`slack sandbox delete`](/tools/slack-cli/reference/commands/slack_sandbox_delete/), and [`slack sandbox list`](tools/slack-cli/reference/commands/slack_sandbox_list/) commands for more details.
+- **April 2026**: Concluded the `sandboxes` experiment with full support in the Slack CLI. Refer to the [`slack sandbox create`](/tools/slack-cli/reference/commands/slack_sandbox_create/), [`slack sandbox delete`](/tools/slack-cli/reference/commands/slack_sandbox_delete/), and [`slack sandbox list`](/tools/slack-cli/reference/commands/slack_sandbox_list/) commands for more details.
 - **April 2026**: Added the `set-icon` experiment to enable icon upload for non-hosted apps.
 - **April 2026**: Concluded the `huh` experiment with full support now enabled by default in the Slack CLI. 
 - **March 2026**: Split the `charm` experiment into more beautiful `huh` prompts and prettier `lipgloss` styles for ongoing change.


### PR DESCRIPTION
### Summary

A missing slash makes one link broken. This adds it in.

### Preview

(Add screenshots, GIFs, or recordings that show the changes)

### Testing

(List the steps used to verify these changes)

### Notes

(Add any additional context, trade-offs, or follow-up items)

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-cli/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
