### PR TITLE
feat: recommend the official slack plugin to claude code users

### DIFF
--- a/cmd/help/help.go
+++ b/cmd/help/help.go
@@ -77,7 +77,7 @@ func PrintHelpTemplate(cmd *cobra.Command, data style.TemplateData) {
 		cmd.PrintErrln(err)
 	}
 
-	// Recommend the official Slack plugin when running inside Claude Code.
+	// Recommend the official Slack plugin when running inside Claude Code
 	useragent.EmitClaudeCodePluginHint(cmd.ErrOrStderr())
 }
 

--- a/cmd/help/help.go
+++ b/cmd/help/help.go
@@ -51,11 +51,6 @@ func HelpFunc(
 			"Experiments": experiments,
 		}
 		PrintHelpTemplate(cmd, data)
-
-		// Cobra serves help before PersistentPreRunE runs, so the root emit is
-		// skipped on `--help` paths. Recommend the official Slack plugin here too
-		// when running inside Claude Code. No-op in every other environment.
-		useragent.EmitClaudeCodePluginHint(clients.IO.WriteErr())
 	}
 }
 
@@ -81,6 +76,9 @@ func PrintHelpTemplate(cmd *cobra.Command, data style.TemplateData) {
 	if err != nil {
 		cmd.PrintErrln(err)
 	}
+
+	// Recommend the official Slack plugin when running inside Claude Code
+	useragent.EmitClaudeCodePluginHint(cmd.ErrOrStderr())
 }
 
 // ════════════════════════════════════════════════════════════════════════════════

--- a/cmd/help/help.go
+++ b/cmd/help/help.go
@@ -77,7 +77,7 @@ func PrintHelpTemplate(cmd *cobra.Command, data style.TemplateData) {
 		cmd.PrintErrln(err)
 	}
 
-	// Recommend the official Slack plugin when running inside Claude Code
+	// Recommend the official Slack plugin when running inside Claude Code.
 	useragent.EmitClaudeCodePluginHint(cmd.ErrOrStderr())
 }
 

--- a/cmd/help/help.go
+++ b/cmd/help/help.go
@@ -21,6 +21,7 @@ import (
 	"github.com/slackapi/slack-cli/internal/experiment"
 	"github.com/slackapi/slack-cli/internal/shared"
 	"github.com/slackapi/slack-cli/internal/style"
+	"github.com/slackapi/slack-cli/internal/useragent"
 	"github.com/spf13/cobra"
 )
 
@@ -50,6 +51,11 @@ func HelpFunc(
 			"Experiments": experiments,
 		}
 		PrintHelpTemplate(cmd, data)
+
+		// Cobra serves help before PersistentPreRunE runs, so the root emit is
+		// skipped on `--help` paths. Recommend the official Slack plugin here too
+		// when running inside Claude Code. No-op in every other environment.
+		useragent.EmitClaudeCodePluginHint(clients.IO.WriteErr())
 	}
 }
 

