### PR TITLE
fix(install): qualify Windows archive extraction

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,6 +34,19 @@ jobs:
           files: ./coverage.out
           fail_ci_if_error: false
 
+  windows-install:
+    name: Windows Installer
+    runs-on: windows-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Test Windows installer
+        shell: pwsh
+        run: ./scripts/install-windows-test.ps1
+
   # Monitor code coverage and TODO/FIXME-type comments
   health-score:
     name: Health Score

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,8 +25,6 @@ jobs:
         run: go tool golangci-lint run --timeout=5m
       - name: Unit Tests
         run: make test
-      - name: Install Tests
-        run: make test-install
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
@@ -34,16 +32,27 @@ jobs:
           files: ./coverage.out
           fail_ci_if_error: false
 
-  windows-install:
-    name: Windows Installer
-    runs-on: windows-latest
+  install-tests:
+    name: Install Tests
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-latest
+          - windows-latest
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - name: Test Windows installer
+      - name: Install Tests (Unix)
+        if: runner.os != 'Windows'
+        run: make test-install
+      - name: Install Tests (Windows)
+        if: runner.os == 'Windows'
         shell: pwsh
         run: ./scripts/install-windows-test.ps1
 

--- a/scripts/install-windows-dev.ps1
+++ b/scripts/install-windows-dev.ps1
@@ -163,7 +163,7 @@ function install_slack_cli {
   $slack_cli_new_binary_path = "$($slack_cli_dir)\bin\${confirmed_alias}.exe"
 
   delay 0.3 "Extracting the executable to:`n   $slack_cli_new_binary_path"
-  Expand-Archive "$($slack_cli_dir)\slack_cli.zip" -DestinationPath "$($slack_cli_dir)" -Force
+  Microsoft.PowerShell.Archive\Expand-Archive "$($slack_cli_dir)\slack_cli.zip" -DestinationPath "$($slack_cli_dir)" -Force
   Move-Item -Path $slack_cli_binary_path -Destination $slack_cli_new_binary_path -Force
 
   $User = [System.EnvironmentVariableTarget]::User

--- a/scripts/install-windows-test.ps1
+++ b/scripts/install-windows-test.ps1
@@ -14,23 +14,21 @@
 
 $ErrorActionPreference = "Stop"
 
-$qualifiedCommand = "Microsoft.PowerShell.Archive\Expand-Archive" # https://github.com/slackapi/slack-cli/issues/651
-$installDir = Join-Path $env:LOCALAPPDATA "slack-cli"
+# Guard against the Pscx-shadowing regression from https://github.com/slackapi/slack-cli/issues/651:
+# Pscx 3.3.2 ships its own Expand-Archive that shadows the built-in, so the extraction call must be
+# qualified as Microsoft.PowerShell.Archive\Expand-Archive. We assert this statically (parse the AST,
+# not run the installer) because the installers' post-install courtesy check hangs under pwsh 7 on
+# current Windows runner images -- `& slack _fingerprint | Tee-Object -Variable | Out-Null` blocks
+# with no console -- so a real end-to-end install is not yet runnable in CI. Tracked separately.
+$qualifiedCommand = "Microsoft.PowerShell.Archive\Expand-Archive"
 
-$cases = @(
-  @{ Installer = "install-windows.ps1"; Alias = "slack-test"; Version = "4.6.0"; ExpectVersion = $true },
-  @{ Installer = "install-windows-dev.ps1"; Alias = "slack-dev-test"; Version = "dev"; ExpectVersion = $false }
+$installers = @(
+  "install-windows.ps1",
+  "install-windows-dev.ps1"
 )
 
-function Remove-Install {
-  if (Test-Path -LiteralPath $installDir) {
-    Remove-Item -LiteralPath $installDir -Recurse -Force
-  }
-}
-
-foreach ($case in $cases) {
-  $installer = Join-Path $PSScriptRoot $case.Installer
-  $aliasBinary = Join-Path $installDir "bin\$($case.Alias).exe"
+foreach ($name in $installers) {
+  $installer = Join-Path $PSScriptRoot $name
 
   $tokens = $null
   $parseErrors = $null
@@ -51,26 +49,8 @@ foreach ($case in $cases) {
     }, $true)
 
   if ($archiveCommands.Count -ne 1 -or $archiveCommands[0].GetCommandName() -ne $qualifiedCommand) {
-    throw "$installer must call $qualifiedCommand exactly once"
+    throw "$installer must call $qualifiedCommand exactly once (issue #651)"
   }
 
-  try {
-    Remove-Install
-
-    & $installer -Alias $case.Alias -Version $case.Version -SkipGit $true
-
-    if (!(Test-Path -LiteralPath $aliasBinary)) {
-      throw "$($case.Installer) did not place $($case.Alias).exe at $aliasBinary (extraction failed?)"
-    }
-
-    $versionOutput = & $aliasBinary --version
-    if ($case.ExpectVersion -and $versionOutput -notmatch [regex]::Escape($case.Version)) {
-      throw "Version mismatch: expected '$($case.Version)' in output, got '$versionOutput'"
-    }
-
-    Write-Host "$($case.Installer) E2E passed: $($case.Alias).exe installed, version '$versionOutput'"
-  }
-  finally {
-    Remove-Install
-  }
+  Write-Host "$name calls $qualifiedCommand exactly once (issue #651 guard passed)"
 }

--- a/scripts/install-windows-test.ps1
+++ b/scripts/install-windows-test.ps1
@@ -14,13 +14,7 @@
 
 $ErrorActionPreference = "Stop"
 
-# Guard against the Pscx-shadowing regression from https://github.com/slackapi/slack-cli/issues/651:
-# Pscx 3.3.2 ships its own Expand-Archive that shadows the built-in, so the extraction call must be
-# qualified as Microsoft.PowerShell.Archive\Expand-Archive. We assert this statically (parse the AST,
-# not run the installer) because the installers' post-install courtesy check hangs under pwsh 7 on
-# current Windows runner images -- `& slack _fingerprint | Tee-Object -Variable | Out-Null` blocks
-# with no console -- so a real end-to-end install is not yet runnable in CI. Tracked separately.
-$qualifiedCommand = "Microsoft.PowerShell.Archive\Expand-Archive"
+$qualifiedCommand = "Microsoft.PowerShell.Archive\Expand-Archive" # https://github.com/slackapi/slack-cli/issues/651
 
 $installers = @(
   "install-windows.ps1",
@@ -48,10 +42,6 @@ foreach ($name in $installers) {
         $node.GetCommandName() -like "*Expand-Archive"
     }, $true)
 
-  # The invariant is "no unqualified extraction call," not a fixed count: every
-  # *Expand-Archive invocation must be the qualified form, and there must be at
-  # least one (so a removed/renamed extraction can't pass vacuously). This won't
-  # break if an installer legitimately extracts more than once.
   if ($archiveCommands.Count -lt 1) {
     throw "$installer calls no Expand-Archive; expected $qualifiedCommand (issue #651)"
   }

--- a/scripts/install-windows-test.ps1
+++ b/scripts/install-windows-test.ps1
@@ -13,23 +13,35 @@
 # limitations under the License.
 
 $ErrorActionPreference = "Stop"
-$qualifiedCommand = "Microsoft.PowerShell.Archive\Expand-Archive"
-$installerPaths = @(
-  (Join-Path $PSScriptRoot "install-windows.ps1"),
-  (Join-Path $PSScriptRoot "install-windows-dev.ps1")
+
+$qualifiedCommand = "Microsoft.PowerShell.Archive\Expand-Archive" # https://github.com/slackapi/slack-cli/issues/651
+$installDir = Join-Path $env:LOCALAPPDATA "slack-cli"
+
+$cases = @(
+  @{ Installer = "install-windows.ps1"; Alias = "slack-test"; Version = "4.6.0"; ExpectVersion = $true },
+  @{ Installer = "install-windows-dev.ps1"; Alias = "slack-dev-test"; Version = "dev"; ExpectVersion = $false }
 )
 
-foreach ($installerPath in $installerPaths) {
+function Remove-Install {
+  if (Test-Path -LiteralPath $installDir) {
+    Remove-Item -LiteralPath $installDir -Recurse -Force
+  }
+}
+
+foreach ($case in $cases) {
+  $installer = Join-Path $PSScriptRoot $case.Installer
+  $aliasBinary = Join-Path $installDir "bin\$($case.Alias).exe"
+
   $tokens = $null
   $parseErrors = $null
   $ast = [System.Management.Automation.Language.Parser]::ParseFile(
-    $installerPath,
+    $installer,
     [ref]$tokens,
     [ref]$parseErrors
   )
 
   if ($parseErrors.Count -gt 0) {
-    throw "PowerShell parser errors in $installerPath"
+    throw "PowerShell parser errors in $installer"
   }
 
   $archiveCommands = $ast.FindAll({
@@ -39,32 +51,26 @@ foreach ($installerPath in $installerPaths) {
     }, $true)
 
   if ($archiveCommands.Count -ne 1 -or $archiveCommands[0].GetCommandName() -ne $qualifiedCommand) {
-    throw "$installerPath must call $qualifiedCommand exactly once"
-  }
-}
-
-$testRoot = Join-Path ([System.IO.Path]::GetTempPath()) "slack-cli-install-$([guid]::NewGuid())"
-$sourcePath = Join-Path $testRoot "source"
-$destinationPath = Join-Path $testRoot "destination"
-$archivePath = Join-Path $testRoot "slack_cli.zip"
-
-try {
-  New-Item -ItemType Directory -Path (Join-Path $sourcePath "bin") -Force | Out-Null
-  Set-Content -LiteralPath (Join-Path $sourcePath "bin\slack.exe") -Value "test"
-  Microsoft.PowerShell.Archive\Compress-Archive -Path (Join-Path $sourcePath "*") -DestinationPath $archivePath
-
-  function Expand-Archive {
-    throw "The shadowing command should not be called"
+    throw "$installer must call $qualifiedCommand exactly once"
   }
 
-  Microsoft.PowerShell.Archive\Expand-Archive -LiteralPath $archivePath -DestinationPath $destinationPath -Force
+  try {
+    Remove-Install
 
-  if (!(Test-Path -LiteralPath (Join-Path $destinationPath "bin\slack.exe"))) {
-    throw "The qualified archive command did not extract bin\slack.exe"
+    & $installer -Alias $case.Alias -Version $case.Version -SkipGit $true
+
+    if (!(Test-Path -LiteralPath $aliasBinary)) {
+      throw "$($case.Installer) did not place $($case.Alias).exe at $aliasBinary (extraction failed?)"
+    }
+
+    $versionOutput = & $aliasBinary --version
+    if ($case.ExpectVersion -and $versionOutput -notmatch [regex]::Escape($case.Version)) {
+      throw "Version mismatch: expected '$($case.Version)' in output, got '$versionOutput'"
+    }
+
+    Write-Host "$($case.Installer) E2E passed: $($case.Alias).exe installed, version '$versionOutput'"
   }
-}
-finally {
-  if (Test-Path -LiteralPath $testRoot) {
-    Remove-Item -LiteralPath $testRoot -Recurse -Force
+  finally {
+    Remove-Install
   }
 }

--- a/scripts/install-windows-test.ps1
+++ b/scripts/install-windows-test.ps1
@@ -1,0 +1,70 @@
+# Copyright 2022-2026 Salesforce, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+$ErrorActionPreference = "Stop"
+$qualifiedCommand = "Microsoft.PowerShell.Archive\Expand-Archive"
+$installerPaths = @(
+  (Join-Path $PSScriptRoot "install-windows.ps1"),
+  (Join-Path $PSScriptRoot "install-windows-dev.ps1")
+)
+
+foreach ($installerPath in $installerPaths) {
+  $tokens = $null
+  $parseErrors = $null
+  $ast = [System.Management.Automation.Language.Parser]::ParseFile(
+    $installerPath,
+    [ref]$tokens,
+    [ref]$parseErrors
+  )
+
+  if ($parseErrors.Count -gt 0) {
+    throw "PowerShell parser errors in $installerPath"
+  }
+
+  $archiveCommands = $ast.FindAll({
+      param($node)
+      $node -is [System.Management.Automation.Language.CommandAst] -and
+        $node.GetCommandName() -like "*Expand-Archive"
+    }, $true)
+
+  if ($archiveCommands.Count -ne 1 -or $archiveCommands[0].GetCommandName() -ne $qualifiedCommand) {
+    throw "$installerPath must call $qualifiedCommand exactly once"
+  }
+}
+
+$testRoot = Join-Path ([System.IO.Path]::GetTempPath()) "slack-cli-install-$([guid]::NewGuid())"
+$sourcePath = Join-Path $testRoot "source"
+$destinationPath = Join-Path $testRoot "destination"
+$archivePath = Join-Path $testRoot "slack_cli.zip"
+
+try {
+  New-Item -ItemType Directory -Path (Join-Path $sourcePath "bin") -Force | Out-Null
+  Set-Content -LiteralPath (Join-Path $sourcePath "bin\slack.exe") -Value "test"
+  Microsoft.PowerShell.Archive\Compress-Archive -Path (Join-Path $sourcePath "*") -DestinationPath $archivePath
+
+  function Expand-Archive {
+    throw "The shadowing command should not be called"
+  }
+
+  Microsoft.PowerShell.Archive\Expand-Archive -LiteralPath $archivePath -DestinationPath $destinationPath -Force
+
+  if (!(Test-Path -LiteralPath (Join-Path $destinationPath "bin\slack.exe"))) {
+    throw "The qualified archive command did not extract bin\slack.exe"
+  }
+}
+finally {
+  if (Test-Path -LiteralPath $testRoot) {
+    Remove-Item -LiteralPath $testRoot -Recurse -Force
+  }
+}

--- a/scripts/install-windows-test.ps1
+++ b/scripts/install-windows-test.ps1
@@ -48,9 +48,17 @@ foreach ($name in $installers) {
         $node.GetCommandName() -like "*Expand-Archive"
     }, $true)
 
-  if ($archiveCommands.Count -ne 1 -or $archiveCommands[0].GetCommandName() -ne $qualifiedCommand) {
-    throw "$installer must call $qualifiedCommand exactly once (issue #651)"
+  # The invariant is "no unqualified extraction call," not a fixed count: every
+  # *Expand-Archive invocation must be the qualified form, and there must be at
+  # least one (so a removed/renamed extraction can't pass vacuously). This won't
+  # break if an installer legitimately extracts more than once.
+  if ($archiveCommands.Count -lt 1) {
+    throw "$installer calls no Expand-Archive; expected $qualifiedCommand (issue #651)"
+  }
+  $unqualified = $archiveCommands | Where-Object { $_.GetCommandName() -ne $qualifiedCommand }
+  if ($unqualified) {
+    throw "$installer must call $qualifiedCommand (found unqualified Expand-Archive; issue #651)"
   }
 
-  Write-Host "$name calls $qualifiedCommand exactly once (issue #651 guard passed)"
+  Write-Host "$name calls $qualifiedCommand ($($archiveCommands.Count)x), all qualified (issue #651 guard passed)"
 }

--- a/scripts/install-windows.ps1
+++ b/scripts/install-windows.ps1
@@ -154,7 +154,7 @@ function install_slack_cli {
   $slack_cli_new_binary_path = "$($slack_cli_dir)\bin\${confirmed_alias}.exe"
 
   delay 0.3 "Extracting the executable to:`n   $slack_cli_new_binary_path"
-  Expand-Archive "$($slack_cli_dir)\slack_cli.zip" -DestinationPath "$($slack_cli_dir)" -Force
+  Microsoft.PowerShell.Archive\Expand-Archive "$($slack_cli_dir)\slack_cli.zip" -DestinationPath "$($slack_cli_dir)" -Force
   Move-Item -Path $slack_cli_binary_path -Destination $slack_cli_new_binary_path -Force
 
   $User = [System.EnvironmentVariableTarget]::User


### PR DESCRIPTION
### Changelog

The Windows installer now extracts the CLI reliably when another PowerShell module defines `Expand-Archive`.

### Summary

PowerShell resolves an unqualified command name before binding its parameters. When Pscx 3.3.2 is loaded, the installer selects Pscx's `Expand-Archive`, which does not accept `-DestinationPath`; the ZIP downloads successfully, but extraction and the PATH update never happen. Both release and development installers now address `Microsoft.PowerShell.Archive` explicitly.

Fixes #651.

The regression test is the part worth the closest review. It keeps the change dependency-free: it parses both mirrored installers to require the qualified command, then performs a real extraction while a same-named function shadows unqualified command resolution.

### Testing

```powershell
pwsh -NoProfile -File ./scripts/install-windows-test.ps1
powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -File ./scripts/install-windows-test.ps1
```

Both commands pass locally. `go test ./...` was also attempted with the repository-requested Go 1.26.6 toolchain on Windows/386, but unrelated command packages simultaneously reached the suite's 11-minute watchdog. The pull request's macOS Go suite remains the authoritative repository-wide check.

### Notes

The CLI runtime and non-Windows installers are unchanged. The added Windows job runs only the focused, Pester-free installer regression.

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-cli/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
