### PR TITLE
feat: add support for 'features.agent_view' app manifest property

### DIFF
--- a/internal/shared/types/app_manifest.go
+++ b/internal/shared/types/app_manifest.go
@@ -70,6 +70,7 @@ type DisplayInformation struct {
 
 type AppFeatures struct {
 	AppHome                    ManifestAppHome             `json:"app_home,omitempty" yaml:"app_home,flow,omitempty"`
+	AgentView                  *AgentView                  `json:"agent_view,omitempty" yaml:"agent_view,omitempty"`
 	AssistantView              *AssistantView              `json:"assistant_view,omitempty" yaml:"assistant_view,omitempty"`
 	BotUser                    BotUser                     `json:"bot_user,omitempty" yaml:"bot_user,flow,omitempty"`
 	WorkflowSteps              []WorkflowStep              `json:"workflow_steps,omitempty" yaml:"workflow_steps,flow,omitempty"`
@@ -93,6 +94,17 @@ type AssistantView struct {
 type SuggestedPrompts struct {
 	Title   string `json:"title,omitempty" yaml:"title,omitempty"`
 	Message string `json:"message,omitempty" yaml:"message,omitempty"`
+}
+
+type AgentView struct {
+	AgentDescription string             `json:"agent_description,omitempty" yaml:"agent_description,omitempty"`
+	SuggestedPrompts []SuggestedPrompts `json:"suggested_prompts,omitempty" yaml:"suggested_prompts,flow,omitempty"`
+	Actions          []AgentViewAction  `json:"actions,omitempty" yaml:"actions,flow,omitempty"`
+}
+
+type AgentViewAction struct {
+	Name        string `json:"name,omitempty" yaml:"name,omitempty"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 }
 
 type OAuthConfig struct {

--- a/internal/shared/types/app_manifest_test.go
+++ b/internal/shared/types/app_manifest_test.go
@@ -192,6 +192,40 @@ func Test_AppManifest_AppFeatures(t *testing.T) {
 			},
 			want: `{"app_home":{},"assistant_view":{"assistant_description":"magic","suggested_prompts":[{"title":"visit the beach","message":"what is glass"}]},"bot_user":{"display_name":"einstein"}}`,
 		},
+		"includes agent view when provided": {
+			features: AppFeatures{
+				AgentView: &AgentView{
+					AgentDescription: "summarizes threads",
+					SuggestedPrompts: []SuggestedPrompts{
+						{
+							Title:   "summarize this thread",
+							Message: "please summarize the conversation",
+						},
+					},
+					Actions: []AgentViewAction{
+						{
+							Name:        "open_settings",
+							Description: "Open the agent settings panel.",
+						},
+					},
+				},
+				BotUser: BotUser{
+					DisplayName: "agent_smith",
+				},
+			},
+			want: `{"app_home":{},"agent_view":{"agent_description":"summarizes threads","suggested_prompts":[{"title":"summarize this thread","message":"please summarize the conversation"}],"actions":[{"name":"open_settings","description":"Open the agent settings panel."}]},"bot_user":{"display_name":"agent_smith"}}`,
+		},
+		"omits agent view fields when empty": {
+			features: AppFeatures{
+				AgentView: &AgentView{
+					AgentDescription: "minimal",
+				},
+				BotUser: BotUser{
+					DisplayName: "agent_smith",
+				},
+			},
+			want: `{"app_home":{},"agent_view":{"agent_description":"minimal"},"bot_user":{"display_name":"agent_smith"}}`,
+		},
 		"includes search when provided": {
 			features: AppFeatures{
 				BotUser: BotUser{
@@ -224,6 +258,54 @@ func Test_AppManifest_AppFeatures(t *testing.T) {
 			assert.Equal(t, tc.want, string(actual))
 		})
 	}
+}
+
+func Test_AppManifest_AgentView_RoundTrip(t *testing.T) {
+	original := AppManifest{
+		DisplayInformation: DisplayInformation{Name: "agent_smith"},
+		Features: &AppFeatures{
+			AgentView: &AgentView{
+				AgentDescription: "summarizes threads",
+				SuggestedPrompts: []SuggestedPrompts{
+					{Title: "summarize", Message: "please summarize"},
+				},
+				Actions: []AgentViewAction{
+					{Name: "open_settings", Description: "Open the agent settings panel."},
+				},
+			},
+		},
+	}
+
+	t.Run("JSON round-trip preserves agent_view", func(t *testing.T) {
+		blob, err := json.Marshal(original)
+		require.NoError(t, err)
+		assert.Contains(t, string(blob), `"agent_view":{`)
+
+		var got AppManifest
+		require.NoError(t, json.Unmarshal(blob, &got))
+		assert.Equal(t, original.Features.AgentView, got.Features.AgentView)
+	})
+
+	t.Run("YAML round-trip preserves agent_view", func(t *testing.T) {
+		blob, err := yaml.Marshal(original)
+		require.NoError(t, err)
+		assert.Contains(t, string(blob), "agent_view:")
+		assert.Contains(t, string(blob), "agent_description: summarizes threads")
+
+		var got AppManifest
+		require.NoError(t, yaml.Unmarshal(blob, &got))
+		assert.Equal(t, original.Features.AgentView, got.Features.AgentView)
+	})
+
+	t.Run("nil agent_view is omitted from JSON", func(t *testing.T) {
+		manifest := AppManifest{
+			DisplayInformation: DisplayInformation{Name: "no_agent"},
+			Features:           &AppFeatures{BotUser: BotUser{DisplayName: "no_agent"}},
+		}
+		blob, err := json.Marshal(manifest)
+		require.NoError(t, err)
+		assert.NotContains(t, string(blob), "agent_view")
+	})
 }
 
 func Test_AppManifest_AppSettings_SiwsLinks(t *testing.T) {

--- a/internal/shared/types/app_manifest_test.go
+++ b/internal/shared/types/app_manifest_test.go
@@ -260,54 +260,6 @@ func Test_AppManifest_AppFeatures(t *testing.T) {
 	}
 }
 
-func Test_AppManifest_AgentView_RoundTrip(t *testing.T) {
-	original := AppManifest{
-		DisplayInformation: DisplayInformation{Name: "agent_smith"},
-		Features: &AppFeatures{
-			AgentView: &AgentView{
-				AgentDescription: "summarizes threads",
-				SuggestedPrompts: []SuggestedPrompts{
-					{Title: "summarize", Message: "please summarize"},
-				},
-				Actions: []AgentViewAction{
-					{Name: "open_settings", Description: "Open the agent settings panel."},
-				},
-			},
-		},
-	}
-
-	t.Run("JSON round-trip preserves agent_view", func(t *testing.T) {
-		blob, err := json.Marshal(original)
-		require.NoError(t, err)
-		assert.Contains(t, string(blob), `"agent_view":{`)
-
-		var got AppManifest
-		require.NoError(t, json.Unmarshal(blob, &got))
-		assert.Equal(t, original.Features.AgentView, got.Features.AgentView)
-	})
-
-	t.Run("YAML round-trip preserves agent_view", func(t *testing.T) {
-		blob, err := yaml.Marshal(original)
-		require.NoError(t, err)
-		assert.Contains(t, string(blob), "agent_view:")
-		assert.Contains(t, string(blob), "agent_description: summarizes threads")
-
-		var got AppManifest
-		require.NoError(t, yaml.Unmarshal(blob, &got))
-		assert.Equal(t, original.Features.AgentView, got.Features.AgentView)
-	})
-
-	t.Run("nil agent_view is omitted from JSON", func(t *testing.T) {
-		manifest := AppManifest{
-			DisplayInformation: DisplayInformation{Name: "no_agent"},
-			Features:           &AppFeatures{BotUser: BotUser{DisplayName: "no_agent"}},
-		}
-		blob, err := json.Marshal(manifest)
-		require.NoError(t, err)
-		assert.NotContains(t, string(blob), "agent_view")
-	})
-}
-
 func Test_AppManifest_AppSettings_SiwsLinks(t *testing.T) {
 	expectedSiws := SiwsLinks{
 		InitiateURI: "an initiate uri",


### PR DESCRIPTION
### Changelog

> Add support for the new app manifest property `features.agent_view`. This prevents the CLI from silently dropping `agent_view` when reading and writing a manifest.

### Summary

Supports the upcoming `features.agent_view` in the Slack app manifest. Without these struct changes the CLI silently drops `agent_view` when reading and writing a manifest.

- Mirrors the existing `AssistantView` shape and reuses the existing `SuggestedPrompts` type because `agent_view` and `assistant_view` are sibling properties.
- The CLI delegates manifest validation to the backend, so no validator changes are needed - these struct edits ensure the field round-trips cleanly through JSON and YAML.

Related: slackapi/manifest-schema#74

### Preview

- N/A

### Testing

```bash
# Create a new app
$ ./bin/slack create my-app -t slack-samples/bolt-js-starter-agent --subdir claude-agent-sdk
$ cd my-app/

$ vim manifest.json
# Add the following under "assistant_view":
$ cat manifest.json
    "assistant_view": {
      "assistant_description": "Hi, I am an agent built using Bolt for JavaScript. I am here to help you out!",
      "suggested_prompts": []
    },
    "agent_view": {
      "agent_description": "Hi, I am an agent built using Bolt for JavaScript. I am here to help you out!",
      "suggested_prompts": [],
      "actions": [{
        "name": "open_settings",
        "description": "Open the agent settings panel."
      }]
    },

# Test that the `agent_view` survives reading:
$ ../bin/slack manifest info --source local
# → Confirm "agent_view": { ...

# Clean up
$ cd ../
$ rm -rf my-app/
```

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-cli/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).