### PR TITLE
fix: always show the blocks command in help

### DIFF
--- a/cmd/blocks/blocks.go
+++ b/cmd/blocks/blocks.go
@@ -17,19 +17,14 @@ package blocks
 import (
 	"github.com/slackapi/slack-cli/internal/shared"
 	"github.com/slackapi/slack-cli/internal/style"
-	"github.com/slackapi/slack-cli/internal/useragent"
 	"github.com/spf13/cobra"
 )
 
-// aiAgentFunc is a package variable so it can be stubbed in tests.
-var aiAgentFunc = useragent.GetAIAgent
-
 func NewCommand(clients *shared.ClientFactory) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:    "blocks <subcommand> [flags]",
-		Short:  "Build with Block Kit",
-		Long:   "Build layouts using Block Kit and iterate on designs with Block Kit Builder.",
-		Hidden: aiAgentFunc() == nil,
+		Use:   "blocks <subcommand> [flags]",
+		Short: "Build with Block Kit",
+		Long:  "Build layouts using Block Kit and iterate on designs with Block Kit Builder.",
 		Example: style.ExampleCommandsf([]style.ExampleCommand{
 			{
 				Meaning: "Preview blocks in Block Kit Builder",

--- a/cmd/blocks/blocks_test.go
+++ b/cmd/blocks/blocks_test.go
@@ -19,10 +19,8 @@ import (
 	"testing"
 
 	"github.com/slackapi/slack-cli/internal/shared"
-	"github.com/slackapi/slack-cli/internal/useragent"
 	"github.com/slackapi/slack-cli/test/testutil"
 	"github.com/spf13/cobra"
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_Blocks_Command(t *testing.T) {
@@ -38,31 +36,4 @@ func Test_Blocks_Command(t *testing.T) {
 	}, func(cf *shared.ClientFactory) *cobra.Command {
 		return NewCommand(cf)
 	})
-}
-
-func Test_Blocks_Command_Hidden(t *testing.T) {
-	tests := map[string]struct {
-		aiAgent        *useragent.AIAgent
-		expectedHidden bool
-	}{
-		"hidden when no AI coding tool is detected": {
-			aiAgent:        nil,
-			expectedHidden: true,
-		},
-		"visible when an AI coding tool is detected": {
-			aiAgent:        &useragent.AIAgent{Name: "claude-code"},
-			expectedHidden: false,
-		},
-	}
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			restore := stubAIAgent(tc.aiAgent)
-			defer restore()
-
-			clientsMock := shared.NewClientsMock()
-			clients := shared.NewClientFactory(clientsMock.MockClientFactory())
-			cmd := NewCommand(clients)
-			assert.Equal(t, tc.expectedHidden, cmd.Hidden)
-		})
-	}
 }

--- a/cmd/blocks/preview_test.go
+++ b/cmd/blocks/preview_test.go
@@ -23,21 +23,12 @@ import (
 	"github.com/slackapi/slack-cli/internal/shared/types"
 	"github.com/slackapi/slack-cli/internal/slackerror"
 	"github.com/slackapi/slack-cli/internal/slacktrace"
-	"github.com/slackapi/slack-cli/internal/useragent"
 	"github.com/slackapi/slack-cli/test/testutil"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
-
-// stubAIAgent stubs the detected AI coding tool and returns a function that
-// restores the original detection.
-func stubAIAgent(agent *useragent.AIAgent) func() {
-	original := aiAgentFunc
-	aiAgentFunc = func() *useragent.AIAgent { return agent }
-	return func() { aiAgentFunc = original }
-}
 
 func Test_Blocks_PreviewCommand(t *testing.T) {
 	// teamlessURL is the Block Kit Builder URL rendered when no team can be


### PR DESCRIPTION
### Changelog

The `blocks` command is now listed in `slack help` for everyone, instead of only appearing when the CLI detects it is being run by an AI coding agent.

### Summary

This pull request removes the AI-agent visibility gate from the `blocks` command so it behaves like every other command.

Agent detection is unchanged everywhere.

### Preview

Root help with all agent environment variables stripped, which previously omitted `blocks` entirely:

```
    token       Collect a service token
  blocks
    preview     Preview blocks in Block Kit Builder
  collaborator
    add         Add a new collaborator to the app
```

### Testing

```
# Confirm blocks command is visible
$ slack --help
```

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-cli/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
