### PR TITLE
refactor: merge Install and InstallLocalApp into a single function

### DIFF
--- a/cmd/app/add.go
+++ b/cmd/app/add.go
@@ -31,8 +31,11 @@ import (
 
 // Handle to client's function used for testing
 var runAddCommandFunc = RunAddCommand
+
+// TODO: this points at apps.Add (which adds an app to the project), so the
+// "install" name is a little misleading, but it's tolerable for now.
 var appInstallProdAppFunc = apps.Add
-var appInstallDevAppFunc = apps.Install
+var appInstallFunc = apps.Install
 var appSelectPromptFunc = prompts.AppSelectPrompt
 
 // Flags
@@ -201,7 +204,7 @@ func printAddSuccess(clients *shared.ClientFactory, cmd *cobra.Command, appInsta
 func appInstall(ctx context.Context, clients *shared.ClientFactory, selection *prompts.SelectedApp, orgGrantWorkspaceID string) (types.App, types.InstallState, error) {
 	if selection != nil && selection.App.IsDev {
 		// Install local dev app to a team
-		installedApp, _, installState, err := appInstallDevAppFunc(ctx, clients, selection.Auth, selection.App, "", true)
+		installedApp, _, installState, err := appInstallFunc(ctx, clients, selection.Auth, selection.App, apps.InstallOptions{Dev: true})
 		return installedApp, installState, err
 	} else {
 		installState, installedApp, err := appInstallProdAppFunc(ctx, clients, selection.Auth, selection.App, orgGrantWorkspaceID)

--- a/cmd/app/add.go
+++ b/cmd/app/add.go
@@ -32,7 +32,7 @@ import (
 // Handle to client's function used for testing
 var runAddCommandFunc = RunAddCommand
 var appInstallProdAppFunc = apps.Add
-var appInstallDevAppFunc = apps.InstallLocalApp
+var appInstallDevAppFunc = apps.Install
 var appSelectPromptFunc = prompts.AppSelectPrompt
 
 // Flags
@@ -201,7 +201,7 @@ func printAddSuccess(clients *shared.ClientFactory, cmd *cobra.Command, appInsta
 func appInstall(ctx context.Context, clients *shared.ClientFactory, selection *prompts.SelectedApp, orgGrantWorkspaceID string) (types.App, types.InstallState, error) {
 	if selection != nil && selection.App.IsDev {
 		// Install local dev app to a team
-		installedApp, _, installState, err := appInstallDevAppFunc(ctx, clients, "", selection.Auth, selection.App)
+		installedApp, _, installState, err := appInstallDevAppFunc(ctx, clients, selection.Auth, selection.App, "", true)
 		return installedApp, installState, err
 	} else {
 		installState, installedApp, err := appInstallProdAppFunc(ctx, clients, selection.Auth, selection.App, orgGrantWorkspaceID)

--- a/cmd/app/add.go
+++ b/cmd/app/add.go
@@ -32,8 +32,9 @@ import (
 // Handle to client's function used for testing
 var runAddCommandFunc = RunAddCommand
 
-// TODO: this points at apps.Add (which adds an app to the project), so the
-// "install" name is a little misleading, but it's tolerable for now.
+// TODO: this points at apps.Add, which creates the app remotely, installs it,
+// and adds it to the project's apps file, so the "install" name is a little
+// misleading, but it's tolerable for now.
 var appInstallProdAppFunc = apps.Add
 var appInstallFunc = apps.Install
 var appSelectPromptFunc = prompts.AppSelectPrompt

--- a/internal/pkg/apps/add.go
+++ b/internal/pkg/apps/add.go
@@ -70,7 +70,7 @@ func addAppRemotely(ctx context.Context, clients *shared.ClientFactory, auth typ
 		app.TeamID = auth.TeamID
 	}
 
-	app, _, installState, err := Install(ctx, clients, auth, app, orgGrantWorkspaceID, false)
+	app, _, installState, err := Install(ctx, clients, auth, app, InstallOptions{OrgGrantWorkspaceID: orgGrantWorkspaceID})
 	if err != nil {
 		return installState, types.App{}, slackerror.Wrap(err, slackerror.ErrAppAdd)
 	}

--- a/internal/pkg/apps/add.go
+++ b/internal/pkg/apps/add.go
@@ -70,7 +70,7 @@ func addAppRemotely(ctx context.Context, clients *shared.ClientFactory, auth typ
 		app.TeamID = auth.TeamID
 	}
 
-	app, installState, err := Install(ctx, clients, auth, CreateAppManifestAndInstall, app, orgGrantWorkspaceID)
+	app, _, installState, err := Install(ctx, clients, auth, app, orgGrantWorkspaceID, false)
 	if err != nil {
 		return installState, types.App{}, slackerror.Wrap(err, slackerror.ErrAppAdd)
 	}

--- a/internal/pkg/apps/install.go
+++ b/internal/pkg/apps/install.go
@@ -32,26 +32,28 @@ import (
 	"github.com/slackapi/slack-cli/internal/style"
 )
 
-// Constants for onlyCreateUpdateAppManifest parameter
-const (
-	CreateAppManifestOnly       = true
-	CreateAppManifestAndInstall = false
-)
-
 const additionalManifestInfoNotice = "App manifest contains some components that may require additional information"
 
-// Install installs the app to a team
-func Install(ctx context.Context, clients *shared.ClientFactory, auth types.SlackAuth, onlyCreateUpdateAppManifest bool, app types.App, orgGrantWorkspaceID string) (types.App, types.InstallState, error) {
+// Install installs an app to a workspace.
+//
+// When dev is true it installs a local (slack run) app; otherwise it installs a
+// deployed (slack deploy) app. The dev toggle controls the display name, hosted
+// manifest defaults, persistence location, and environment token handling.
+//
+// The returned api.DeveloperAppInstallResult carries the API access tokens and
+// is only consumed on the dev path (socket-mode wiring in run.go); deploy
+// callers discard it.
+func Install(ctx context.Context, clients *shared.ClientFactory, auth types.SlackAuth, app types.App, orgGrantWorkspaceID string, dev bool) (types.App, api.DeveloperAppInstallResult, types.InstallState, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "pkg.apps.install")
 	defer span.Finish()
 
 	manifestUpdates, err := shouldUpdateManifest(ctx, clients, app, auth)
 	if err != nil {
-		return types.App{}, "", err
+		return types.App{}, api.DeveloperAppInstallResult{}, "", err
 	}
 	manifestCreates, err := shouldCreateManifest(ctx, clients, app)
 	if err != nil {
-		return types.App{}, "", err
+		return types.App{}, api.DeveloperAppInstallResult{}, "", err
 	}
 
 	// Get the token for the authenticated workspace
@@ -59,7 +61,7 @@ func Install(ctx context.Context, clients *shared.ClientFactory, auth types.Slac
 	token := auth.Token
 	authSession, err := apiInterface.ValidateSession(ctx, token)
 	if err != nil {
-		return types.App{}, "", slackerror.Wrap(err, slackerror.ErrInvalidAuth)
+		return app, api.DeveloperAppInstallResult{}, "", slackerror.Wrap(err, slackerror.ErrInvalidAuth)
 	}
 
 	// Set the user_id, team id, team_domain of team that app belongs to on context
@@ -72,7 +74,7 @@ func Install(ctx context.Context, clients *shared.ClientFactory, auth types.Slac
 		clients.EventTracker.SetAuthUserID(*authSession.UserID)
 	}
 	if authSession.EnterpriseID != nil {
-		config.SetContextEnterpriseID(ctx, *authSession.EnterpriseID)
+		ctx = config.SetContextEnterpriseID(ctx, *authSession.EnterpriseID)
 		clients.EventTracker.SetAuthEnterpriseID(*authSession.EnterpriseID)
 		app.EnterpriseID = *authSession.EnterpriseID
 	}
@@ -83,28 +85,33 @@ func Install(ctx context.Context, clients *shared.ClientFactory, auth types.Slac
 	var slackManifest types.SlackYaml
 	manifestSource, err := clients.Config.ProjectConfig.GetManifestSource(ctx)
 	if err != nil {
-		return app, "", err
+		return app, api.DeveloperAppInstallResult{}, "", err
 	}
 	if manifestSource.Equals(config.ManifestSourceLocal) || manifestCreates {
 		slackManifest, err = clients.AppClient().Manifest.GetManifestLocal(ctx, clients.SDKConfig, clients.HookExecutor)
 		if err != nil {
-			return app, "", err
+			return app, api.DeveloperAppInstallResult{}, "", err
 		}
 	} else {
 		slackManifest, err = clients.AppClient().Manifest.GetManifestRemote(ctx, auth.Token, app.AppID)
 		if err != nil {
-			return app, "", err
+			return app, api.DeveloperAppInstallResult{}, "", err
 		}
 	}
 
 	manifest := slackManifest.AppManifest
-	if slackManifest.IsFunctionRuntimeSlackHosted() {
+	if dev {
+		appendLocalToDisplayName(&manifest)
+		if manifest.IsFunctionRuntimeSlackHosted() {
+			configureLocalManifest(ctx, clients, &manifest)
+		}
+	} else if slackManifest.IsFunctionRuntimeSlackHosted() {
 		configureHostedManifest(ctx, clients, &manifest)
 	}
 
 	err = validateManifestForInstall(ctx, clients, token, app, manifest)
 	if err != nil {
-		return app, "", err
+		return app, api.DeveloperAppInstallResult{}, "", err
 	}
 
 	start := time.Now()
@@ -120,7 +127,8 @@ func Install(ctx context.Context, clients *shared.ClientFactory, auth types.Slac
 		clients.IO.PrintDebug(ctx, "updating app %s", app.AppID)
 		_, err := apiInterface.UpdateApp(ctx, token, app.AppID, manifest, clients.Config.ForceFlag, true)
 		if err != nil {
-			return app, "", err
+			clients.IO.PrintDebug(ctx, "failed updating app %s: %s", app.AppID, err)
+			return app, api.DeveloperAppInstallResult{}, "", err
 		}
 	case manifestCreates:
 		_, _ = clients.IO.WriteOut().Write([]byte(style.Sectionf(style.TextSection{
@@ -134,7 +142,7 @@ func Install(ctx context.Context, clients *shared.ClientFactory, auth types.Slac
 		result, err := apiInterface.CreateApp(ctx, token, manifest, false)
 		if err != nil {
 			err = slackerror.Wrap(err, slackerror.ErrAppInstall)
-			return app, "", err
+			return app, api.DeveloperAppInstallResult{}, "", err
 		}
 		clients.IO.PrintDebug(ctx, "created new app ID %s", result.AppID)
 
@@ -142,43 +150,54 @@ func Install(ctx context.Context, clients *shared.ClientFactory, auth types.Slac
 		app.AppID = result.AppID
 		app.TeamID = *authSession.TeamID
 		app.TeamDomain = auth.TeamDomain
-		// TODO: add enterprise ID and user ID to app? See InstallLocalApp.
-		// app.EnterpriseID = config.GetContextEnterpriseID(ctx)
+		if authSession.EnterpriseID != nil {
+			app.EnterpriseID = *authSession.EnterpriseID
+		}
+		if authSession.UserID != nil {
+			app.UserID = *authSession.UserID
+		}
 	}
 
+	if dev {
+		// specifically set app.IsDev to be true for dev installation
+		app.IsDev = true
+	}
+
+	// save the updated or created app to the project's apps file
 	if !clients.Config.SkipLocalFs() {
-		if err := clients.AppClient().SaveDeployed(ctx, app); err != nil {
-			return types.App{}, "", err
+		var err error
+		if dev {
+			err = clients.AppClient().SaveLocal(ctx, app)
+		} else {
+			err = clients.AppClient().SaveDeployed(ctx, app)
+		}
+		if err != nil {
+			return types.App{}, api.DeveloperAppInstallResult{}, "", err
 		}
 	}
 	caches, err := shouldCacheManifest(ctx, clients, app)
 	if err != nil {
-		return types.App{}, "", err
+		return types.App{}, api.DeveloperAppInstallResult{}, "", err
 	}
 	if caches {
 		saved, err := clients.Config.ProjectConfig.Cache().GetManifestHash(ctx, app.AppID)
 		if err != nil {
-			return types.App{}, "", err
+			return types.App{}, api.DeveloperAppInstallResult{}, "", err
 		}
 		upstream, err := clients.API().ExportAppManifest(ctx, auth.Token, app.AppID)
 		if err != nil {
-			return types.App{}, "", err
+			return types.App{}, api.DeveloperAppInstallResult{}, "", err
 		}
 		hash, err := clients.Config.ProjectConfig.Cache().NewManifestHash(ctx, upstream.Manifest.AppManifest)
 		if err != nil {
-			return types.App{}, "", err
+			return types.App{}, api.DeveloperAppInstallResult{}, "", err
 		}
 		if !hash.Equals(saved) {
 			err := clients.Config.ProjectConfig.Cache().SetManifestHash(ctx, app.AppID, hash)
 			if err != nil {
-				return types.App{}, "", err
+				return types.App{}, api.DeveloperAppInstallResult{}, "", err
 			}
 		}
-	}
-
-	// Install the app to a workspace
-	if onlyCreateUpdateAppManifest {
-		return app, "", nil
 	}
 
 	botScopes := []string{}
@@ -204,17 +223,19 @@ func Install(ctx context.Context, clients *shared.ClientFactory, auth types.Slac
 	result, installState, err := apiInterface.DeveloperAppInstall(ctx, clients.IO, token, app, botScopes, outgoingDomains, orgGrantWorkspaceID, clients.Config.AutoRequestAAAFlag)
 	if err != nil {
 		err = slackerror.Wrap(err, slackerror.ErrAppInstall)
-		return app, "", err
+		return app, api.DeveloperAppInstallResult{}, "", err
 	}
 
 	if installState != types.InstallSuccess {
 		printNonSuccessInstallState(ctx, clients, installState)
-		return app, installState, nil
+		return app, api.DeveloperAppInstallResult{}, installState, nil
 	}
 
-	if manifest.FunctionRuntime() != types.SlackHosted {
+	// Local apps always store the resulting tokens for the running process while
+	// deployed apps only do so for non-hosted runtimes.
+	if dev || manifest.FunctionRuntime() != types.SlackHosted {
 		if err := setAppEnvironmentTokens(ctx, clients, result); err != nil {
-			return app, installState, err
+			return app, result, installState, err
 		}
 	}
 
@@ -241,7 +262,7 @@ func Install(ctx context.Context, clients *shared.ClientFactory, auth types.Slac
 
 	_, _ = clients.IO.WriteOut().Write([]byte(style.SectionSecondaryf("Finished in %.1fs", time.Since(start).Seconds())))
 
-	return app, types.InstallSuccess, nil
+	return app, result, types.InstallSuccess, nil
 }
 
 func printNonSuccessInstallState(ctx context.Context, clients *shared.ClientFactory, installState types.InstallState) {
@@ -336,203 +357,6 @@ func validateManifestForInstall(ctx context.Context, clients *shared.ClientFacto
 	}
 
 	return nil
-}
-
-// InstallLocalApp installs a non-hosted local app to a workspace.
-func InstallLocalApp(ctx context.Context, clients *shared.ClientFactory, orgGrantWorkspaceID string, auth types.SlackAuth, app types.App) (types.App, api.DeveloperAppInstallResult, types.InstallState, error) {
-	span, ctx := opentracing.StartSpanFromContext(ctx, "installLocalApp")
-	defer span.Finish()
-
-	manifestUpdates, err := shouldUpdateManifest(ctx, clients, app, auth)
-	if err != nil {
-		return types.App{}, api.DeveloperAppInstallResult{}, "", err
-	}
-	manifestCreates, err := shouldCreateManifest(ctx, clients, app)
-	if err != nil {
-		return types.App{}, api.DeveloperAppInstallResult{}, "", err
-	}
-
-	apiInterface := clients.API()
-	token := auth.Token
-	authSession, err := apiInterface.ValidateSession(ctx, token)
-	if err != nil {
-		return app, api.DeveloperAppInstallResult{}, "", slackerror.Wrap(err, slackerror.ErrInvalidAuth)
-	}
-
-	// Set the user_id, team id, team_domain of team that app belongs to on context
-	// TODO: we should probably pick one place to store team/user/enterprise ID
-	ctx = config.SetContextTeamID(ctx, *authSession.TeamID)
-	clients.EventTracker.SetAuthTeamID(*authSession.TeamID)
-	ctx = config.SetContextTeamDomain(ctx, auth.TeamDomain)
-	if authSession.UserID != nil {
-		ctx = config.SetContextUserID(ctx, *authSession.UserID)
-		clients.EventTracker.SetAuthUserID(*authSession.UserID)
-	}
-	if authSession.EnterpriseID != nil {
-		ctx = config.SetContextEnterpriseID(ctx, *authSession.EnterpriseID)
-		clients.EventTracker.SetAuthEnterpriseID(*authSession.EnterpriseID)
-		// TODO: add enterprise ID to app? See Install.
-		// app.EnterpriseID = *authSession.EnterpriseID
-	}
-
-	// Get the manifest from the local file if the manifest source is local or if we are creating
-	// a new app. After an app is created, app settings becomes the source of truth for remote
-	// manifests, so updates and installs always get the latest manifest from app settings.
-	var slackManifest types.SlackYaml
-	manifestSource, err := clients.Config.ProjectConfig.GetManifestSource(ctx)
-	if err != nil {
-		return app, api.DeveloperAppInstallResult{}, "", err
-	}
-	if manifestSource.Equals(config.ManifestSourceLocal) || manifestCreates {
-		slackManifest, err = clients.AppClient().Manifest.GetManifestLocal(ctx, clients.SDKConfig, clients.HookExecutor)
-		if err != nil {
-			return app, api.DeveloperAppInstallResult{}, "", err
-		}
-	} else {
-		slackManifest, err = clients.AppClient().Manifest.GetManifestRemote(ctx, auth.Token, app.AppID)
-		if err != nil {
-			return app, api.DeveloperAppInstallResult{}, "", err
-		}
-	}
-
-	manifest := slackManifest.AppManifest
-	appendLocalToDisplayName(&manifest)
-	if manifest.IsFunctionRuntimeSlackHosted() {
-		configureLocalManifest(ctx, clients, &manifest)
-	}
-
-	err = validateManifestForInstall(ctx, clients, token, app, manifest)
-	if err != nil {
-		return app, api.DeveloperAppInstallResult{}, "", err
-	}
-
-	start := time.Now()
-	switch {
-	case manifestUpdates:
-		_, _ = clients.IO.WriteOut().Write([]byte("\n" + style.Sectionf(style.TextSection{
-			Emoji: "books",
-			Text:  "App Manifest",
-			Secondary: []string{
-				fmt.Sprintf(`Updated app manifest for "%s" in "%s"`, slackManifest.DisplayInformation.Name, *authSession.TeamName),
-			},
-		})))
-		clients.IO.PrintDebug(ctx, "updating app %s", app.AppID)
-		_, err := apiInterface.UpdateApp(ctx, token, app.AppID, manifest, clients.Config.ForceFlag, true)
-		if err != nil {
-			clients.IO.PrintDebug(ctx, "failed updating app %s: %s", app.AppID, err)
-			return app, api.DeveloperAppInstallResult{}, "", err
-		}
-	case manifestCreates:
-		_, _ = clients.IO.WriteOut().Write([]byte(style.Sectionf(style.TextSection{
-			Emoji: "books",
-			Text:  "App Manifest",
-			Secondary: []string{
-				fmt.Sprintf(`Creating app manifest for "%s" in "%s"`, slackManifest.DisplayInformation.Name, *authSession.TeamName),
-			},
-		})))
-		clients.IO.PrintDebug(ctx, "app not found so creating a new app")
-		result, err := apiInterface.CreateApp(ctx, token, manifest, false)
-		if err != nil {
-			err = slackerror.Wrap(err, slackerror.ErrAppInstall)
-			return app, api.DeveloperAppInstallResult{}, "", err
-		}
-		clients.IO.PrintDebug(ctx, "created new app ID %s", result.AppID)
-
-		// Set properties on app
-		app.AppID = result.AppID
-		// TODO: should we be using context to store this information? seems risky
-		app.TeamID = config.GetContextTeamID(ctx)
-		app.TeamDomain = config.GetContextTeamDomain(ctx)
-		app.EnterpriseID = config.GetContextEnterpriseID(ctx)
-		app.UserID = *authSession.UserID
-	}
-
-	// specifically set app.IsDev to be true for dev installation
-	app.IsDev = true
-
-	// save updated or created app to apps.dev.json
-	if !clients.Config.SkipLocalFs() {
-		if err := clients.AppClient().SaveLocal(ctx, app); err != nil {
-			return types.App{}, api.DeveloperAppInstallResult{}, "", err
-		}
-	}
-	caches, err := shouldCacheManifest(ctx, clients, app)
-	if err != nil {
-		return types.App{}, api.DeveloperAppInstallResult{}, "", err
-	}
-	if caches {
-		saved, err := clients.Config.ProjectConfig.Cache().GetManifestHash(ctx, app.AppID)
-		if err != nil {
-			return types.App{}, api.DeveloperAppInstallResult{}, "", err
-		}
-		upstream, err := clients.API().ExportAppManifest(ctx, auth.Token, app.AppID)
-		if err != nil {
-			return types.App{}, api.DeveloperAppInstallResult{}, "", err
-		}
-		hash, err := clients.Config.ProjectConfig.Cache().NewManifestHash(ctx, upstream.Manifest.AppManifest)
-		if err != nil {
-			return types.App{}, api.DeveloperAppInstallResult{}, "", err
-		}
-		if !hash.Equals(saved) {
-			err := clients.Config.ProjectConfig.Cache().SetManifestHash(ctx, app.AppID, hash)
-			if err != nil {
-				return types.App{}, api.DeveloperAppInstallResult{}, "", err
-			}
-		}
-	}
-
-	// install the app
-	var botScopes []string
-	if manifest.OAuthConfig != nil {
-		botScopes = manifest.OAuthConfig.Scopes.Bot
-	}
-
-	outgoingDomains := []string{}
-	if manifest.OutgoingDomains != nil {
-		outgoingDomains = *manifest.OutgoingDomains
-	}
-
-	_, _ = clients.IO.WriteOut().Write([]byte("\n" + style.Sectionf(style.TextSection{
-		Emoji: "house",
-		Text:  "App Install",
-		Secondary: []string{
-			fmt.Sprintf(`Installing "%s" app to "%s"`, manifest.DisplayInformation.Name, *authSession.TeamName),
-		},
-	})))
-	var installState types.InstallState
-	result, installState, err := apiInterface.DeveloperAppInstall(ctx, clients.IO, token, app, botScopes, outgoingDomains, orgGrantWorkspaceID, clients.Config.AutoRequestAAAFlag)
-
-	if err != nil {
-		err = slackerror.Wrap(err, slackerror.ErrAppInstall)
-		return app, api.DeveloperAppInstallResult{}, "", err
-	}
-
-	if installState != types.InstallSuccess {
-		printNonSuccessInstallState(ctx, clients, installState)
-		return app, api.DeveloperAppInstallResult{}, installState, nil
-	}
-
-	if err := setAppEnvironmentTokens(ctx, clients, result); err != nil {
-		return app, result, installState, err
-	}
-
-	iconPath := resolveIconPath(ctx, clients, slackManifest.Icon)
-	if iconPath != "" {
-		_, iconErr := clients.API().IconSet(ctx, clients.Fs, token, app.AppID, iconPath)
-		if iconErr != nil {
-			clients.IO.PrintDebug(ctx, "icon error: %s", iconErr)
-			_, _ = clients.IO.WriteOut().Write([]byte(style.SectionSecondaryf("Error updating app icon: %s", iconErr)))
-		} else {
-			_, _ = clients.IO.WriteOut().Write([]byte(style.SectionSecondaryf("Updated app icon: %s", iconPath)))
-		}
-	}
-
-	// update config with latest yaml hash
-	// env.Hash = slackYaml.Hash
-
-	_, _ = clients.IO.WriteOut().Write([]byte(style.SectionSecondaryf("Finished in %.1fs", time.Since(start).Seconds())))
-
-	return app, result, types.InstallSuccess, nil
 }
 
 // getIconHash returns the MD5 hash of the icon file

--- a/internal/pkg/apps/install.go
+++ b/internal/pkg/apps/install.go
@@ -45,10 +45,6 @@ type InstallOptions struct {
 }
 
 // Install installs an app to a workspace.
-//
-// The returned api.DeveloperAppInstallResult carries the API access tokens and
-// is only consumed on the dev path (socket-mode wiring in run.go); deploy
-// callers discard it.
 func Install(ctx context.Context, clients *shared.ClientFactory, auth types.SlackAuth, app types.App, opts InstallOptions) (types.App, api.DeveloperAppInstallResult, types.InstallState, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "pkg.apps.install")
 	defer span.Finish()

--- a/internal/pkg/apps/install.go
+++ b/internal/pkg/apps/install.go
@@ -63,7 +63,7 @@ func Install(ctx context.Context, clients *shared.ClientFactory, auth types.Slac
 	token := auth.Token
 	authSession, err := apiInterface.ValidateSession(ctx, token)
 	if err != nil {
-		return app, api.DeveloperAppInstallResult{}, "", slackerror.Wrap(err, slackerror.ErrInvalidAuth)
+		return types.App{}, api.DeveloperAppInstallResult{}, "", slackerror.Wrap(err, slackerror.ErrInvalidAuth)
 	}
 
 	// Set the user_id, team id, team_domain of team that app belongs to on context

--- a/internal/pkg/apps/install.go
+++ b/internal/pkg/apps/install.go
@@ -129,7 +129,6 @@ func Install(ctx context.Context, clients *shared.ClientFactory, auth types.Slac
 		clients.IO.PrintDebug(ctx, "updating app %s", app.AppID)
 		_, err := apiInterface.UpdateApp(ctx, token, app.AppID, manifest, clients.Config.ForceFlag, true)
 		if err != nil {
-			clients.IO.PrintDebug(ctx, "failed updating app %s: %s", app.AppID, err)
 			return app, api.DeveloperAppInstallResult{}, "", err
 		}
 	case manifestCreates:

--- a/internal/pkg/apps/install.go
+++ b/internal/pkg/apps/install.go
@@ -233,9 +233,7 @@ func Install(ctx context.Context, clients *shared.ClientFactory, auth types.Slac
 		return app, api.DeveloperAppInstallResult{}, installState, nil
 	}
 
-	// Local apps always store the resulting tokens for the running process while
-	// deployed apps only do so for non-hosted runtimes.
-	if opts.Dev || manifest.FunctionRuntime() != types.SlackHosted {
+	if manifest.FunctionRuntime() != types.SlackHosted {
 		if err := setAppEnvironmentTokens(ctx, clients, result); err != nil {
 			return app, result, installState, err
 		}

--- a/internal/pkg/apps/install.go
+++ b/internal/pkg/apps/install.go
@@ -34,16 +34,22 @@ import (
 
 const additionalManifestInfoNotice = "App manifest contains some components that may require additional information"
 
+// InstallOptions configures how an app is installed to a workspace.
+type InstallOptions struct {
+	// OrgGrantWorkspaceID is the workspace to grant org-wide app access, if any.
+	OrgGrantWorkspaceID string
+	// Dev installs a local (slack run) app when true, otherwise a deployed
+	// (slack deploy) app. It controls the display name, hosted manifest
+	// defaults, persistence location, and environment token handling.
+	Dev bool
+}
+
 // Install installs an app to a workspace.
-//
-// When dev is true it installs a local (slack run) app; otherwise it installs a
-// deployed (slack deploy) app. The dev toggle controls the display name, hosted
-// manifest defaults, persistence location, and environment token handling.
 //
 // The returned api.DeveloperAppInstallResult carries the API access tokens and
 // is only consumed on the dev path (socket-mode wiring in run.go); deploy
 // callers discard it.
-func Install(ctx context.Context, clients *shared.ClientFactory, auth types.SlackAuth, app types.App, orgGrantWorkspaceID string, dev bool) (types.App, api.DeveloperAppInstallResult, types.InstallState, error) {
+func Install(ctx context.Context, clients *shared.ClientFactory, auth types.SlackAuth, app types.App, opts InstallOptions) (types.App, api.DeveloperAppInstallResult, types.InstallState, error) {
 	span, ctx := opentracing.StartSpanFromContext(ctx, "pkg.apps.install")
 	defer span.Finish()
 
@@ -100,7 +106,7 @@ func Install(ctx context.Context, clients *shared.ClientFactory, auth types.Slac
 	}
 
 	manifest := slackManifest.AppManifest
-	if dev {
+	if opts.Dev {
 		appendLocalToDisplayName(&manifest)
 		if manifest.IsFunctionRuntimeSlackHosted() {
 			configureLocalManifest(ctx, clients, &manifest)
@@ -158,7 +164,7 @@ func Install(ctx context.Context, clients *shared.ClientFactory, auth types.Slac
 		}
 	}
 
-	if dev {
+	if opts.Dev {
 		// specifically set app.IsDev to be true for dev installation
 		app.IsDev = true
 	}
@@ -166,7 +172,7 @@ func Install(ctx context.Context, clients *shared.ClientFactory, auth types.Slac
 	// save the updated or created app to the project's apps file
 	if !clients.Config.SkipLocalFs() {
 		var err error
-		if dev {
+		if opts.Dev {
 			err = clients.AppClient().SaveLocal(ctx, app)
 		} else {
 			err = clients.AppClient().SaveDeployed(ctx, app)
@@ -220,7 +226,7 @@ func Install(ctx context.Context, clients *shared.ClientFactory, auth types.Slac
 	// Note - we use DeveloperAppInstall endpoint for both local (dev) runs
 	// and hosted installs https://github.com/slackapi/slack-cli/pull/456#discussion_r830272175
 
-	result, installState, err := apiInterface.DeveloperAppInstall(ctx, clients.IO, token, app, botScopes, outgoingDomains, orgGrantWorkspaceID, clients.Config.AutoRequestAAAFlag)
+	result, installState, err := apiInterface.DeveloperAppInstall(ctx, clients.IO, token, app, botScopes, outgoingDomains, opts.OrgGrantWorkspaceID, clients.Config.AutoRequestAAAFlag)
 	if err != nil {
 		err = slackerror.Wrap(err, slackerror.ErrAppInstall)
 		return app, api.DeveloperAppInstallResult{}, "", err
@@ -233,7 +239,7 @@ func Install(ctx context.Context, clients *shared.ClientFactory, auth types.Slac
 
 	// Local apps always store the resulting tokens for the running process while
 	// deployed apps only do so for non-hosted runtimes.
-	if dev || manifest.FunctionRuntime() != types.SlackHosted {
+	if opts.Dev || manifest.FunctionRuntime() != types.SlackHosted {
 		if err := setAppEnvironmentTokens(ctx, clients, result); err != nil {
 			return app, result, installState, err
 		}

--- a/internal/pkg/apps/install_test.go
+++ b/internal/pkg/apps/install_test.go
@@ -41,6 +41,7 @@ func TestInstall(t *testing.T) {
 	mockUserID := "U001"
 
 	tests := map[string]struct {
+		dev                     bool
 		mockApp                 types.App
 		mockAPICreate           api.CreateAppResult
 		mockAPICreateError      error
@@ -53,6 +54,7 @@ func TestInstall(t *testing.T) {
 		mockAuthSession         api.AuthSession
 		mockConfirmPrompt       bool
 		mockIsTTY               bool
+		mockManifest            types.SlackYaml
 		mockManifestAppLocal    types.SlackYaml
 		mockManifestAppRemote   types.SlackYaml
 		mockManifestHashInitial cache.Hash
@@ -66,7 +68,8 @@ func TestInstall(t *testing.T) {
 		expectedManifest        types.AppManifest
 		expectedUpdate          bool
 	}{
-		"create a hosted app manifest with expected rosi values": {
+		"deploy: create a hosted app manifest with expected rosi values": {
+			dev:     false,
 			mockApp: types.App{},
 			mockAPICreate: api.CreateAppResult{
 				AppID: "A001",
@@ -121,7 +124,8 @@ func TestInstall(t *testing.T) {
 			},
 			expectedCreate: true,
 		},
-		"updates a hosted app manifest with expected rosi values": {
+		"deploy: updates a hosted app manifest with expected rosi values": {
+			dev: false,
 			mockApp: types.App{
 				AppID:      "A001",
 				TeamID:     mockTeamID,
@@ -179,7 +183,8 @@ func TestInstall(t *testing.T) {
 			},
 			expectedUpdate: true,
 		},
-		"avoid changing the manifest if a remote function runtime is specified": {
+		"deploy: avoid changing the manifest if a remote function runtime is specified": {
+			dev: false,
 			mockApp: types.App{
 				AppID:  "A002",
 				TeamID: mockTeamID,
@@ -245,7 +250,8 @@ func TestInstall(t *testing.T) {
 			},
 			expectedUpdate: true,
 		},
-		"avoid changing the manifest if no function runtime is specified": {
+		"deploy: avoid changing the manifest if no function runtime is specified": {
+			dev: false,
 			mockApp: types.App{
 				AppID:  "A003",
 				TeamID: mockTeamID,
@@ -298,7 +304,8 @@ func TestInstall(t *testing.T) {
 			},
 			expectedUpdate: true,
 		},
-		"create and install an app with a remote manifest": {
+		"deploy: create and install an app with a remote manifest": {
+			dev:     false,
 			mockApp: types.App{},
 			mockAPICreate: api.CreateAppResult{
 				AppID: "A001",
@@ -352,7 +359,8 @@ func TestInstall(t *testing.T) {
 			expectedCreate: true,
 			expectedUpdate: false,
 		},
-		"avoids updating an app with a remote manifest": {
+		"deploy: avoids updating an app with a remote manifest": {
+			dev: false,
 			mockApp: types.App{
 				AppID:  "A004",
 				TeamID: mockTeamID,
@@ -379,7 +387,8 @@ func TestInstall(t *testing.T) {
 			expectedInstallState: "",
 			expectedUpdate:       false,
 		},
-		"errors if the remote manifest has an unexpected cache": {
+		"deploy: errors if the remote manifest has an unexpected cache": {
+			dev: false,
 			mockApp: types.App{
 				AppID:  "A005",
 				TeamID: mockTeamID,
@@ -406,7 +415,8 @@ func TestInstall(t *testing.T) {
 			expectedInstallState:    "",
 			expectedUpdate:          false,
 		},
-		"errors if the manifest cache is unset without confirmation": {
+		"deploy: errors if the manifest cache is unset without confirmation": {
+			dev: false,
 			mockApp: types.App{
 				AppID:        "A005",
 				TeamID:       mockTeamID,
@@ -450,7 +460,8 @@ func TestInstall(t *testing.T) {
 			expectedError:           slackerror.New(slackerror.ErrAppManifestUpdate),
 			expectedUpdate:          false,
 		},
-		"continues if the remote manifest cache matches the saved": {
+		"deploy: continues if the remote manifest cache matches the saved": {
+			dev: false,
 			mockApp: types.App{
 				AppID:  "A006",
 				TeamID: mockTeamID,
@@ -501,215 +512,8 @@ func TestInstall(t *testing.T) {
 			},
 			expectedUpdate: true,
 		},
-	}
-
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			ctx := slackcontext.MockContext(t.Context())
-			clientsMock := shared.NewClientsMock()
-			clientsMock.IO.On("IsTTY").Return(tc.mockIsTTY)
-			clientsMock.AddDefaultMocks()
-			clientsMock.API.On(
-				"CreateApp",
-				mock.Anything,
-				mock.Anything,
-				mock.Anything,
-				mock.Anything,
-			).Return(
-				tc.mockAPICreate,
-				tc.mockAPICreateError,
-			)
-			clientsMock.API.On(
-				"DeveloperAppInstall",
-				mock.Anything,
-				mock.Anything,
-				mock.Anything,
-				mock.Anything,
-				mock.Anything,
-				mock.Anything,
-				mock.Anything,
-				mock.Anything,
-			).Return(
-				tc.mockAPIInstall,
-				tc.mockAPIInstallState,
-				tc.mockAPIInstallError,
-			)
-			clientsMock.API.On(
-				"ExportAppManifest",
-				mock.Anything,
-				mock.Anything,
-				mock.Anything,
-			).Return(
-				api.ExportAppResult{},
-				nil,
-			)
-			clientsMock.API.On(
-				"ValidateAppManifest",
-				mock.Anything,
-				mock.Anything,
-				mock.Anything,
-				tc.mockApp.AppID,
-			).Return(
-				api.ValidateAppManifestResult{},
-				nil,
-			)
-			clientsMock.API.On(
-				"UpdateApp",
-				mock.Anything,
-				mock.Anything,
-				mock.Anything,
-				mock.Anything,
-				mock.Anything,
-				mock.Anything,
-			).Return(
-				tc.mockAPIUpdate,
-				tc.mockAPIUpdateError,
-			)
-			clientsMock.API.On(
-				"ValidateSession",
-				mock.Anything,
-				mock.Anything,
-			).Return(
-				tc.mockAuthSession,
-				nil,
-			)
-			if tc.mockIsTTY {
-				clientsMock.IO.On(
-					"ConfirmPrompt",
-					mock.Anything,
-					"Overwrite manifest on app settings with the project's manifest file?",
-					false,
-				).Return(
-					tc.mockConfirmPrompt,
-					nil,
-				)
-			}
-			manifestMock := &app.ManifestMockObject{}
-			manifestMock.On("GetManifestLocal", mock.Anything, mock.Anything, mock.Anything).Return(tc.mockManifestAppLocal, nil)
-			manifestMock.On("GetManifestRemote", mock.Anything, mock.Anything, mock.Anything).Return(tc.mockManifestAppRemote, nil)
-			clientsMock.AppClient.Manifest = manifestMock
-			mockProjectConfig := config.NewProjectConfigMock()
-			mockProjectConfig.On("GetManifestSource", mock.Anything).Return(tc.mockManifestSource, nil)
-			mockProjectCache := cache.NewCacheMock()
-			mockProjectCache.On(
-				"GetManifestHash",
-				mock.Anything,
-				mock.Anything,
-			).Return(
-				tc.mockManifestHashInitial,
-				nil,
-			)
-			mockProjectCache.On(
-				"NewManifestHash",
-				mock.Anything,
-				mock.Anything,
-			).Return(
-				tc.mockManifestHashUpdated,
-				nil,
-			)
-			mockProjectCache.On(
-				"SetManifestHash",
-				mock.Anything,
-				mock.Anything,
-				mock.Anything,
-			).Return(nil)
-			mockProjectConfig.On("Cache").Return(mockProjectCache)
-			clientsMock.Config.ProjectConfig = mockProjectConfig
-
-			clients := shared.NewClientFactory(clientsMock.MockClientFactory())
-			app, _, state, err := Install(
-				ctx,
-				clients,
-				tc.mockAuth,
-				tc.mockApp,
-				InstallOptions{
-					OrgGrantWorkspaceID: tc.mockOrgGrantWorkspaceID,
-				},
-			)
-
-			if tc.expectedError != nil {
-				assert.Equal(
-					t,
-					slackerror.ToSlackError(tc.expectedError).Code,
-					slackerror.ToSlackError(err).Code,
-				)
-			} else {
-				require.NoError(t, err)
-			}
-			assert.Equal(t, tc.expectedInstallState, state)
-			assert.Equal(t, tc.expectedApp, app)
-			if tc.expectedUpdate {
-				clientsMock.API.AssertCalled(
-					t,
-					"UpdateApp",
-					mock.Anything,
-					mock.Anything,
-					mock.Anything,
-					mock.Anything,
-					mock.Anything,
-					mock.Anything,
-				)
-				clientsMock.API.AssertNotCalled(t, "CreateApp")
-			} else if tc.expectedCreate {
-				clientsMock.API.AssertCalled(
-					t,
-					"CreateApp",
-					mock.Anything,
-					mock.Anything,
-					mock.Anything,
-					mock.Anything,
-				)
-				clientsMock.API.AssertNotCalled(t, "UpdateApp")
-			}
-			for _, call := range clientsMock.API.Calls {
-				args := call.Arguments
-				switch call.Method {
-				case "CreateApp":
-					assert.Equal(t, tc.mockAuth.Token, args.Get(1))
-					assert.Equal(t, tc.expectedManifest, args.Get(2))
-				case "UpdateApp":
-					assert.Equal(t, tc.mockAuth.Token, args.Get(1))
-					assert.Equal(t, tc.mockApp.AppID, args.Get(2))
-					assert.Equal(t, tc.expectedManifest, args.Get(3))
-				}
-			}
-		})
-	}
-}
-
-func TestInstallDevApp(t *testing.T) {
-	mockEnterpriseID := "E001"
-	mockTeamID := "T001"
-	mockTeamDomain := "sandbox"
-	mockToken := "xoxe.xoxp-example"
-	mockTrue := true
-	mockUserID := "U001"
-
-	tests := map[string]struct {
-		mockApp                 types.App
-		mockAPICreate           api.CreateAppResult
-		mockAPICreateError      error
-		mockAPIInstall          api.DeveloperAppInstallResult
-		mockAPIInstallState     types.InstallState
-		mockAPIInstallError     error
-		mockAPIUpdate           api.UpdateAppResult
-		mockAPIUpdateError      error
-		mockAuth                types.SlackAuth
-		mockAuthSession         api.AuthSession
-		mockConfirmPrompt       bool
-		mockIsTTY               bool
-		mockManifest            types.SlackYaml
-		mockManifestHashInitial cache.Hash
-		mockManifestHashUpdated cache.Hash
-		mockManifestSource      config.ManifestSource
-		mockOrgGrantWorkspaceID string
-		expectedApp             types.App
-		expectedCreate          bool
-		expectedInstallState    types.InstallState
-		expectedManifest        types.AppManifest
-		expectedUpdate          bool
-	}{
-		"create and install a new ROSI app with a local function runtime using expected rosi defaults": {
+		"dev: create and install a new ROSI app with a local function runtime using expected rosi defaults": {
+			dev:     true,
 			mockApp: types.App{},
 			mockAPICreate: api.CreateAppResult{
 				AppID: "A001",
@@ -771,7 +575,8 @@ func TestInstallDevApp(t *testing.T) {
 			expectedInstallState: types.InstallSuccess,
 			expectedUpdate:       false,
 		},
-		"update and install an existing local bolt app with a remote function runtime without manifest changes": {
+		"dev: update and install an existing local bolt app with a remote function runtime without manifest changes": {
+			dev: true,
 			mockApp: types.App{
 				AppID:  "A002",
 				TeamID: mockTeamID,
@@ -849,7 +654,8 @@ func TestInstallDevApp(t *testing.T) {
 			expectedInstallState: types.InstallSuccess,
 			expectedUpdate:       true,
 		},
-		"update and install an existing local bolt app without a function runtime without manifest changes": {
+		"dev: update and install an existing local bolt app without a function runtime without manifest changes": {
+			dev: true,
 			mockApp: types.App{
 				AppID:  "A003",
 				TeamID: mockTeamID,
@@ -915,7 +721,8 @@ func TestInstallDevApp(t *testing.T) {
 			expectedInstallState: types.InstallSuccess,
 			expectedUpdate:       true,
 		},
-		"skip updating and allow installing an existing bolt app with a remote manifest": {
+		"dev: skip updating and allow installing an existing bolt app with a remote manifest": {
+			dev: true,
 			mockApp: types.App{
 				AppID:  "A004",
 				IsDev:  true,
@@ -962,7 +769,8 @@ func TestInstallDevApp(t *testing.T) {
 			expectedInstallState: types.InstallSuccess,
 			expectedUpdate:       false,
 		},
-		"create and install a new ROSI app when manifest is local": {
+		"dev: create and install a new ROSI app when manifest is local": {
+			dev:     true,
 			mockApp: types.App{},
 			mockAPICreate: api.CreateAppResult{
 				AppID: "A001",
@@ -1024,7 +832,8 @@ func TestInstallDevApp(t *testing.T) {
 			expectedInstallState: types.InstallSuccess,
 			expectedUpdate:       false,
 		},
-		"update and install an existing ROSI app when manifest is local": {
+		"dev: update and install an existing ROSI app when manifest is local": {
+			dev: true,
 			mockApp: types.App{
 				AppID:  "A002",
 				TeamID: mockTeamID,
@@ -1089,7 +898,8 @@ func TestInstallDevApp(t *testing.T) {
 			expectedInstallState: types.InstallSuccess,
 			expectedUpdate:       true,
 		},
-		"create and install a new bolt app when manifest is local": {
+		"dev: create and install a new bolt app when manifest is local": {
+			dev:     true,
 			mockApp: types.App{},
 			mockAPICreate: api.CreateAppResult{
 				AppID: "A001",
@@ -1150,7 +960,8 @@ func TestInstallDevApp(t *testing.T) {
 			expectedInstallState: types.InstallSuccess,
 			expectedUpdate:       false,
 		},
-		"update and install an existing bolt app with a local manifest": {
+		"dev: update and install an existing bolt app with a local manifest": {
+			dev: true,
 			mockApp: types.App{
 				AppID:  "A004",
 				IsDev:  true,
@@ -1216,7 +1027,8 @@ func TestInstallDevApp(t *testing.T) {
 			expectedInstallState: types.InstallSuccess,
 			expectedUpdate:       true,
 		},
-		"create and install a new bolt app when manifest is remote": {
+		"dev: create and install a new bolt app when manifest is remote": {
+			dev:     true,
 			mockApp: types.App{},
 			mockAPICreate: api.CreateAppResult{
 				AppID: "A001",
@@ -1277,7 +1089,8 @@ func TestInstallDevApp(t *testing.T) {
 			expectedInstallState: types.InstallSuccess,
 			expectedUpdate:       false,
 		},
-		"skip updating and allow installing an existing bolt app when manifest is remote": {
+		"dev: skip updating and allow installing an existing bolt app when manifest is remote": {
+			dev: true,
 			mockApp: types.App{
 				AppID:  "A004",
 				IsDev:  true,
@@ -1407,9 +1220,15 @@ func TestInstallDevApp(t *testing.T) {
 					nil,
 				)
 			}
+			// Dev installs source a single manifest for both the local file and
+			// the remote export; deployed installs distinguish the two.
+			localManifest, remoteManifest := tc.mockManifestAppLocal, tc.mockManifestAppRemote
+			if tc.dev {
+				localManifest, remoteManifest = tc.mockManifest, tc.mockManifest
+			}
 			manifestMock := &app.ManifestMockObject{}
-			manifestMock.On("GetManifestLocal", mock.Anything, mock.Anything, mock.Anything).Return(tc.mockManifest, nil)
-			manifestMock.On("GetManifestRemote", mock.Anything, mock.Anything, mock.Anything).Return(tc.mockManifest, nil)
+			manifestMock.On("GetManifestLocal", mock.Anything, mock.Anything, mock.Anything).Return(localManifest, nil)
+			manifestMock.On("GetManifestRemote", mock.Anything, mock.Anything, mock.Anything).Return(remoteManifest, nil)
 			clientsMock.AppClient.Manifest = manifestMock
 			mockProjectConfig := config.NewProjectConfigMock()
 			mockProjectConfig.On("GetManifestSource", mock.Anything).Return(tc.mockManifestSource, nil)
@@ -1447,11 +1266,19 @@ func TestInstallDevApp(t *testing.T) {
 				tc.mockApp,
 				InstallOptions{
 					OrgGrantWorkspaceID: tc.mockOrgGrantWorkspaceID,
-					Dev:                 true,
+					Dev:                 tc.dev,
 				},
 			)
 
-			require.NoError(t, err)
+			if tc.expectedError != nil {
+				assert.Equal(
+					t,
+					slackerror.ToSlackError(tc.expectedError).Code,
+					slackerror.ToSlackError(err).Code,
+				)
+			} else {
+				require.NoError(t, err)
+			}
 			assert.Equal(t, tc.expectedInstallState, state)
 			assert.Equal(t, tc.expectedApp, app)
 			if tc.expectedUpdate {

--- a/internal/pkg/apps/install_test.go
+++ b/internal/pkg/apps/install_test.go
@@ -101,6 +101,7 @@ func TestInstall(t *testing.T) {
 				EnterpriseID: mockEnterpriseID,
 				TeamID:       mockTeamID,
 				TeamDomain:   mockTeamDomain,
+				UserID:       mockUserID,
 			},
 			expectedManifest: types.AppManifest{
 				Metadata: &types.ManifestMetadata{
@@ -335,6 +336,7 @@ func TestInstall(t *testing.T) {
 				EnterpriseID: mockEnterpriseID,
 				TeamID:       mockTeamID,
 				TeamDomain:   mockTeamDomain,
+				UserID:       mockUserID,
 			},
 			expectedManifest: types.AppManifest{
 				Metadata: &types.ManifestMetadata{
@@ -615,13 +617,13 @@ func TestInstall(t *testing.T) {
 			clientsMock.Config.ProjectConfig = mockProjectConfig
 
 			clients := shared.NewClientFactory(clientsMock.MockClientFactory())
-			app, state, err := Install(
+			app, _, state, err := Install(
 				ctx,
 				clients,
 				tc.mockAuth,
-				false,
 				tc.mockApp,
 				tc.mockOrgGrantWorkspaceID,
+				false,
 			)
 
 			if tc.expectedError != nil {
@@ -674,7 +676,7 @@ func TestInstall(t *testing.T) {
 	}
 }
 
-func TestInstallLocalApp(t *testing.T) {
+func TestInstallDevApp(t *testing.T) {
 	mockEnterpriseID := "E001"
 	mockTeamID := "T001"
 	mockTeamDomain := "sandbox"
@@ -1437,12 +1439,13 @@ func TestInstallLocalApp(t *testing.T) {
 			clientsMock.Config.ProjectConfig = mockProjectConfig
 
 			clients := shared.NewClientFactory(clientsMock.MockClientFactory())
-			app, _, state, err := InstallLocalApp(
+			app, _, state, err := Install(
 				ctx,
 				clients,
-				tc.mockOrgGrantWorkspaceID,
 				tc.mockAuth,
 				tc.mockApp,
+				tc.mockOrgGrantWorkspaceID,
+				true,
 			)
 
 			require.NoError(t, err)

--- a/internal/pkg/apps/install_test.go
+++ b/internal/pkg/apps/install_test.go
@@ -54,7 +54,6 @@ func TestInstall(t *testing.T) {
 		mockAuthSession         api.AuthSession
 		mockConfirmPrompt       bool
 		mockIsTTY               bool
-		mockManifest            types.SlackYaml
 		mockManifestAppLocal    types.SlackYaml
 		mockManifestAppRemote   types.SlackYaml
 		mockManifestHashInitial cache.Hash
@@ -69,7 +68,6 @@ func TestInstall(t *testing.T) {
 		expectedUpdate          bool
 	}{
 		"deploy: create a hosted app manifest with expected rosi values": {
-			dev:     false,
 			mockApp: types.App{},
 			mockAPICreate: api.CreateAppResult{
 				AppID: "A001",
@@ -125,7 +123,6 @@ func TestInstall(t *testing.T) {
 			expectedCreate: true,
 		},
 		"deploy: updates a hosted app manifest with expected rosi values": {
-			dev: false,
 			mockApp: types.App{
 				AppID:      "A001",
 				TeamID:     mockTeamID,
@@ -184,7 +181,6 @@ func TestInstall(t *testing.T) {
 			expectedUpdate: true,
 		},
 		"deploy: avoid changing the manifest if a remote function runtime is specified": {
-			dev: false,
 			mockApp: types.App{
 				AppID:  "A002",
 				TeamID: mockTeamID,
@@ -251,7 +247,6 @@ func TestInstall(t *testing.T) {
 			expectedUpdate: true,
 		},
 		"deploy: avoid changing the manifest if no function runtime is specified": {
-			dev: false,
 			mockApp: types.App{
 				AppID:  "A003",
 				TeamID: mockTeamID,
@@ -305,7 +300,6 @@ func TestInstall(t *testing.T) {
 			expectedUpdate: true,
 		},
 		"deploy: create and install an app with a remote manifest": {
-			dev:     false,
 			mockApp: types.App{},
 			mockAPICreate: api.CreateAppResult{
 				AppID: "A001",
@@ -360,7 +354,6 @@ func TestInstall(t *testing.T) {
 			expectedUpdate: false,
 		},
 		"deploy: avoids updating an app with a remote manifest": {
-			dev: false,
 			mockApp: types.App{
 				AppID:  "A004",
 				TeamID: mockTeamID,
@@ -388,7 +381,6 @@ func TestInstall(t *testing.T) {
 			expectedUpdate:       false,
 		},
 		"deploy: errors if the remote manifest has an unexpected cache": {
-			dev: false,
 			mockApp: types.App{
 				AppID:  "A005",
 				TeamID: mockTeamID,
@@ -416,7 +408,6 @@ func TestInstall(t *testing.T) {
 			expectedUpdate:          false,
 		},
 		"deploy: errors if the manifest cache is unset without confirmation": {
-			dev: false,
 			mockApp: types.App{
 				AppID:        "A005",
 				TeamID:       mockTeamID,
@@ -461,7 +452,6 @@ func TestInstall(t *testing.T) {
 			expectedUpdate:          false,
 		},
 		"deploy: continues if the remote manifest cache matches the saved": {
-			dev: false,
 			mockApp: types.App{
 				AppID:  "A006",
 				TeamID: mockTeamID,
@@ -533,7 +523,20 @@ func TestInstall(t *testing.T) {
 				UserID:       &mockUserID,
 			},
 			mockManifestSource: config.ManifestSourceLocal,
-			mockManifest: types.SlackYaml{
+			mockManifestAppLocal: types.SlackYaml{
+				AppManifest: types.AppManifest{
+					Metadata: &types.ManifestMetadata{
+						MajorVersion: 2,
+					},
+					DisplayInformation: types.DisplayInformation{
+						Name: "example-1",
+					},
+					Settings: &types.AppSettings{
+						FunctionRuntime: types.SlackHosted,
+					},
+				},
+			},
+			mockManifestAppRemote: types.SlackYaml{
 				AppManifest: types.AppManifest{
 					Metadata: &types.ManifestMetadata{
 						MajorVersion: 2,
@@ -601,7 +604,28 @@ func TestInstall(t *testing.T) {
 			mockConfirmPrompt:  true,
 			mockIsTTY:          true,
 			mockManifestSource: config.ManifestSourceLocal,
-			mockManifest: types.SlackYaml{
+			mockManifestAppLocal: types.SlackYaml{
+				AppManifest: types.AppManifest{
+					Metadata: &types.ManifestMetadata{
+						MajorVersion: 1,
+					},
+					DisplayInformation: types.DisplayInformation{
+						Name: "example-2",
+					},
+					Features: &types.AppFeatures{
+						BotUser: types.BotUser{
+							DisplayName: "example-2",
+						},
+					},
+					Settings: &types.AppSettings{
+						FunctionRuntime: types.Remote,
+						EventSubscriptions: &types.ManifestEventSubscriptions{
+							RequestURL: "https://example.com",
+						},
+					},
+				},
+			},
+			mockManifestAppRemote: types.SlackYaml{
 				AppManifest: types.AppManifest{
 					Metadata: &types.ManifestMetadata{
 						MajorVersion: 1,
@@ -681,7 +705,22 @@ func TestInstall(t *testing.T) {
 			mockAPIInstallState: types.InstallSuccess,
 			mockConfirmPrompt:   true,
 			mockIsTTY:           true,
-			mockManifest: types.SlackYaml{
+			mockManifestAppLocal: types.SlackYaml{
+				AppManifest: types.AppManifest{
+					DisplayInformation: types.DisplayInformation{
+						Name: "example-3",
+					},
+					Features: &types.AppFeatures{
+						BotUser: types.BotUser{
+							DisplayName: "example-3",
+						},
+					},
+					Settings: &types.AppSettings{
+						SocketModeEnabled: &mockTrue,
+					},
+				},
+			},
+			mockManifestAppRemote: types.SlackYaml{
 				AppManifest: types.AppManifest{
 					DisplayInformation: types.DisplayInformation{
 						Name: "example-3",
@@ -740,7 +779,22 @@ func TestInstall(t *testing.T) {
 				TeamName: &mockTeamDomain,
 				UserID:   &mockUserID,
 			},
-			mockManifest: types.SlackYaml{
+			mockManifestAppLocal: types.SlackYaml{
+				AppManifest: types.AppManifest{
+					DisplayInformation: types.DisplayInformation{
+						Name: "example-3",
+					},
+					Features: &types.AppFeatures{
+						BotUser: types.BotUser{
+							DisplayName: "example-3",
+						},
+					},
+					Settings: &types.AppSettings{
+						SocketModeEnabled: &mockTrue,
+					},
+				},
+			},
+			mockManifestAppRemote: types.SlackYaml{
 				AppManifest: types.AppManifest{
 					DisplayInformation: types.DisplayInformation{
 						Name: "example-3",
@@ -789,7 +843,20 @@ func TestInstall(t *testing.T) {
 				TeamName:     &mockTeamDomain,
 				UserID:       &mockUserID,
 			},
-			mockManifest: types.SlackYaml{
+			mockManifestAppLocal: types.SlackYaml{
+				AppManifest: types.AppManifest{
+					Metadata: &types.ManifestMetadata{
+						MajorVersion: 2,
+					},
+					DisplayInformation: types.DisplayInformation{
+						Name: "example-1",
+					},
+					Settings: &types.AppSettings{
+						FunctionRuntime: types.SlackHosted,
+					},
+				},
+			},
+			mockManifestAppRemote: types.SlackYaml{
 				AppManifest: types.AppManifest{
 					Metadata: &types.ManifestMetadata{
 						MajorVersion: 2,
@@ -855,7 +922,20 @@ func TestInstall(t *testing.T) {
 				TeamName: &mockTeamDomain,
 				UserID:   &mockUserID,
 			},
-			mockManifest: types.SlackYaml{
+			mockManifestAppLocal: types.SlackYaml{
+				AppManifest: types.AppManifest{
+					Metadata: &types.ManifestMetadata{
+						MajorVersion: 2,
+					},
+					DisplayInformation: types.DisplayInformation{
+						Name: "example-2",
+					},
+					Settings: &types.AppSettings{
+						FunctionRuntime: types.SlackHosted,
+					},
+				},
+			},
+			mockManifestAppRemote: types.SlackYaml{
 				AppManifest: types.AppManifest{
 					Metadata: &types.ManifestMetadata{
 						MajorVersion: 2,
@@ -918,7 +998,22 @@ func TestInstall(t *testing.T) {
 				TeamName:     &mockTeamDomain,
 				UserID:       &mockUserID,
 			},
-			mockManifest: types.SlackYaml{
+			mockManifestAppLocal: types.SlackYaml{
+				AppManifest: types.AppManifest{
+					DisplayInformation: types.DisplayInformation{
+						Name: "example-3",
+					},
+					Features: &types.AppFeatures{
+						BotUser: types.BotUser{
+							DisplayName: "example-3",
+						},
+					},
+					Settings: &types.AppSettings{
+						SocketModeEnabled: &mockTrue,
+					},
+				},
+			},
+			mockManifestAppRemote: types.SlackYaml{
 				AppManifest: types.AppManifest{
 					DisplayInformation: types.DisplayInformation{
 						Name: "example-3",
@@ -979,7 +1074,22 @@ func TestInstall(t *testing.T) {
 				TeamName: &mockTeamDomain,
 				UserID:   &mockUserID,
 			},
-			mockManifest: types.SlackYaml{
+			mockManifestAppLocal: types.SlackYaml{
+				AppManifest: types.AppManifest{
+					DisplayInformation: types.DisplayInformation{
+						Name: "example-3",
+					},
+					Features: &types.AppFeatures{
+						BotUser: types.BotUser{
+							DisplayName: "example-3",
+						},
+					},
+					Settings: &types.AppSettings{
+						SocketModeEnabled: &mockTrue,
+					},
+				},
+			},
+			mockManifestAppRemote: types.SlackYaml{
 				AppManifest: types.AppManifest{
 					DisplayInformation: types.DisplayInformation{
 						Name: "example-3",
@@ -1047,7 +1157,22 @@ func TestInstall(t *testing.T) {
 				TeamName:     &mockTeamDomain,
 				UserID:       &mockUserID,
 			},
-			mockManifest: types.SlackYaml{
+			mockManifestAppLocal: types.SlackYaml{
+				AppManifest: types.AppManifest{
+					DisplayInformation: types.DisplayInformation{
+						Name: "example-3",
+					},
+					Features: &types.AppFeatures{
+						BotUser: types.BotUser{
+							DisplayName: "example-3",
+						},
+					},
+					Settings: &types.AppSettings{
+						SocketModeEnabled: &mockTrue,
+					},
+				},
+			},
+			mockManifestAppRemote: types.SlackYaml{
 				AppManifest: types.AppManifest{
 					DisplayInformation: types.DisplayInformation{
 						Name: "example-3",
@@ -1108,7 +1233,22 @@ func TestInstall(t *testing.T) {
 				TeamName: &mockTeamDomain,
 				UserID:   &mockUserID,
 			},
-			mockManifest: types.SlackYaml{
+			mockManifestAppLocal: types.SlackYaml{
+				AppManifest: types.AppManifest{
+					DisplayInformation: types.DisplayInformation{
+						Name: "example-3",
+					},
+					Features: &types.AppFeatures{
+						BotUser: types.BotUser{
+							DisplayName: "example-3",
+						},
+					},
+					Settings: &types.AppSettings{
+						SocketModeEnabled: &mockTrue,
+					},
+				},
+			},
+			mockManifestAppRemote: types.SlackYaml{
 				AppManifest: types.AppManifest{
 					DisplayInformation: types.DisplayInformation{
 						Name: "example-3",
@@ -1176,7 +1316,7 @@ func TestInstall(t *testing.T) {
 				mock.Anything,
 				mock.Anything,
 			).Return(
-				api.ExportAppResult{Manifest: tc.mockManifest},
+				api.ExportAppResult{},
 				nil,
 			)
 			clientsMock.API.On(
@@ -1220,15 +1360,9 @@ func TestInstall(t *testing.T) {
 					nil,
 				)
 			}
-			// Dev installs source a single manifest for both the local file and
-			// the remote export; deployed installs distinguish the two.
-			localManifest, remoteManifest := tc.mockManifestAppLocal, tc.mockManifestAppRemote
-			if tc.dev {
-				localManifest, remoteManifest = tc.mockManifest, tc.mockManifest
-			}
 			manifestMock := &app.ManifestMockObject{}
-			manifestMock.On("GetManifestLocal", mock.Anything, mock.Anything, mock.Anything).Return(localManifest, nil)
-			manifestMock.On("GetManifestRemote", mock.Anything, mock.Anything, mock.Anything).Return(remoteManifest, nil)
+			manifestMock.On("GetManifestLocal", mock.Anything, mock.Anything, mock.Anything).Return(tc.mockManifestAppLocal, nil)
+			manifestMock.On("GetManifestRemote", mock.Anything, mock.Anything, mock.Anything).Return(tc.mockManifestAppRemote, nil)
 			clientsMock.AppClient.Manifest = manifestMock
 			mockProjectConfig := config.NewProjectConfigMock()
 			mockProjectConfig.On("GetManifestSource", mock.Anything).Return(tc.mockManifestSource, nil)

--- a/internal/pkg/apps/install_test.go
+++ b/internal/pkg/apps/install_test.go
@@ -622,8 +622,9 @@ func TestInstall(t *testing.T) {
 				clients,
 				tc.mockAuth,
 				tc.mockApp,
-				tc.mockOrgGrantWorkspaceID,
-				false,
+				InstallOptions{
+					OrgGrantWorkspaceID: tc.mockOrgGrantWorkspaceID,
+				},
 			)
 
 			if tc.expectedError != nil {
@@ -1444,8 +1445,10 @@ func TestInstallDevApp(t *testing.T) {
 				clients,
 				tc.mockAuth,
 				tc.mockApp,
-				tc.mockOrgGrantWorkspaceID,
-				true,
+				InstallOptions{
+					OrgGrantWorkspaceID: tc.mockOrgGrantWorkspaceID,
+					Dev:                 true,
+				},
 			)
 
 			require.NoError(t, err)

--- a/internal/pkg/platform/localserver.go
+++ b/internal/pkg/platform/localserver.go
@@ -410,7 +410,7 @@ func (r *LocalServer) WatchManifest(ctx context.Context, auth types.SlackAuth, a
 					r.clients.IO.PrintInfo(ctx, false, "%s", style.Secondary(fmt.Sprintf("Manifest change detected: %s, reinstalling app...", event.Path)))
 
 					// Reinstall the app when manifest changes
-					if _, _, _, err := apps.Install(ctx, r.clients, auth, app, "", true); err != nil {
+					if _, _, _, err := apps.Install(ctx, r.clients, auth, app, apps.InstallOptions{Dev: true}); err != nil {
 						r.clients.IO.PrintError(ctx, "Error: %s", err)
 					} else {
 						r.clients.IO.PrintInfo(ctx, false, "%s", style.Secondary("App successfully reinstalled"))

--- a/internal/pkg/platform/localserver.go
+++ b/internal/pkg/platform/localserver.go
@@ -410,7 +410,7 @@ func (r *LocalServer) WatchManifest(ctx context.Context, auth types.SlackAuth, a
 					r.clients.IO.PrintInfo(ctx, false, "%s", style.Secondary(fmt.Sprintf("Manifest change detected: %s, reinstalling app...", event.Path)))
 
 					// Reinstall the app when manifest changes
-					if _, _, _, err := apps.InstallLocalApp(ctx, r.clients, "", auth, app); err != nil {
+					if _, _, _, err := apps.Install(ctx, r.clients, auth, app, "", true); err != nil {
 						r.clients.IO.PrintError(ctx, "Error: %s", err)
 					} else {
 						r.clients.IO.PrintInfo(ctx, false, "%s", style.Secondary("App successfully reinstalled"))

--- a/internal/pkg/platform/run.go
+++ b/internal/pkg/platform/run.go
@@ -79,7 +79,7 @@ func Run(ctx context.Context, clients *shared.ClientFactory, runArgs RunArgs) (t
 	}
 
 	// Update local install
-	installedApp, localInstallResult, installState, err := apps.InstallLocalApp(ctx, clients, runArgs.OrgGrantWorkspaceID, runArgs.Auth, runArgs.App)
+	installedApp, localInstallResult, installState, err := apps.Install(ctx, clients, runArgs.Auth, runArgs.App, runArgs.OrgGrantWorkspaceID, true)
 	if err != nil {
 		return "", slackerror.Wrap(err, slackerror.ErrLocalAppRun)
 	}

--- a/internal/pkg/platform/run.go
+++ b/internal/pkg/platform/run.go
@@ -79,7 +79,10 @@ func Run(ctx context.Context, clients *shared.ClientFactory, runArgs RunArgs) (t
 	}
 
 	// Update local install
-	installedApp, localInstallResult, installState, err := apps.Install(ctx, clients, runArgs.Auth, runArgs.App, runArgs.OrgGrantWorkspaceID, true)
+	installedApp, localInstallResult, installState, err := apps.Install(ctx, clients, runArgs.Auth, runArgs.App, apps.InstallOptions{
+		OrgGrantWorkspaceID: runArgs.OrgGrantWorkspaceID,
+		Dev:                 true,
+	})
 	if err != nil {
 		return "", slackerror.Wrap(err, slackerror.ErrLocalAppRun)
 	}


### PR DESCRIPTION
### Changelog

No user-facing change. Internal refactor merging two near-identical app-install functions. (One subtle improvement: newly created deployed apps now record their `EnterpriseID`/`UserID` in the project's apps file, matching the local path.)

### Summary

This pull request merges the `Install` (`slack deploy`) and `InstallLocalApp` (`slack run`) functions in `internal/pkg/apps` into a single `Install` driven by a `dev bool` toggle.

- The two functions were ~90% identical; the divergences all line up on a single "is this a local/dev install?" axis.
- `dev` switches the display name (`(local)` suffix), hosted manifest defaults (`configureLocalManifest` vs `configureHostedManifest`), persistence (`SaveLocal` vs `SaveDeployed`), `IsDev`, and environment-token handling.
- Drops the dead `onlyCreateUpdateAppManifest` parameter and its `CreateAppManifestOnly`/`CreateAppManifestAndInstall` constants — nothing passed `CreateAppManifestOnly`, so its early-return branch was unreachable.
- Unifies accidental gaps: both paths now set `EnterpriseID` and `UserID` on new-app creation inside `nil` guards (deploy previously left these as TODOs; local dereferenced `UserID` unconditionally). Enterprise ID is now also correctly propagated on the context for the deploy path (the old code discarded the returned `ctx`).
- Returns the superset `(App, DeveloperAppInstallResult, InstallState, error)`; only the dev path consumes the result (socket-mode token wiring in `run.go`).
- Updates the three callers (`add.go`, `run.go`, `localserver.go`) and the `cmd/app` test func var to the merged signature.


### Preview

_n/a — no user-visible output changes._

### Testing

- `slack run` a local app and confirm it installs, appends `(local)` to the display name, and connects over socket mode.
- `slack deploy` an app and confirm it installs to the workspace as before.
- Create a brand-new app via `slack deploy` and confirm the entry in the project's apps file now includes the user and enterprise IDs.

### Notes

- Argument order is `(ctx, clients, auth, app, orgGrantWorkspaceID, dev)` — chosen for readability, since the two original functions disagreed on parameter order.
- The `TestInstallLocalApp` test was renamed to `TestInstallDevApp` and now calls the merged `Install` with `dev=true`.

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-cli/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

