### PR TITLE
docs: fix unclosed info admonition in authorizing-the-slack-cli

### DIFF
--- a/docs/guides/authorizing-the-slack-cli.md
+++ b/docs/guides/authorizing-the-slack-cli.md
@@ -65,7 +65,7 @@ Update notifications can be disabled using a command-line flag or an environment
 
 When the CLI runs in a non-interactive environment, such as inside a CI/CD pipeline or when the output is piped, the update check runs without the auto-update confirmation prompt. The notification text may still appear in command output, however. You can suppress the check entirely with the `--skip-update` flag or `SLACK_SKIP_UPDATE` environment variable to keep the automation output clean.
 
-:::info[The `--skip-update` flag and the `SLACK_SKIP_UPDATE` environment variable are intentionally ignored when running the `slack upgrade` command directly, since that command's purpose is to check for updates.
+:::info[The `--skip-update` flag and the `SLACK_SKIP_UPDATE` environment variable are intentionally ignored when running the `slack upgrade` command directly, since that command's purpose is to check for updates.]
 :::
 
 ## CI/CD authorization {#ci-cd}


### PR DESCRIPTION
### Changelog

Fixed a malformed `:::info` admonition on the Authorizing the Slack CLI guide that was breaking page rendering.

### Summary

This pull request fixes an unclosed `:::info` admonition in the Authorizing the Slack CLI guide.

- The admonition about `--skip-update` / `SLACK_SKIP_UPDATE` being ignored by `slack upgrade` was missing the closing `]` on its title.
- The unclosed title bracket caused the MDX renderer to mangle later content, surfacing a stray `authorize-cli}` in the rendered page.
- Adding the missing `]` closes the title and restores correct rendering.

### Preview

https://docs.slack.dev/tools/slack-cli/guides/authorizing-the-slack-cli/#version-updates

### Testing

- Open the guide above and scroll to the **Version update notifications** section.
- Confirm the info admonition about `slack upgrade` ignoring `--skip-update` / `SLACK_SKIP_UPDATE` renders as a normal callout box.
- Confirm no stray `authorize-cli}` text appears near the top of the page.

### Notes

Source file: `docs/guides/authorizing-the-slack-cli.md`. One-character fix (adds the closing `]`).

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-cli/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).