--- a/cmd/help/help_test.go
+++ b/cmd/help/help_test.go
@@ -28,11 +28,11 @@ import (
 
 func TestHelpFunc(t *testing.T) {
 	tests := map[string]struct {
-		exampleCommands []style.ExampleCommand
-		experiments     []string
-		envVars         map[string]string
-		expectedOutput  []string
-		expectHint      bool
+		exampleCommands     []style.ExampleCommand
+		experiments         []string
+		envVars             map[string]string
+		expectedOutput      []string
+		expectedErrorOutput []string
 	}{
 		"basic command information is included": {
 			expectedOutput: []string{
@@ -66,12 +66,8 @@ func TestHelpFunc(t *testing.T) {
 			},
 		},
 		"the Claude Code plugin hint is emitted inside Claude Code": {
-			envVars:    map[string]string{"CLAUDECODE": "1"},
-			expectHint: true,
-		},
-		"the Claude Code plugin hint is not emitted outside Claude Code": {
-			envVars:    map[string]string{"CLAUDECODE": ""},
-			expectHint: false,
+			envVars:             map[string]string{"CLAUDECODE": "1"},
+			expectedErrorOutput: []string{"claude-code-hint"},
 		},
 	}
 
@@ -84,9 +80,6 @@ func TestHelpFunc(t *testing.T) {
 				// Restore original EnabledExperiments
 				experiment.EnabledExperiments = _EnabledExperiments
 			}()
-			// Clear CLAUDECODE first so cases without an explicit value assert
-			// the hint's absence deterministically, then apply per-case vars.
-			t.Setenv("CLAUDECODE", "")
 			for name, value := range tc.envVars {
 				t.Setenv(name, value)
 			}
@@ -118,13 +111,8 @@ func TestHelpFunc(t *testing.T) {
 			for _, expectedString := range tc.expectedOutput {
 				assert.Contains(t, clientsMock.GetStdoutOutput(), expectedString)
 			}
-
-			// The hint belongs on stderr so it stays out of the help text on stdout.
-			assert.NotContains(t, clientsMock.GetStdoutOutput(), "claude-code-hint")
-			if tc.expectHint {
-				assert.Contains(t, clientsMock.GetStderrOutput(), "claude-code-hint")
-			} else {
-				assert.NotContains(t, clientsMock.GetStderrOutput(), "claude-code-hint")
+			for _, expectedString := range tc.expectedErrorOutput {
+				assert.Contains(t, clientsMock.GetStderrOutput(), expectedString)
 			}
 		})
 	}

--- a/cmd/help/help_test.go
+++ b/cmd/help/help_test.go
@@ -30,7 +30,7 @@ func TestHelpFunc(t *testing.T) {
 	tests := map[string]struct {
 		exampleCommands []style.ExampleCommand
 		experiments     []string
-		claudeCode      string
+		envVars         map[string]string
 		expectedOutput  []string
 		expectHint      bool
 	}{
@@ -66,11 +66,11 @@ func TestHelpFunc(t *testing.T) {
 			},
 		},
 		"the Claude Code plugin hint is emitted inside Claude Code": {
-			claudeCode: "1",
+			envVars:    map[string]string{"CLAUDECODE": "1"},
 			expectHint: true,
 		},
 		"the Claude Code plugin hint is not emitted outside Claude Code": {
-			claudeCode: "",
+			envVars:    map[string]string{"CLAUDECODE": ""},
 			expectHint: false,
 		},
 	}
@@ -84,7 +84,12 @@ func TestHelpFunc(t *testing.T) {
 				// Restore original EnabledExperiments
 				experiment.EnabledExperiments = _EnabledExperiments
 			}()
-			t.Setenv("CLAUDECODE", tc.claudeCode)
+			// Clear CLAUDECODE first so cases without an explicit value assert
+			// the hint's absence deterministically, then apply per-case vars.
+			t.Setenv("CLAUDECODE", "")
+			for name, value := range tc.envVars {
+				t.Setenv(name, value)
+			}
 
 			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := shared.NewClientsMock()

--- a/cmd/help/help_test.go
+++ b/cmd/help/help_test.go
@@ -65,7 +65,7 @@ func TestHelpFunc(t *testing.T) {
 				"unknown (invalid)",
 			},
 		},
-		"the Claude Code plugin hint is emitted inside Claude Code": {
+		"the claude code plugin hint is emitted inside claude code": {
 			envVars:             map[string]string{"CLAUDECODE": "1"},
 			expectedErrorOutput: []string{"claude-code-hint"},
 		},

--- a/cmd/help/help_test.go
+++ b/cmd/help/help_test.go
@@ -30,7 +30,9 @@ func TestHelpFunc(t *testing.T) {
 	tests := map[string]struct {
 		exampleCommands []style.ExampleCommand
 		experiments     []string
+		claudeCode      string
 		expectedOutput  []string
+		expectHint      bool
 	}{
 		"basic command information is included": {
 			expectedOutput: []string{
@@ -63,6 +65,14 @@ func TestHelpFunc(t *testing.T) {
 				"unknown (invalid)",
 			},
 		},
+		"the Claude Code plugin hint is emitted inside Claude Code": {
+			claudeCode: "1",
+			expectHint: true,
+		},
+		"the Claude Code plugin hint is not emitted outside Claude Code": {
+			claudeCode: "",
+			expectHint: false,
+		},
 	}
 
 	for name, tc := range tests {
@@ -74,6 +84,7 @@ func TestHelpFunc(t *testing.T) {
 				// Restore original EnabledExperiments
 				experiment.EnabledExperiments = _EnabledExperiments
 			}()
+			t.Setenv("CLAUDECODE", tc.claudeCode)
 
 			ctx := slackcontext.MockContext(t.Context())
 			clientsMock := shared.NewClientsMock()
@@ -102,44 +113,6 @@ func TestHelpFunc(t *testing.T) {
 			for _, expectedString := range tc.expectedOutput {
 				assert.Contains(t, clientsMock.GetStdoutOutput(), expectedString)
 			}
-		})
-	}
-}
-
-func TestHelpFunc_ClaudeCodePluginHint(t *testing.T) {
-	tests := map[string]struct {
-		claudeCode string
-		expectHint bool
-	}{
-		"emits the plugin hint on stderr inside Claude Code": {
-			claudeCode: "1",
-			expectHint: true,
-		},
-		"does not emit the plugin hint outside Claude Code": {
-			claudeCode: "",
-			expectHint: false,
-		},
-	}
-
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			t.Setenv("CLAUDECODE", tc.claudeCode)
-
-			ctx := slackcontext.MockContext(t.Context())
-			clientsMock := shared.NewClientsMock()
-			clientsMock.AddDefaultMocks()
-			rootCmd := &cobra.Command{
-				Use: "root",
-				Run: func(cmd *cobra.Command, args []string) {},
-			}
-			rootCmd.SetContext(ctx)
-			rootCmd.Flags().Bool("help", true, "mock help flag")
-			clientsMock.Config.SetFlags(rootCmd)
-			testutil.MockCmdIO(clientsMock.IO, rootCmd)
-			clients := shared.NewClientFactory(clientsMock.MockClientFactory())
-
-			helpFunc := HelpFunc(clients, map[string]string{})
-			helpFunc(rootCmd, []string{})
 
 			// The hint belongs on stderr so it stays out of the help text on stdout.
 			assert.NotContains(t, clientsMock.GetStdoutOutput(), "claude-code-hint")

--- a/cmd/help/help_test.go
+++ b/cmd/help/help_test.go
@@ -105,3 +105,49 @@ func TestHelpFunc(t *testing.T) {
 		})
 	}
 }
