### PR TITLE
docs: use client-id secret name for the releaser app in the maintainers guide

### DIFF
--- a/.github/MAINTAINERS_GUIDE.md
+++ b/.github/MAINTAINERS_GUIDE.md
@@ -534,7 +534,7 @@ Access to this project is also required with the selected application scopes.
 
 Credentials and secrets for the app can be stored as the following variables:
 
-- `GH_APP_ID_RELEASER`
+- `GH_APP_CLIENT_ID_RELEASER`
 - `GH_APP_PRIVATE_KEY_RELEASER`
 
 #### Bumping Go package versions


### PR DESCRIPTION
### Changelog

N/A — maintainer docs only, no user-facing change.

### Summary

This pull request updates the maintainers guide so its releaser-app credentials list matches the secret names the workflows actually use.

- #639 switched `.github/workflows/release.yml` and `dependencies.yml` from `app-id: ${{ secrets.GH_APP_ID_RELEASER }}` to `client-id: ${{ secrets.GH_APP_CLIENT_ID_RELEASER }}` (following `create-github-app-token`'s `app-id` deprecation).
- The "Credentials and secrets" section still listed the deprecated `GH_APP_ID_RELEASER`, leaving docs and workflows out of sync.
- Anyone bootstrapping the releaser app from this guide (fork, key rotation, new environment) would set the wrong secret name and hit an empty client-id at runtime.

### Preview

N/A — text-only doc change.

### Testing

- `grep -rn GH_APP_ID_RELEASER .github/` returns no matches; `GH_APP_CLIENT_ID_RELEASER` now appears in the guide and both workflows.

### Notes

- Follow-up (tracked separately, out of scope here): once a release/dependencies run succeeds on `GH_APP_CLIENT_ID_RELEASER`, the now-unreferenced `GH_APP_ID_RELEASER` repo secret should be deleted to keep the secret surface tidy.

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-cli/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).