### PR TITLE
feat: detect OpenCode as an AI agent

### DIFF
--- a/internal/useragent/useragent.go
+++ b/internal/useragent/useragent.go
@@ -30,7 +30,7 @@ type AIAgent struct {
 // GetAIAgent checks environment variables to determine if the CLI is being run
 // by an AI coding agent. Returns nil if no agent is detected. Detection
 // priority: CLAUDECODE > CODEX_CI > GEMINI_CLI > CLINE_ACTIVE > CURSOR_AGENT >
-// AGENT.
+// OPENCODE > AGENT.
 func GetAIAgent() *AIAgent {
 	switch {
 	case os.Getenv("CLAUDECODE") == "1":
@@ -46,6 +46,10 @@ func GetAIAgent() *AIAgent {
 		return &AIAgent{Name: "cline"}
 	case os.Getenv("CURSOR_AGENT") == "1":
 		return &AIAgent{Name: "cursor"}
+	// OpenCode sets both OPENCODE=1 and AGENT=1, so it must be checked before
+	// the AGENT fallback to report a name instead of the literal "1".
+	case os.Getenv("OPENCODE") == "1":
+		return &AIAgent{Name: "opencode"}
 	case os.Getenv("AGENT") != "":
 		return &AIAgent{Name: os.Getenv("AGENT")}
 	default:

--- a/internal/useragent/useragent_test.go
+++ b/internal/useragent/useragent_test.go
@@ -22,7 +22,7 @@ import (
 
 func clearEnvVars(t *testing.T) {
 	t.Helper()
-	for _, env := range []string{"CLAUDECODE", "CLAUDE_CODE_ENTRYPOINT", "CODEX_CI", "GEMINI_CLI", "CLINE_ACTIVE", "CURSOR_AGENT", "AGENT"} {
+	for _, env := range []string{"CLAUDECODE", "CLAUDE_CODE_ENTRYPOINT", "CODEX_CI", "GEMINI_CLI", "CLINE_ACTIVE", "CURSOR_AGENT", "OPENCODE", "AGENT"} {
 		t.Setenv(env, "")
 	}
 }
@@ -36,6 +36,10 @@ func Test_UserAgent_BuildUserAgent(t *testing.T) {
 		"CLAUDECODE takes priority over AGENT": {
 			envVars:  map[string]string{"CLAUDECODE": "1", "AGENT": "goose", "CLAUDE_CODE_ENTRYPOINT": "cli"},
 			contains: "AI-Agent (name: claude-code, entry: cli)",
+		},
+		"OPENCODE takes priority over AGENT": {
+			envVars:  map[string]string{"OPENCODE": "1", "AGENT": "1"},
+			contains: "AI-Agent (name: opencode)",
 		},
 		"includes AI-Agent suffix for AGENT env var": {
 			envVars:  map[string]string{"AGENT": "goose"},
@@ -68,6 +72,10 @@ func Test_UserAgent_BuildUserAgent(t *testing.T) {
 		"includes AI-Agent suffix for Gemini CLI": {
 			envVars:  map[string]string{"GEMINI_CLI": "1"},
 			contains: "AI-Agent (name: gemini-cli)",
+		},
+		"includes AI-Agent suffix for OpenCode": {
+			envVars:  map[string]string{"OPENCODE": "1"},
+			contains: "AI-Agent (name: opencode)",
 		},
 		"includes AI-Agent suffix for unknown agent": {
 			envVars:  map[string]string{"AGENT": "future-agent"},
@@ -105,9 +113,17 @@ func Test_UserAgent_GetAIAgent(t *testing.T) {
 			envVars:  map[string]string{"CLAUDECODE": "1", "AGENT": "goose"},
 			expected: &AIAgent{Name: "claude-code", Entry: ""},
 		},
+		"CLAUDECODE takes priority over OPENCODE": {
+			envVars:  map[string]string{"CLAUDECODE": "1", "OPENCODE": "1", "AGENT": "1"},
+			expected: &AIAgent{Name: "claude-code", Entry: ""},
+		},
 		"CODEX_CI takes priority over AGENT": {
 			envVars:  map[string]string{"CODEX_CI": "1", "AGENT": "goose"},
 			expected: &AIAgent{Name: "codex"},
+		},
+		"OPENCODE takes priority over AGENT": {
+			envVars:  map[string]string{"OPENCODE": "1", "AGENT": "1"},
+			expected: &AIAgent{Name: "opencode"},
 		},
 		"detects agent via AGENT env var": {
 			envVars:  map[string]string{"AGENT": "goose"},
@@ -140,6 +156,10 @@ func Test_UserAgent_GetAIAgent(t *testing.T) {
 		"detects Gemini CLI": {
 			envVars:  map[string]string{"GEMINI_CLI": "1"},
 			expected: &AIAgent{Name: "gemini-cli"},
+		},
+		"detects OpenCode": {
+			envVars:  map[string]string{"OPENCODE": "1"},
+			expected: &AIAgent{Name: "opencode"},
 		},
 		"detects unknown agent via AGENT env var": {
 			envVars:  map[string]string{"AGENT": "future-agent"},


### PR DESCRIPTION
### Changelog

The CLI now reports `opencode` as the AI agent name when run from OpenCode, instead of the literal `1`.

### Summary

This pull request teaches the CLI to detect OpenCode so its telemetry and `User-Agent` carry a real agent name.

- OpenCode sets `AGENT=1` (not `AGENT=opencode`), so the `AGENT` fallback in `internal/useragent/useragent.go` passed `1` straight through as the agent name.
- It also sets `OPENCODE=1` unconditionally, alongside `AGENT=1` and `OPENCODE_PID`, in [`packages/opencode/src/index.ts`](https://github.com/sst/opencode/blob/dev/packages/opencode/src/index.ts) - a reliable discriminator present in every process it spawns.
- Adds an `OPENCODE` case to `GetAIAgent()` just ahead of the `AGENT` fallback. Ordering matters: OpenCode sets both variables, so `OPENCODE` has to be checked first.
- Higher-priority agents still win, since someone can run another agent from inside an OpenCode shell.

`internal/tracking/tracking.go` already feeds `useragent.GetAIAgentName()` into the `ai_agent` telemetry field, so no other production code changes were needed.

Closes #664

### Preview

Verified via `./bin/slack version --skip-update --verbose`:

| Environment | Reported name |
| --- | --- |
| `OPENCODE=1 AGENT=1` | `AI-Agent (name: opencode)` |
| `AGENT=1` | `AI-Agent (name: 1)` (fallback unchanged) |
| `AGENT=goose` | `AI-Agent (name: goose)` (fallback unchanged) |
| `CURSOR_AGENT=1 OPENCODE=1` | `AI-Agent (name: cursor)` (priority holds) |
| no agent variables | no `AI-Agent` suffix |

### Testing

1. Build the CLI with `make build`.
2. Run `env -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT OPENCODE=1 AGENT=1 ./bin/slack version --skip-update --verbose` and confirm the `user_agent` debug line ends with `AI-Agent (name: opencode)`.
3. Re-run with only `AGENT=1` set and confirm the name is still `1`, so the generic fallback is unchanged for other agents.
4. Re-run with `CURSOR_AGENT=1 OPENCODE=1` and confirm `cursor` wins, so detection priority is preserved.

Note: unset `CLAUDECODE`/`CLAUDE_CODE_ENTRYPOINT` when testing from inside Claude Code, otherwise it takes priority and masks the result.

### Notes

- OpenCode does not document these variables, so this could break if they rename `OPENCODE`. The `AGENT` fallback would then resume reporting `1`, which is the current behavior - no worse than today.

### Requirements

- [x] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-cli/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).

