### PR TITLE
feat: support features.code_channels in app manifest round trip

### DIFF
--- a/internal/shared/types/app_manifest.go
+++ b/internal/shared/types/app_manifest.go
@@ -79,6 +79,7 @@ type AppFeatures struct {
 	ManifestSlashCommandsItems []ManifestSlashCommandsItem `json:"slash_commands,omitempty" yaml:"slash_commands,flow,omitempty"`
 	Search                     *Search                     `json:"search,omitempty" yaml:"search,flow,omitempty"`
 	RichPreviews               *RichPreviews               `json:"rich_previews,omitempty" yaml:"rich_previews,flow,omitempty"`
+	CodeChannels               *RawJSON                    `json:"code_channels,omitempty" yaml:"code_channels,flow,omitempty"`
 }
 
 type RichPreviews struct {

--- a/internal/shared/types/app_manifest_test.go
+++ b/internal/shared/types/app_manifest_test.go
@@ -250,6 +250,15 @@ func Test_AppManifest_AppFeatures(t *testing.T) {
 			},
 			want: `{"app_home":{},"bot_user":{"display_name":"business_bot"},"rich_previews":{"entity_types":["slack#/entities/file"]}}`,
 		},
+		"includes code channels when provided": {
+			features: AppFeatures{
+				BotUser: BotUser{
+					DisplayName: "codebot",
+				},
+				CodeChannels: ToRawJSON(`{"enabled":true}`),
+			},
+			want: `{"app_home":{},"bot_user":{"display_name":"codebot"},"code_channels":{"enabled":true}}`,
+		},
 	}
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION

### Changelog

Lets devs set code_channels feature in their manifests, and have it display in `manifest export` 

### Summary

AppFeatures had no field for code_channels, so Go's json.Unmarshal silently dropped it before the manifest was sent to apps.manifest.validate/update. Add it as a RawJSON passthrough so any future sub-fields survive without further struct changes.


### Preview

Before
<img width="876" height="797" alt="Screenshot 2026-09-09 at 2 24 12 PM" src="https://github.com/user-attachments/assets/0c1e3b34-d5c0-421d-a0dd-da5b5738234d" />


After

<img width="662" height="838" alt="Screenshot 2026-09-09 at 2 23 43 PM" src="https://github.com/user-attachments/assets/a6d91c0e-6f91-49fc-8a56-f0e710596180" />


### Testing

Run `manifest export` on app that has the code_channels feature set in the manifest


### Notes

(Add any additional context, trade-offs, or follow-up items)

### Requirements

- [ ] I've read and understood the [Contributing Guidelines](https://github.com/slackapi/slack-cli/blob/main/.github/CONTRIBUTING.md) and have done my best effort to follow them.
- [ ] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct).