+
+func TestHelpFunc_ClaudeCodePluginHint(t *testing.T) {
+	tests := map[string]struct {
+		claudeCode string
+		expectHint bool
+	}{
+		"emits the plugin hint on stderr inside Claude Code": {
+			claudeCode: "1",
+			expectHint: true,
+		},
+		"does not emit the plugin hint outside Claude Code": {
+			claudeCode: "",
+			expectHint: false,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("CLAUDECODE", tc.claudeCode)
+
+			ctx := slackcontext.MockContext(t.Context())
+			clientsMock := shared.NewClientsMock()
+			clientsMock.AddDefaultMocks()
+			rootCmd := &cobra.Command{
+				Use: "root",
+				Run: func(cmd *cobra.Command, args []string) {},
+			}
+			rootCmd.SetContext(ctx)
+			rootCmd.Flags().Bool("help", true, "mock help flag")
+			clientsMock.Config.SetFlags(rootCmd)
+			testutil.MockCmdIO(clientsMock.IO, rootCmd)
+			clients := shared.NewClientFactory(clientsMock.MockClientFactory())
+
+			helpFunc := HelpFunc(clients, map[string]string{})
+			helpFunc(rootCmd, []string{})
+
+			// The hint belongs on stderr so it stays out of the help text on stdout.
+			assert.NotContains(t, clientsMock.GetStdoutOutput(), "claude-code-hint")
+			if tc.expectHint {
+				assert.Contains(t, clientsMock.GetStderrOutput(), "claude-code-hint")
+			} else {
+				assert.NotContains(t, clientsMock.GetStderrOutput(), "claude-code-hint")
+			}
+		})
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -130,7 +130,7 @@ func NewRootCommand(clients *shared.ClientFactory, updateNotification *update.Up
 			updateNotification = update.New(clients, version.Raw(), "SLACK_SKIP_UPDATE")
 			updateNotification.CheckForUpdateInBackground(ctx, false)
 
-			// Recommend the official Slack plugin when running inside Claude Code.
+			// Recommend the official Slack plugin when running inside Claude Code
 			useragent.EmitClaudeCodePluginHint(clients.IO.WriteErr())
 			return nil
 		},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -131,7 +131,6 @@ func NewRootCommand(clients *shared.ClientFactory, updateNotification *update.Up
 			updateNotification.CheckForUpdateInBackground(ctx, false)
 
 			// Recommend the official Slack plugin when running inside Claude Code.
-			// No-op in every other environment. See internal/useragent/hint.go.
 			useragent.EmitClaudeCodePluginHint(clients.IO.WriteErr())
 			return nil
 		},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -129,6 +129,10 @@ func NewRootCommand(clients *shared.ClientFactory, updateNotification *update.Up
 			// Check for an CLI update in the background while the command runs
 			updateNotification = update.New(clients, version.Raw(), "SLACK_SKIP_UPDATE")
 			updateNotification.CheckForUpdateInBackground(ctx, false)
+
+			// Recommend the official Slack plugin when running inside Claude Code.
+			// No-op in every other environment. See internal/useragent/hint.go.
+			useragent.EmitClaudeCodePluginHint(clients.IO.WriteErr())
 			return nil
 		},
 		PersistentPostRunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/useragent/hint.go
+++ b/internal/useragent/hint.go
@@ -34,7 +34,9 @@ const claudeCodePluginHint = `<claude-code-hint v="1" type="plugin" value="slack
 // environment. Claude Code deduplicates the hint by plugin and per session, so
 // callers may emit it on every invocation without spamming the user.
 func EmitClaudeCodePluginHint(w io.Writer) {
-	if os.Getenv("CLAUDECODE") != "1" {
+	// Gate on any non-empty CLAUDECODE value, matching the published protocol
+	// example, so the hint keeps working if Claude Code ever changes the value.
+	if os.Getenv("CLAUDECODE") == "" {
 		return
 	}
 	fmt.Fprintln(w, claudeCodePluginHint)

--- a/internal/useragent/hint.go
+++ b/internal/useragent/hint.go
@@ -20,22 +20,16 @@ import (
 	"os"
 )
 
-// claudeCodePluginHint is the one-line marker that recommends the official Slack
-// plugin to Claude Code users. Claude Code scans command output for this tag,
-// strips it before the output reaches the model (so it never counts toward token
-// usage), and shows a one-time install prompt. The tag must occupy its own line
-// and the plugin must live in Anthropic's official marketplace to have any
-// effect. See https://code.claude.com/docs/en/plugin-hints.
+// claudeCodePluginHint is the marker to recommend the official Slack plugin to
+// users of Claude Code.
+//
+// https://code.claude.com/docs/en/plugin-hints
 const claudeCodePluginHint = `<claude-code-hint v="1" type="plugin" value="slack@claude-plugins-official" />`
 
-// EmitClaudeCodePluginHint writes the Claude Code plugin-recommendation marker to
-// w on its own line when the CLI is running inside Claude Code, prompting a
-// one-time install of the official Slack plugin. It is a no-op in every other
-// environment. Claude Code deduplicates the hint by plugin and per session, so
-// callers may emit it on every invocation without spamming the user.
+// EmitClaudeCodePluginHint writes the Claude Code plugin recommendation marker
+// to a writer that must be stderr to prompt installation without an appearance
+// in actual outputs.
 func EmitClaudeCodePluginHint(w io.Writer) {
-	// Gate on any non-empty CLAUDECODE value, matching the published protocol
-	// example, so the hint keeps working if Claude Code ever changes the value.
 	if os.Getenv("CLAUDECODE") == "" {
 		return
 	}

--- a/internal/useragent/hint.go
+++ b/internal/useragent/hint.go
@@ -1,0 +1,41 @@
+// Copyright 2022-2026 Salesforce, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package useragent
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+// claudeCodePluginHint is the one-line marker that recommends the official Slack
+// plugin to Claude Code users. Claude Code scans command output for this tag,
+// strips it before the output reaches the model (so it never counts toward token
+// usage), and shows a one-time install prompt. The tag must occupy its own line
+// and the plugin must live in Anthropic's official marketplace to have any
+// effect. See https://code.claude.com/docs/en/plugin-hints.
+const claudeCodePluginHint = `<claude-code-hint v="1" type="plugin" value="slack@claude-plugins-official" />`
+
+// EmitClaudeCodePluginHint writes the Claude Code plugin-recommendation marker to
+// w on its own line when the CLI is running inside Claude Code, prompting a
+// one-time install of the official Slack plugin. It is a no-op in every other
+// environment. Claude Code deduplicates the hint by plugin and per session, so
+// callers may emit it on every invocation without spamming the user.
+func EmitClaudeCodePluginHint(w io.Writer) {
+	if os.Getenv("CLAUDECODE") != "1" {
+		return
+	}
+	fmt.Fprintln(w, claudeCodePluginHint)
+}

--- a/internal/useragent/hint_test.go
+++ b/internal/useragent/hint_test.go
@@ -30,12 +30,12 @@ func Test_EmitClaudeCodePluginHint(t *testing.T) {
 			claudeCode: "1",
 			expected:   claudeCodePluginHint + "\n",
 		},
+		"emits the hint for any non-empty CLAUDECODE value": {
+			claudeCode: "true",
+			expected:   claudeCodePluginHint + "\n",
+		},
 		"emits nothing when CLAUDECODE is unset": {
 			claudeCode: "",
-			expected:   "",
-		},
-		"emits nothing when CLAUDECODE is set to another value": {
-			claudeCode: "true",
 			expected:   "",
 		},
 	}

--- a/internal/useragent/hint_test.go
+++ b/internal/useragent/hint_test.go
@@ -26,7 +26,7 @@ func Test_EmitClaudeCodePluginHint(t *testing.T) {
 		claudeCode string
 		expected   string
 	}{
-		"emits the hint on its own line inside Claude Code": {
+		"emits the hint on its own line inside claude code": {
 			claudeCode: "1",
 			expected:   claudeCodePluginHint + "\n",
 		},

--- a/internal/useragent/hint_test.go
+++ b/internal/useragent/hint_test.go
@@ -1,0 +1,53 @@
+// Copyright 2022-2026 Salesforce, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package useragent
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_EmitClaudeCodePluginHint(t *testing.T) {
+	tests := map[string]struct {
+		claudeCode string
+		expected   string
+	}{
+		"emits the hint on its own line inside Claude Code": {
+			claudeCode: "1",
+			expected:   claudeCodePluginHint + "\n",
+		},
+		"emits nothing when CLAUDECODE is unset": {
+			claudeCode: "",
+			expected:   "",
+		},
+		"emits nothing when CLAUDECODE is set to another value": {
+			claudeCode: "true",
+			expected:   "",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			clearEnvVars(t)
+			t.Setenv("CLAUDECODE", tc.claudeCode)
+
+			var buf bytes.Buffer
+			EmitClaudeCodePluginHint(&buf)
+
+			assert.Equal(t, tc.expected, buf.String())
+		})
+	}
+}


### PR DESCRIPTION
### Changelog

The CLI now recommends the official Slack plugin to Claude Code users. No change for anyone running the CLI outside Claude Code.

### Summary

When the CLI runs inside Claude Code (detected via `CLAUDECODE=1`), it emits a one-line `<claude-code-hint />` marker to stderr recommending the official `slack@claude-plugins-official` plugin. Claude Code strips the marker before the output reaches the model (so it never counts toward token usage), dedupes it per plugin and per session, and shows the user a one-time install prompt. Claude Code never installs anything automatically — the user always confirms.

Protocol reference: https://code.claude.com/docs/en/plugin-hints

Design decisions worth calling out:

- **Placement.** The emitter lives beside the existing `CLAUDECODE` detection (`GetAIAgent`) in `internal/useragent`, since that package already owns "behavior conditioned on which AI agent is running us." A dedicated `internal/plugins` (or `internal/agents`) package felt premature for a ~10-line, single-vendor feature — Codex/Gemini/etc. have no equivalent protocol today. If a second agent-conditioned behavior or a second vendor protocol lands, that's the trigger to extract.
- **Two call sites.** `root.go`'s `PersistentPreRunE` covers every normal subcommand. Cobra serves `--help` *before* `PersistentPreRunE` runs, so the custom help func (`cmd/help/help.go`) needs its own emit to cover `slack --help` and `slack <cmd> --help` (two of the touchpoints the docs recommend).
- **stderr, on its own line.** The marker is written to stderr via `IO.WriteErr()` so it stays out of stdout pipelines and out of the help text, and the protocol's one hard requirement (own line) is satisfied by `Fprintln`.

### Preview

Emitted on stderr only when `CLAUDECODE=1`:

```
$ CLAUDECODE=1 slack version 2>&1 1>/dev/null
<claude-code-hint v="1" type="plugin" value="slack@claude-plugins-official" />
```

Nothing is emitted otherwise.

### Testing

Unit tests:
- `internal/useragent/hint_test.go` — emits on its own line when `CLAUDECODE=1`; no-op when unset or set to another value.
- `cmd/help/help_test.go` — help func emits the hint on stderr (not stdout) inside Claude Code; nothing outside.

Manual end-to-end against a built binary:
- `CLAUDECODE=1 slack version` → 1 hint on stderr, 0 on stdout ✅
- `slack version` (no `CLAUDECODE`) → 0 bytes on stderr ✅
- `CLAUDECODE=1 slack --help` and `slack auth --help` → 1 hint on stderr each, help text unaffected on stdout ✅
- `slack --help` without `CLAUDECODE` → 0 ✅

`go build ./...`, `go test ./cmd/... ./internal/useragent/...`, and `golangci-lint` on the touched packages all pass.

### Notes

- **Depends on an official-marketplace listing.** The hint only renders for plugins in Anthropic's curated `claude-plugins-official` marketplace; hints pointing elsewhere are silently dropped. Until a `slack` plugin is listed there, this marker is emitted but not shown. This needs to be coordinated with an Anthropic contact — flagging so it isn't a surprise.
- Emitting on every invocation is intentional and has no downside: Claude Code dedupes by plugin and shows at most one hint prompt per session.

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-cli/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
