### PR TITLE
feat(create): cleanup app creation outputs when `slack create -app` passed

### DIFF
--- a/cmd/app/link.go
+++ b/cmd/app/link.go
@@ -32,9 +32,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// LinkAppConfirmPromptText is displayed when prompting to add an existing app
-const LinkAppConfirmPromptText = "Do you want to add an existing app?"
-
 // appLinkFlagSet contains flag values to reference
 type appLinkFlagSet struct {
 	environmentFlag string

--- a/cmd/app/link.go
+++ b/cmd/app/link.go
@@ -192,6 +192,37 @@ func LinkExistingApp(ctx context.Context, clients *shared.ClientFactory, app *ty
 	return nil
 }
 
+// LinkExistingAppQuiet links an existing app without verbose output. It resolves
+// the team and environment, validates the app, saves it, and prints only the app
+// summary. Used by `create --app` where the surrounding create output is enough.
+func LinkExistingAppQuiet(ctx context.Context, clients *shared.ClientFactory, app *types.App) error {
+	linkedApp, auth, err := promptExistingApp(ctx, clients)
+	if err != nil {
+		return err
+	}
+	*app = linkedApp
+
+	appIDs := []string{app.AppID}
+	_, err = clients.API().GetAppStatus(ctx, auth.Token, appIDs, app.TeamID)
+	if err != nil {
+		return err
+	}
+
+	err = saveAppToJSON(ctx, clients, *app)
+	if err != nil {
+		clients.IO.PrintDebug(ctx, "Error saving app to file when linking existing app: %s", err)
+		return err
+	}
+
+	clients.IO.PrintInfo(ctx, false, "\n%s", style.Sectionf(style.TextSection{
+		Emoji:     "house",
+		Text:      "App",
+		Secondary: formatListSuccess([]types.App{*app}),
+	}))
+
+	return nil
+}
+
 // LinkAppFooterSection displays the details of app that was added to the project.
 func LinkAppFooterSection(ctx context.Context, clients *shared.ClientFactory, app *types.App) {
 	clients.IO.PrintInfo(ctx, false, "\n%s", style.Sectionf(style.TextSection{

--- a/cmd/app/link.go
+++ b/cmd/app/link.go
@@ -98,7 +98,7 @@ func LinkCommandRunE(ctx context.Context, clients *shared.ClientFactory, app *ty
 	clients.IO.PrintInfo(ctx, false, "")
 
 	// Header section
-	LinkAppHeaderSection(ctx, clients, false)
+	LinkAppHeaderSection(ctx, clients)
 
 	// App Manifest section
 	manifestSource, err := clients.Config.ProjectConfig.GetManifestSource(ctx)
@@ -141,23 +141,14 @@ func LinkCommandRunE(ctx context.Context, clients *shared.ClientFactory, app *ty
 }
 
 // LinkAppHeaderSection displays a section explaining how to find existing apps.
-// External callers can use extraSecondaryText to show additional information.
-// When shouldConfirm is true, additional information is included in the header
-// explaining how to link apps, in case the user declines.
-func LinkAppHeaderSection(ctx context.Context, clients *shared.ClientFactory, shouldConfirm bool) {
-	var secondaryText = []string{
-		"Add an existing app from app settings",
-		"Find your existing apps at: " + style.Underline("https://api.slack.com/apps"),
-	}
-
-	if shouldConfirm {
-		secondaryText = append(secondaryText, "Manually add apps later with "+style.Commandf("app link", true))
-	}
-
+func LinkAppHeaderSection(ctx context.Context, clients *shared.ClientFactory) {
 	clients.IO.PrintInfo(ctx, false, "%s", style.Sectionf(style.TextSection{
-		Emoji:     "house",
-		Text:      "App Link",
-		Secondary: secondaryText,
+		Emoji: "house",
+		Text:  "App Link",
+		Secondary: []string{
+			"Add an existing app from app settings",
+			"Find your existing apps at: " + style.Underline("https://api.slack.com/apps"),
+		},
 	}))
 }
 

--- a/cmd/app/link.go
+++ b/cmd/app/link.go
@@ -80,7 +80,7 @@ func NewLinkCommand(clients *shared.ClientFactory) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			clients.IO.PrintTrace(ctx, slacktrace.AppLinkStart)
-			return LinkCommandRunE(ctx, clients, app)
+			return LinkCommandRunE(ctx, clients, app, false, false)
 		},
 		PostRunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
@@ -93,13 +93,69 @@ func NewLinkCommand(clients *shared.ClientFactory) *cobra.Command {
 }
 
 // LinkCommandRunE saves details about the provided application
-func LinkCommandRunE(ctx context.Context, clients *shared.ClientFactory, app *types.App) (err error) {
-	// Add empty line between executed command and first output
-	clients.IO.PrintInfo(ctx, false, "")
+func LinkCommandRunE(ctx context.Context, clients *shared.ClientFactory, app *types.App, shouldConfirm bool, quiet bool) (err error) {
+	if !quiet {
+		// Add empty line between executed command and first output
+		clients.IO.PrintInfo(ctx, false, "")
+		// Header section
+		LinkAppHeaderSection(ctx, clients, shouldConfirm)
+	}
 
-	err = LinkExistingApp(ctx, clients, app, false)
+	// Confirm to add an existing app; useful for third-party callers
+	if shouldConfirm {
+		proceed, err := clients.IO.ConfirmPrompt(ctx, LinkAppConfirmPromptText, true)
+		if err != nil {
+			clients.IO.PrintDebug(ctx, "Error prompting to add an existing app: %s", err)
+			return err
+		}
+
+		// Add newline to match the trailing newline inserted from the footer section
+		clients.IO.PrintInfo(ctx, false, "")
+
+		if !proceed {
+			return nil
+		}
+	}
+
+	if !quiet {
+		// App Manifest section
+		manifestSource, err := clients.Config.ProjectConfig.GetManifestSource(ctx)
+		if err != nil {
+			return err
+		}
+
+		configPath := filepath.Join(config.ProjectConfigDirName, config.ProjectConfigJSONFilename)
+		clients.IO.PrintInfo(ctx, false, "%s", style.Sectionf(style.TextSection{
+			Emoji: "books",
+			Text:  "App Manifest",
+			Secondary: []string{
+				"Manifest source is gathered from " + style.Highlight(manifestSource.Human()),
+				"Manifest source is configured in " + style.Highlight(configPath),
+			},
+		}))
+	}
+
+	err = LinkExistingApp(ctx, clients, app)
 	if err != nil {
 		return err
+	}
+
+	// App summary section
+	clients.IO.PrintInfo(ctx, false, "%s", style.Sectionf(style.TextSection{
+		Emoji:     "house",
+		Text:      "App",
+		Secondary: formatListSuccess([]types.App{*app}),
+	}))
+
+	if !quiet {
+		// Footer section
+		clients.IO.PrintInfo(ctx, false, "%s", style.Sectionf(style.TextSection{
+			Emoji: "house_with_garden",
+			Text:  "App Link",
+			Secondary: []string{
+				"Added existing app to project",
+			},
+		}))
 	}
 
 	return nil
@@ -126,46 +182,9 @@ func LinkAppHeaderSection(ctx context.Context, clients *shared.ClientFactory, sh
 	}))
 }
 
-// LinkExistingApp prompts for an existing App ID and saves the details to the project.
-// When shouldConfirm is true, a confirmation prompt will ask the user if they want to
-// link an existing app and additional information is included in the header.
-// The shouldConfirm option is encouraged for third-party callers.
-func LinkExistingApp(ctx context.Context, clients *shared.ClientFactory, app *types.App, shouldConfirm bool) (err error) {
-	// Header section
-	LinkAppHeaderSection(ctx, clients, shouldConfirm)
-
-	// Confirm to add an existing app; useful for third-party callers
-	if shouldConfirm {
-		proceed, err := clients.IO.ConfirmPrompt(ctx, LinkAppConfirmPromptText, true)
-		if err != nil {
-			clients.IO.PrintDebug(ctx, "Error prompting to add an existing app: %s", err)
-			return err
-		}
-
-		// Add newline to match the trailing newline inserted from the footer section
-		clients.IO.PrintInfo(ctx, false, "")
-
-		if !proceed {
-			return nil
-		}
-	}
-
-	// App Manifest section
-	manifestSource, err := clients.Config.ProjectConfig.GetManifestSource(ctx)
-	if err != nil {
-		return err
-	}
-
-	configPath := filepath.Join(config.ProjectConfigDirName, config.ProjectConfigJSONFilename)
-	clients.IO.PrintInfo(ctx, false, "%s", style.Sectionf(style.TextSection{
-		Emoji: "books",
-		Text:  "App Manifest",
-		Secondary: []string{
-			"Manifest source is gathered from " + style.Highlight(manifestSource.Human()),
-			"Manifest source is configured in " + style.Highlight(configPath),
-		},
-	}))
-
+// LinkExistingApp resolves app details, validates the app, and saves it to the
+// project. It produces no output — callers handle their own display.
+func LinkExistingApp(ctx context.Context, clients *shared.ClientFactory, app *types.App) (err error) {
 	// Prompt to get app details
 	var auth *types.SlackAuth
 	*app, auth, err = promptExistingApp(ctx, clients)
@@ -186,57 +205,7 @@ func LinkExistingApp(ctx context.Context, clients *shared.ClientFactory, app *ty
 		return err
 	}
 
-	// Footer section
-	LinkAppFooterSection(ctx, clients, app)
-
 	return nil
-}
-
-// LinkExistingAppQuiet links an existing app without verbose output. It resolves
-// the team and environment, validates the app, saves it, and prints only the app
-// summary. Used by `create --app` where the surrounding create output is enough.
-func LinkExistingAppQuiet(ctx context.Context, clients *shared.ClientFactory, app *types.App) error {
-	linkedApp, auth, err := promptExistingApp(ctx, clients)
-	if err != nil {
-		return err
-	}
-	*app = linkedApp
-
-	appIDs := []string{app.AppID}
-	_, err = clients.API().GetAppStatus(ctx, auth.Token, appIDs, app.TeamID)
-	if err != nil {
-		return err
-	}
-
-	err = saveAppToJSON(ctx, clients, *app)
-	if err != nil {
-		clients.IO.PrintDebug(ctx, "Error saving app to file when linking existing app: %s", err)
-		return err
-	}
-
-	clients.IO.PrintInfo(ctx, false, "\n%s", style.Sectionf(style.TextSection{
-		Emoji:     "house",
-		Text:      "App",
-		Secondary: formatListSuccess([]types.App{*app}),
-	}))
-
-	return nil
-}
-
-// LinkAppFooterSection displays the details of app that was added to the project.
-func LinkAppFooterSection(ctx context.Context, clients *shared.ClientFactory, app *types.App) {
-	clients.IO.PrintInfo(ctx, false, "\n%s", style.Sectionf(style.TextSection{
-		Emoji:     "house",
-		Text:      "App",
-		Secondary: formatListSuccess([]types.App{*app}),
-	}))
-	clients.IO.PrintInfo(ctx, false, "%s", style.Sectionf(style.TextSection{
-		Emoji: "house_with_garden",
-		Text:  "App Link",
-		Secondary: []string{
-			"Added existing app to project",
-		},
-	}))
 }
 
 // promptExistingApp gathers details to represent app information

--- a/cmd/app/link.go
+++ b/cmd/app/link.go
@@ -80,7 +80,7 @@ func NewLinkCommand(clients *shared.ClientFactory) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
 			clients.IO.PrintTrace(ctx, slacktrace.AppLinkStart)
-			return LinkCommandRunE(ctx, clients, app, false, false)
+			return LinkCommandRunE(ctx, clients, app)
 		},
 		PostRunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
@@ -93,47 +93,28 @@ func NewLinkCommand(clients *shared.ClientFactory) *cobra.Command {
 }
 
 // LinkCommandRunE saves details about the provided application
-func LinkCommandRunE(ctx context.Context, clients *shared.ClientFactory, app *types.App, shouldConfirm bool, quiet bool) (err error) {
-	if !quiet {
-		// Add empty line between executed command and first output
-		clients.IO.PrintInfo(ctx, false, "")
-		// Header section
-		LinkAppHeaderSection(ctx, clients, shouldConfirm)
+func LinkCommandRunE(ctx context.Context, clients *shared.ClientFactory, app *types.App) (err error) {
+	// Add empty line between executed command and first output
+	clients.IO.PrintInfo(ctx, false, "")
+
+	// Header section
+	LinkAppHeaderSection(ctx, clients, false)
+
+	// App Manifest section
+	manifestSource, err := clients.Config.ProjectConfig.GetManifestSource(ctx)
+	if err != nil {
+		return err
 	}
 
-	// Confirm to add an existing app; useful for third-party callers
-	if shouldConfirm {
-		proceed, err := clients.IO.ConfirmPrompt(ctx, LinkAppConfirmPromptText, true)
-		if err != nil {
-			clients.IO.PrintDebug(ctx, "Error prompting to add an existing app: %s", err)
-			return err
-		}
-
-		// Add newline to match the trailing newline inserted from the footer section
-		clients.IO.PrintInfo(ctx, false, "")
-
-		if !proceed {
-			return nil
-		}
-	}
-
-	if !quiet {
-		// App Manifest section
-		manifestSource, err := clients.Config.ProjectConfig.GetManifestSource(ctx)
-		if err != nil {
-			return err
-		}
-
-		configPath := filepath.Join(config.ProjectConfigDirName, config.ProjectConfigJSONFilename)
-		clients.IO.PrintInfo(ctx, false, "%s", style.Sectionf(style.TextSection{
-			Emoji: "books",
-			Text:  "App Manifest",
-			Secondary: []string{
-				"Manifest source is gathered from " + style.Highlight(manifestSource.Human()),
-				"Manifest source is configured in " + style.Highlight(configPath),
-			},
-		}))
-	}
+	configPath := filepath.Join(config.ProjectConfigDirName, config.ProjectConfigJSONFilename)
+	clients.IO.PrintInfo(ctx, false, "%s", style.Sectionf(style.TextSection{
+		Emoji: "books",
+		Text:  "App Manifest",
+		Secondary: []string{
+			"Manifest source is gathered from " + style.Highlight(manifestSource.Human()),
+			"Manifest source is configured in " + style.Highlight(configPath),
+		},
+	}))
 
 	err = LinkExistingApp(ctx, clients, app)
 	if err != nil {
@@ -144,19 +125,17 @@ func LinkCommandRunE(ctx context.Context, clients *shared.ClientFactory, app *ty
 	clients.IO.PrintInfo(ctx, false, "%s", style.Sectionf(style.TextSection{
 		Emoji:     "house",
 		Text:      "App",
-		Secondary: formatListSuccess([]types.App{*app}),
+		Secondary: FormatListSuccess([]types.App{*app}),
 	}))
 
-	if !quiet {
-		// Footer section
-		clients.IO.PrintInfo(ctx, false, "%s", style.Sectionf(style.TextSection{
-			Emoji: "house_with_garden",
-			Text:  "App Link",
-			Secondary: []string{
-				"Added existing app to project",
-			},
-		}))
-	}
+	// Footer section
+	clients.IO.PrintInfo(ctx, false, "%s", style.Sectionf(style.TextSection{
+		Emoji: "house_with_garden",
+		Text:  "App Link",
+		Secondary: []string{
+			"Added existing app to project",
+		},
+	}))
 
 	return nil
 }

--- a/cmd/app/link_test.go
+++ b/cmd/app/link_test.go
@@ -572,16 +572,31 @@ func Test_Apps_Link(t *testing.T) {
 }
 
 func Test_Apps_LinkAppHeaderSection(t *testing.T) {
-	ctx := slackcontext.MockContext(t.Context())
-	clientsMock := shared.NewClientsMock()
-	clientsMock.AddDefaultMocks()
-	clients := shared.NewClientFactory(clientsMock.MockClientFactory())
+	tests := map[string]struct {
+		expectedOutputs []string
+	}{
+		"Displays app link header with base information": {
+			expectedOutputs: []string{
+				"Add an existing app from app settings",
+				"Find your existing apps at: https://api.slack.com/apps",
+			},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx := slackcontext.MockContext(t.Context())
+			clientsMock := shared.NewClientsMock()
+			clientsMock.AddDefaultMocks()
+			clients := shared.NewClientFactory(clientsMock.MockClientFactory())
 
-	LinkAppHeaderSection(ctx, clients)
+			LinkAppHeaderSection(ctx, clients)
 
-	output := clientsMock.GetCombinedOutput()
-	require.Contains(t, output, "Add an existing app from app settings")
-	require.Contains(t, output, "Find your existing apps at: https://api.slack.com/apps")
+			output := clientsMock.GetCombinedOutput()
+			for _, expectedOutput := range tc.expectedOutputs {
+				require.Contains(t, output, expectedOutput)
+			}
+		})
+	}
 }
 
 func setupAppLinkCommandMocks(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {

--- a/cmd/app/link_test.go
+++ b/cmd/app/link_test.go
@@ -572,53 +572,16 @@ func Test_Apps_Link(t *testing.T) {
 }
 
 func Test_Apps_LinkAppHeaderSection(t *testing.T) {
-	tests := map[string]struct {
-		shouldConfirm     bool
-		expectedOutputs   []string
-		unexpectedOutputs []string
-	}{
-		"When shouldConfirm is false": {
-			shouldConfirm: false,
-			expectedOutputs: []string{
-				"Add an existing app from app settings",
-				"Find your existing apps at: https://api.slack.com/apps",
-			},
-			unexpectedOutputs: []string{
-				"Manually add apps later with",
-			},
-		},
-		"When shouldConfirm is true": {
-			shouldConfirm: true,
-			expectedOutputs: []string{
-				"Add an existing app from app settings",
-				"Find your existing apps at: https://api.slack.com/apps",
-				"Manually add apps later with",
-			},
-		},
-	}
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			// Create mocks
-			ctx := slackcontext.MockContext(t.Context())
-			clientsMock := shared.NewClientsMock()
-			clientsMock.AddDefaultMocks()
+	ctx := slackcontext.MockContext(t.Context())
+	clientsMock := shared.NewClientsMock()
+	clientsMock.AddDefaultMocks()
+	clients := shared.NewClientFactory(clientsMock.MockClientFactory())
 
-			// Create clients that is mocked for testing
-			clients := shared.NewClientFactory(clientsMock.MockClientFactory())
+	LinkAppHeaderSection(ctx, clients)
 
-			// Run the test
-			LinkAppHeaderSection(ctx, clients, tc.shouldConfirm)
-
-			// Assertions
-			output := clientsMock.GetCombinedOutput()
-			for _, expectedOutput := range tc.expectedOutputs {
-				require.Contains(t, output, expectedOutput)
-			}
-			for _, unexpectedOutput := range tc.unexpectedOutputs {
-				require.NotContains(t, output, unexpectedOutput)
-			}
-		})
-	}
+	output := clientsMock.GetCombinedOutput()
+	require.Contains(t, output, "Add an existing app from app settings")
+	require.Contains(t, output, "Find your existing apps at: https://api.slack.com/apps")
 }
 
 func setupAppLinkCommandMocks(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {

--- a/cmd/app/list.go
+++ b/cmd/app/list.go
@@ -73,13 +73,13 @@ func runListCommand(cmd *cobra.Command, clients *shared.ClientFactory) error {
 	clients.IO.PrintInfo(ctx, false, "\n%s", style.Sectionf(style.TextSection{
 		Emoji:     "house_buildings",
 		Text:      "Apps",
-		Secondary: formatListSuccess(envs),
+		Secondary: FormatListSuccess(envs),
 	}))
 	return nil
 }
 
-// formatListSuccess formats details about the list of project apps
-func formatListSuccess(apps []types.App) (secondaryText []string) {
+// FormatListSuccess formats details about the list of project apps
+func FormatListSuccess(apps []types.App) (secondaryText []string) {
 	for _, app := range apps {
 		if app.AppID == "" {
 			continue

--- a/cmd/app/list_test.go
+++ b/cmd/app/list_test.go
@@ -218,7 +218,7 @@ func TestAppsListFormat(t *testing.T) {
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
 			listFlags = tc.Flags
-			formattedList := formatListSuccess(tc.Apps)
+			formattedList := FormatListSuccess(tc.Apps)
 			for ii, value := range formattedList {
 				formattedList[ii] = strings.TrimRight(value, ":")
 			}

--- a/cmd/project/create.go
+++ b/cmd/project/create.go
@@ -229,7 +229,7 @@ func runCreateCommand(clients *shared.ClientFactory, cmd *cobra.Command, args []
 		defer func() {
 			_ = os.Chdir(originalDir)
 		}()
-		if err := app.LinkExistingAppQuiet(ctx, clients, &types.App{}); err != nil {
+		if err := app.LinkCommandRunE(ctx, clients, &types.App{}, false, true); err != nil {
 			return err
 		}
 	}

--- a/cmd/project/create.go
+++ b/cmd/project/create.go
@@ -229,9 +229,15 @@ func runCreateCommand(clients *shared.ClientFactory, cmd *cobra.Command, args []
 		defer func() {
 			_ = os.Chdir(originalDir)
 		}()
-		if err := app.LinkCommandRunE(ctx, clients, &types.App{}, false, true); err != nil {
+		linkedApp := &types.App{}
+		if err := app.LinkExistingApp(ctx, clients, linkedApp); err != nil {
 			return err
 		}
+		clients.IO.PrintInfo(ctx, false, "%s", style.Sectionf(style.TextSection{
+			Emoji:     "house",
+			Text:      "App",
+			Secondary: app.FormatListSuccess([]types.App{*linkedApp}),
+		}))
 	}
 
 	printCreateSuccess(ctx, clients, appDirPath)

--- a/cmd/project/create.go
+++ b/cmd/project/create.go
@@ -229,7 +229,7 @@ func runCreateCommand(clients *shared.ClientFactory, cmd *cobra.Command, args []
 		defer func() {
 			_ = os.Chdir(originalDir)
 		}()
-		if err := app.LinkExistingApp(ctx, clients, &types.App{}, false); err != nil {
+		if err := app.LinkExistingAppQuiet(ctx, clients, &types.App{}); err != nil {
 			return err
 		}
 	}

--- a/cmd/project/init.go
+++ b/cmd/project/init.go
@@ -110,7 +110,8 @@ func projectInitCommandRunE(clients *shared.ClientFactory, cmd *cobra.Command, a
 	_ = create.InstallProjectDependencies(ctx, clients, projectDirPath)
 
 	// Prompt to add an existing app to the project
-	app.LinkAppHeaderSection(ctx, clients, true)
+	app.LinkAppHeaderSection(ctx, clients)
+	clients.IO.PrintInfo(ctx, false, "   %s\n", "Manually add apps later with "+style.Commandf("app link", true))
 	proceed, err := clients.IO.ConfirmPrompt(ctx, app.LinkAppConfirmPromptText, true)
 	if err != nil {
 		clients.IO.PrintDebug(ctx, "Error prompting to add an existing app: %s", err)

--- a/cmd/project/init.go
+++ b/cmd/project/init.go
@@ -29,6 +29,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const linkAppConfirmPromptText = "Do you want to add an existing app?"
+
 // NewInitCommand returns a Cobra command to initialize projects with Slack CLI support
 func NewInitCommand(clients *shared.ClientFactory) *cobra.Command {
 	cmd := &cobra.Command{
@@ -111,10 +113,9 @@ func projectInitCommandRunE(clients *shared.ClientFactory, cmd *cobra.Command, a
 
 	// Prompt to add an existing app to the project
 	app.LinkAppHeaderSection(ctx, clients)
-	clients.IO.PrintInfo(ctx, false, "   %s\n", "Manually add apps later with "+style.Commandf("app link", true))
-	proceed, err := clients.IO.ConfirmPrompt(ctx, app.LinkAppConfirmPromptText, true)
+	proceed, err := clients.IO.ConfirmPrompt(ctx, linkAppConfirmPromptText, true)
 	if err != nil {
-		clients.IO.PrintDebug(ctx, "Error prompting to add an existing app: %s", err)
+		return err
 	}
 	if proceed {
 		linkedApp := &types.App{}

--- a/cmd/project/init.go
+++ b/cmd/project/init.go
@@ -109,11 +109,25 @@ func projectInitCommandRunE(clients *shared.ClientFactory, cmd *cobra.Command, a
 	// Existing projects initialized always default to config.ManifestSourceLocal.
 	_ = create.InstallProjectDependencies(ctx, clients, projectDirPath)
 
-	// Add an existing app to the project
-	err = app.LinkCommandRunE(ctx, clients, &types.App{}, true, false)
+	// Prompt to add an existing app to the project
+	app.LinkAppHeaderSection(ctx, clients, true)
+	proceed, err := clients.IO.ConfirmPrompt(ctx, app.LinkAppConfirmPromptText, true)
 	if err != nil {
-		// Display the error but continue to init
-		clients.IO.PrintError(ctx, "%s", err.Error())
+		clients.IO.PrintDebug(ctx, "Error prompting to add an existing app: %s", err)
+	}
+	if proceed {
+		linkedApp := &types.App{}
+		err = app.LinkExistingApp(ctx, clients, linkedApp)
+		if err != nil {
+			// Display the error but continue to init
+			clients.IO.PrintError(ctx, "%s", err.Error())
+		} else {
+			clients.IO.PrintInfo(ctx, false, "%s", style.Sectionf(style.TextSection{
+				Emoji:     "house",
+				Text:      "App",
+				Secondary: app.FormatListSuccess([]types.App{*linkedApp}),
+			}))
+		}
 	}
 
 	printNextStepSection(ctx, clients, projectDirPath)

--- a/cmd/project/init.go
+++ b/cmd/project/init.go
@@ -110,7 +110,7 @@ func projectInitCommandRunE(clients *shared.ClientFactory, cmd *cobra.Command, a
 	_ = create.InstallProjectDependencies(ctx, clients, projectDirPath)
 
 	// Add an existing app to the project
-	err = app.LinkExistingApp(ctx, clients, &types.App{}, true)
+	err = app.LinkCommandRunE(ctx, clients, &types.App{}, true, false)
 	if err != nil {
 		// Display the error but continue to init
 		clients.IO.PrintError(ctx, "%s", err.Error())

--- a/cmd/project/init_test.go
+++ b/cmd/project/init_test.go
@@ -20,7 +20,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/slackapi/slack-cli/cmd/app"
 	"github.com/slackapi/slack-cli/internal/api"
 	internalApp "github.com/slackapi/slack-cli/internal/app"
 	"github.com/slackapi/slack-cli/internal/iostreams"
@@ -58,7 +57,7 @@ func Test_Project_InitCommand(t *testing.T) {
 			Setup: func(t *testing.T, ctx context.Context, cm *shared.ClientsMock, cf *shared.ClientFactory) {
 				setupProjectInitCommandMocks(t, ctx, cm, cf)
 				// Do not link an existing app
-				cm.IO.On("ConfirmPrompt", mock.Anything, app.LinkAppConfirmPromptText, mock.Anything).Return(false, nil)
+				cm.IO.On("ConfirmPrompt", mock.Anything, linkAppConfirmPromptText, mock.Anything).Return(false, nil)
 			},
 			ExpectedStdoutOutputs: []string{
 				"Project Initialization", // Assert section header
@@ -78,7 +77,7 @@ func Test_Project_InitCommand(t *testing.T) {
 					t,
 					"ConfirmPrompt",
 					mock.Anything,
-					app.LinkAppConfirmPromptText,
+					linkAppConfirmPromptText,
 					mock.Anything,
 				)
 				// Assert Trace
@@ -109,7 +108,7 @@ func Test_Project_InitCommand(t *testing.T) {
 				// Default setup
 				setupProjectInitCommandMocks(t, ctx, cm, cf)
 				// Link an existing app
-				cm.IO.On("ConfirmPrompt", mock.Anything, app.LinkAppConfirmPromptText, mock.Anything).Return(true, nil)
+				cm.IO.On("ConfirmPrompt", mock.Anything, linkAppConfirmPromptText, mock.Anything).Return(true, nil)
 				// Mock prompt for team
 				cm.IO.On("SelectPrompt",
 					mock.Anything,
@@ -156,7 +155,7 @@ func Test_Project_InitCommand(t *testing.T) {
 				// Assert prompt to add existing apps was called
 				cm.IO.AssertCalled(t, "ConfirmPrompt",
 					mock.Anything,
-					app.LinkAppConfirmPromptText,
+					linkAppConfirmPromptText,
 					mock.Anything,
 				)
 				// Assert prompt for team


### PR DESCRIPTION
### Changelog

Reduced verbose output when using `create --app` to link an existing app during project creation.

### Summary
When `--app` is provided to `slack create`, the linking step previously printed multiple noisy sections (App Link header, App Manifest details, App footer, and "Added existing app" message). Now it only prints the single `🏠 App` summary section showing team, App ID, Team ID, User ID, and Status.

### Preview

#### Before

<img width="1011" height="684" alt="before" src="https://github.com/user-attachments/assets/213327ed-d4aa-476c-b822-1eecd49eaa15" />

#### After

<img width="987" height="484" alt="after" src="https://github.com/user-attachments/assets/8ad3d252-4339-4151-9889-b26e0a716f03" />

### Testing

- `make test`
- Manual test - `./bin/slack create my-test -t slack-samples/bolt-js-starter-template --app A123 --team T123 --environment local`

### Notes

Adresses comments on PR #565 - [Improve the output experience for create when --app is provided.](https://github.com/slackapi/slack-cli/pull/565#:~:text=Improve%20the%20output%20experience%20for%20create%20when%20%2D%2Dapp%20is%20provided.)

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-cli/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
